### PR TITLE
Centralize color helpers

### DIFF
--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -9,6 +9,7 @@ import { useTheme }               from '../system/themeStore';
 import { preset }                 from '../css/stylePresets';
 import { Typography }             from './Typography';
 import type { Presettable }       from '../types';
+import { stripe }                 from '../utilities/colors';
 
 export interface ListProps<T> extends Omit<React.HTMLAttributes<HTMLUListElement>, 'children'>, Presettable {
   data: T[];
@@ -139,41 +140,3 @@ export function List<T>({
 }
 
 export default List;
-
-function stripe(bg: string, txt: string): string {
-  const a = toRgb(bg);
-  const b = toRgb(txt);
-  const mixed = mix(a, b, 0.1);
-  return toHex(mixed);
-}
-
-interface RGB { r: number; g: number; b: number; }
-
-const rgbCache = new Map<string, RGB>();
-function toRgb(hex: string): RGB {
-  if (rgbCache.has(hex)) return rgbCache.get(hex)!;
-  let s = hex.charAt(0) === '#' ? hex.slice(1) : hex;
-  if (s.length === 3) s = s.replace(/./g, (ch) => ch + ch);
-  let rgb: RGB;
-  if (s.length === 6 && !/[^a-f\d]/i.test(s)) {
-    const n = parseInt(s, 16);
-    rgb = { r: (n >> 16) & 255, g: (n >> 8) & 255, b: n & 255 };
-  } else {
-    rgb = { r: 0, g: 0, b: 0 };
-  }
-  rgbCache.set(hex, rgb);
-  return rgb;
-}
-
-function mix(a: RGB, b: RGB, w: number): RGB {
-  const t = w <= 0 ? 0 : w >= 1 ? 1 : w;
-  return {
-    r: ((a.r * (1 - t) + b.r * t) + 0.5) | 0,
-    g: ((a.g * (1 - t) + b.g * t) + 0.5) | 0,
-    b: ((a.b * (1 - t) + b.b * t) + 0.5) | 0,
-  };
-}
-
-function toHex({ r, g, b }: RGB) {
-  return '#' + (((1 << 24) | (r << 16) | (g << 8) | b).toString(16).slice(1));
-}

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -8,52 +8,7 @@ import { useTheme }               from '../system/themeStore';
 import { preset }                 from '../css/stylePresets';
 import { Checkbox }               from './Checkbox';
 import type { Presettable }       from '../types';
-
-/*───────────────────────────────────────────────────────────*/
-/* Ultra‑fast colour helpers                                 */
-
-type RGB = { r:number; g:number; b:number };
-
-// Hex ➜ RGB with bit‑trickery + memoisation
-const rgbCache = new Map<string, RGB>();
-const toRgb = (hex:string):RGB => {
-  if (rgbCache.has(hex)) return rgbCache.get(hex)!;
-  let s = hex.charAt(0)==='#' ? hex.slice(1) : hex;
-  if (s.length===3) s = s.replace(/./g,ch=>ch+ch);            // #abc ⇒ aabbcc
-
-  let rgb:RGB;
-  if (s.length===6 && !/[^a-f\d]/i.test(s)) {
-    const n = parseInt(s,16);
-    rgb = { r:(n>>16)&255, g:(n>>8)&255, b:n&255 };
-  } else {
-    rgb = { r:0, g:0, b:0 };                                  // defensive fallback
-  }
-  rgbCache.set(hex,rgb);
-  return rgb;
-};
-
-// Blend two colours (clamped weight) – bitwise floor for perf
-const mix = (a:RGB, b:RGB, w:number):RGB => {
-  const t = w<=0 ? 0 : w>=1 ? 1 : w;
-  return {
-    r: ((a.r*(1-t)+b.r*t)+0.5)|0,
-    g: ((a.g*(1-t)+b.g*t)+0.5)|0,
-    b: ((a.b*(1-t)+b.b*t)+0.5)|0,
-  };
-};
-
-// RGB ➜ hex (#rrggbb) single op
-const toHex = ({r,g,b}:RGB) => '#'+(((1<<24)|(r<<16)|(g<<8)|b).toString(16).slice(1));
-
-// Memoised zebra‑stripe colour (90% bg + 10% txt)
-const stripeCache = new Map<string,string>();
-const stripe = (bg:string, txt:string):string => {
-  const key = bg+'|'+txt;
-  if (stripeCache.has(key)) return stripeCache.get(key)!;
-  const val = toHex(mix(toRgb(bg),toRgb(txt),0.1));
-  stripeCache.set(key,val);
-  return val;
-};
+import { stripe }                 from '../utilities/colors';
 
 /*───────────────────────────────────────────────────────────*/
 /* Column definition                                          */

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,3 +38,4 @@ export * from './css/stylePresets';
 export * from './system/createFormStore';
 export * from './system/themeStore';
 export * from './hooks/useGoogleFonts';
+export * from './utilities/colors';

--- a/src/utilities/colors.ts
+++ b/src/utilities/colors.ts
@@ -1,0 +1,43 @@
+// ─────────────────────────────────────────────────────────────
+// src/utilities/colors.ts | valet
+// theme colour helpers
+// ─────────────────────────────────────────────────────────────
+
+export interface RGB { r:number; g:number; b:number }
+
+const rgbCache = new Map<string, RGB>();
+export const toRgb = (hex:string):RGB => {
+  if (rgbCache.has(hex)) return rgbCache.get(hex)!;
+  let s = hex.charAt(0)==='#' ? hex.slice(1) : hex;
+  if (s.length===3) s = s.replace(/./g,ch=>ch+ch);
+
+  let rgb:RGB;
+  if (s.length===6 && !/[^a-f\d]/i.test(s)) {
+    const n = parseInt(s,16);
+    rgb = { r:(n>>16)&255, g:(n>>8)&255, b:n&255 };
+  } else {
+    rgb = { r:0, g:0, b:0 };
+  }
+  rgbCache.set(hex,rgb);
+  return rgb;
+};
+
+export const mix = (a:RGB, b:RGB, w:number):RGB => {
+  const t = w<=0 ? 0 : w>=1 ? 1 : w;
+  return {
+    r: ((a.r*(1-t)+b.r*t)+0.5)|0,
+    g: ((a.g*(1-t)+b.g*t)+0.5)|0,
+    b: ((a.b*(1-t)+b.b*t)+0.5)|0,
+  };
+};
+
+export const toHex = ({r,g,b}:RGB):string => '#'+(((1<<24)|(r<<16)|(g<<8)|b).toString(16).slice(1));
+
+const stripeCache = new Map<string,string>();
+export const stripe = (bg:string, txt:string):string => {
+  const key = bg+'|'+txt;
+  if (stripeCache.has(key)) return stripeCache.get(key)!;
+  const val = toHex(mix(toRgb(bg),toRgb(txt),0.1));
+  stripeCache.set(key,val);
+  return val;
+};


### PR DESCRIPTION
## Summary
- add `colors` utilities folder
- remove duplicated color code in Table and List
- export color helpers from new utilities file

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6854f6e96abc8320910fc181cab888a7