### PR TITLE
Add Drawer component

### DIFF
--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -1,0 +1,154 @@
+// src/components/Drawer.tsx | valet
+// Minimal sliding drawer component akin to MUI's Drawer.
+// Controlled/uncontrolled, with backdrop and escape handling.
+
+import React, { useCallback, useLayoutEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { styled } from '../css/createStyled';
+import { useTheme } from '../system/themeStore';
+import { preset } from '../css/stylePresets';
+import type { Presettable } from '../types';
+
+/*───────────────────────────────────────────────────────────*/
+export type DrawerAnchor = 'left' | 'right' | 'top' | 'bottom';
+
+export interface DrawerProps extends Presettable {
+  /** Controlled visibility */
+  open?: boolean;
+  /** Default for uncontrolled */
+  defaultOpen?: boolean;
+  /** Drawer side */
+  anchor?: DrawerAnchor;
+  /** Callback fired when user requests close */
+  onClose?: () => void;
+  /** Size (width or height depending on anchor) */
+  size?: number | string;
+  /** Disable closing via backdrop click */
+  disableBackdropClick?: boolean;
+  /** Disable closing via ESC key */
+  disableEscapeKeyDown?: boolean;
+  /** Drawer contents */
+  children?: React.ReactNode;
+}
+
+/*───────────────────────────────────────────────────────────*/
+/* Styled primitives                                         */
+
+const Backdrop = styled('div')<{$fade: boolean}>`
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+  opacity: ${({ $fade }) => ($fade ? 0 : 1)};
+  transition: opacity 200ms ease;
+  z-index: 9998;
+`;
+
+const Panel = styled('div')<{
+  $anchor: DrawerAnchor;
+  $fade: boolean;
+  $size: string;
+  $bg: string;
+  $text: string;
+}>`
+  position: fixed;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  background: ${({ $bg }) => $bg};
+  color: ${({ $text }) => $text};
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  ${({ $anchor, $size }) =>
+    $anchor === 'left' || $anchor === 'right'
+      ? `width:${$size}; height:100%;`
+      : `height:${$size}; width:100%;`}
+  ${({ $anchor }) =>
+    $anchor === 'left'
+      ? 'top:0; left:0;'
+      : $anchor === 'right'
+      ? 'top:0; right:0;'
+      : $anchor === 'top'
+      ? 'top:0; left:0;'
+      : 'bottom:0; left:0;'}
+  transform: ${({ $anchor, $fade }) =>
+    $anchor === 'left'
+      ? `translateX(${$fade ? '-100%' : '0'})`
+      : $anchor === 'right'
+      ? `translateX(${$fade ? '100%' : '0'})`
+      : $anchor === 'top'
+      ? `translateY(${$fade ? '-100%' : '0'})`
+      : `translateY(${$fade ? '100%' : '0'})`};
+  transition: transform 200ms ease;
+`;
+
+/*───────────────────────────────────────────────────────────*/
+/* Component                                                 */
+
+export const Drawer: React.FC<DrawerProps> = ({
+  open: controlledOpen,
+  defaultOpen = false,
+  anchor = 'left',
+  onClose,
+  size = '16rem',
+  disableBackdropClick = false,
+  disableEscapeKeyDown = false,
+  children,
+  preset: presetKey,
+}) => {
+  const { theme } = useTheme();
+  const presetClasses = presetKey ? preset(presetKey) : '';
+
+  const uncontrolled = controlledOpen === undefined;
+  const [openState, setOpenState] = useState(defaultOpen);
+  const open = uncontrolled ? openState : controlledOpen!;
+  const [fade, setFade] = useState(true);
+
+  const requestClose = useCallback(() => {
+    if (uncontrolled) setOpenState(false);
+    onClose?.();
+  }, [uncontrolled, onClose]);
+
+  /* Mount / unmount side-effects */
+  useLayoutEffect(() => {
+    if (!open) return;
+    setFade(false);
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !disableEscapeKeyDown) {
+        e.stopPropagation();
+        requestClose();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown, true);
+      setFade(true);
+    };
+  }, [open, disableEscapeKeyDown, requestClose]);
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (disableBackdropClick) return;
+    if (e.target === e.currentTarget) requestClose();
+  };
+
+  if (!open) return null;
+
+  const drawerElement = (
+    <>
+      <Backdrop $fade={fade} onClick={handleBackdropClick} />
+      <Panel
+        $anchor={anchor}
+        $fade={fade}
+        $size={typeof size === 'number' ? `${size}px` : size}
+        $bg={theme.colors.surface}
+        $text={theme.colors.text}
+        className={presetClasses}
+      >
+        {children}
+      </Panel>
+    </>
+  );
+
+  return createPortal(drawerElement, document.body);
+};
+
+export default Drawer;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * from './components/FormControl';
 export * from './components/Icon';
 export * from './components/IconButton';
 export * from './components/Modal';
+export * from './components/Drawer';
 export * from './components/Panel';
 export * from './components/Parallax';
 export * from './components/Progress';


### PR DESCRIPTION
## Summary
- implement `Drawer` component with minimal API
- expose new component from library entry

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851c61271c48320b9856d3397849290