### PR TITLE
Add surface store and table auto height

### DIFF
--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -133,3 +133,7 @@ export const useSurfaceStore = () => {
     throw new Error('useSurfaceStore must be used within a <Surface> component');
   return store;
 };
+
+export const useMaybeSurfaceStore = () => {
+  return useContext(SurfaceCtx);
+};

--- a/src/css/createStyled.ts
+++ b/src/css/createStyled.ts
@@ -17,11 +17,27 @@ import hash  from '@emotion/hash';
 const styleCache = new Map<string, string>(); // normal rules
 const injected   = new Set<string>();         // injected IDs
 
+const supportsSheet =
+  typeof document !== 'undefined' &&
+  'adoptedStyleSheets' in document &&
+  'replaceSync' in CSSStyleSheet.prototype;
+const sheet: CSSStyleSheet | null = supportsSheet ? new CSSStyleSheet() : null;
+if (sheet) {
+  (document as any).adoptedStyleSheets = [
+    ...(document as any).adoptedStyleSheets,
+    sheet,
+  ];
+}
+
 function inject(cssId: string, css: string) {
   if (injected.has(cssId)) return;
-  const style = document.createElement('style');
-  style.textContent = css;
-  document.head.appendChild(style);
+  if (sheet) {
+    sheet.insertRule(css);
+  } else {
+    const style = document.createElement('style');
+    style.textContent = css;
+    document.head.appendChild(style);
+  }
   injected.add(cssId);
 }
 

--- a/src/css/createStyled.ts
+++ b/src/css/createStyled.ts
@@ -23,6 +23,7 @@ const supportsSheet =
   'adoptedStyleSheets' in document &&
   'replaceSync' in CSSStyleSheet.prototype;
 const sheet: CSSStyleSheet | null = supportsSheet ? new CSSStyleSheet() : null;
+let sheetText = '';
 if (sheet) {
   (document as any).adoptedStyleSheets = [
     ...(document as any).adoptedStyleSheets,
@@ -33,7 +34,8 @@ if (sheet) {
 function inject(cssId: string, css: string) {
   if (injected.has(cssId)) return;
   if (sheet) {
-    sheet.insertRule(css);
+    sheetText += css;
+    sheet.replaceSync(sheetText);
   } else {
     const style = document.createElement('style');
     style.textContent = css;

--- a/src/system/createSurfaceStore.ts
+++ b/src/system/createSurfaceStore.ts
@@ -1,0 +1,44 @@
+// ─────────────────────────────────────────────────────────────
+// src/system/createSurfaceStore.ts  | valet
+// per-Surface Zustand store tracking viewport and child sizes
+// ─────────────────────────────────────────────────────────────
+import { create } from 'zustand';
+import type { Breakpoint } from './themeStore';
+
+interface Size {
+  width: number;
+  height: number;
+}
+
+export interface SurfaceStore {
+  width: number;
+  height: number;
+  breakpoint: Breakpoint;
+  hasScrollbar: boolean;
+  children: Record<string, Size>;
+  setSize: (w: number, h: number, bp: Breakpoint, scroll: boolean) => void;
+  register: (id: string, size: Size) => void;
+  update: (id: string, size: Size) => void;
+  unregister: (id: string) => void;
+}
+
+export function createSurfaceStore() {
+  return create<SurfaceStore>((set) => ({
+    width: 0,
+    height: 0,
+    breakpoint: 'xs',
+    hasScrollbar: false,
+    children: {},
+    setSize: (w, h, bp, scroll) =>
+      set({ width: w, height: h, breakpoint: bp, hasScrollbar: scroll }),
+    register: (id, size) =>
+      set((s) => ({ children: { ...s.children, [id]: size } })),
+    update: (id, size) =>
+      set((s) => ({ children: { ...s.children, [id]: size } })),
+    unregister: (id) =>
+      set((s) => {
+        const { [id]: _, ...rest } = s.children;
+        return { children: rest };
+      }),
+  }));
+}

--- a/src/system/createSurfaceStore.ts
+++ b/src/system/createSurfaceStore.ts
@@ -20,10 +20,11 @@ export interface SurfaceStore {
   register: (id: string, size: Size) => void;
   update: (id: string, size: Size) => void;
   unregister: (id: string) => void;
+  getAvailable: (id: string) => number;
 }
 
 export function createSurfaceStore() {
-  return create<SurfaceStore>((set) => ({
+  return create<SurfaceStore>((set, get) => ({
     width: 0,
     height: 0,
     breakpoint: 'xs',
@@ -40,5 +41,12 @@ export function createSurfaceStore() {
         const { [id]: _, ...rest } = s.children;
         return { children: rest };
       }),
+    getAvailable: (id) => {
+      const { height, children } = get();
+      let used = 0;
+      for (const key in children)
+        if (key !== id) used += children[key].height;
+      return Math.max(0, height - used);
+    },
   }));
 }


### PR DESCRIPTION
## Summary
- track viewport and child sizes with `createSurfaceStore`
- convert `Surface` context to per-instance Zustand store
- extend `Table` to limit height by surface and register size
- optimise `createStyled` injection with adoptedStyleSheets

## Testing
- `npm run build`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_685711aa1f808320bbe20305188ad804