### PR TITLE
Add surface child store and table scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ cd YourReactLibraryThatUses_valet
 npm link @archway/valet
 ```
 
+## Surface state
+
+`<Surface>` now creates its own Zustand store that tracks the screen size and
+the dimensions of all registered children. The store values are exposed via the
+`useSurface()` hook and CSS variables `--valet-screen-width` and
+`--valet-screen-height`. Every styled element registers itself and gets
+`--valet-el-width` and `--valet-el-height` applied automatically. Nesting
+`<Surface>` components will throw an error.
+
 ## Build
 
 Run `npm run build` to generate the `dist` folder for publishing. Use `npm run dev` during development for a live rebuild.
@@ -92,7 +101,8 @@ These have been mostly tested in the [Valet Playground](https://github.com/off-c
 | Stepper            | 🟡       | 🟡       |        🟡       | 🟡         | 🟡          | 🟡            | WIP                              |
 | Surface            | ✅       | ✅       |        ✅       | ✅         | ✅          | ✅            | ----------                       |
 | Switch             | ✅       | ✅       |        ✅       | ✅         | ✅          | ✅            | ----------                       |
-| Table              | ✅       | ❌       |        ❌       | ✅         | ❌          | ❌            | Needs mobile support!            |
+| Table              | ✅       | ❌       |        ❌       | ✅         | ❌          | ❌            | Uses internal scroll by default. |
+Table automatically fills remaining surface space. Pass `constrainHeight={false}` if you prefer page scrolling.
 | Tabs               | ✅       | ✅       |        ✅       | ✅         | ✅          | ✅            | ----------                       |
 | Textfield          | ✅       | ✅       |        🟡       | ✅         | ✅          | ✅            | ----------                       |
 | Tooltip            | ✅       | ❌       |        ❌       | ✅         | ❌          | ❌            | Needs mobile support!            |

--- a/src/components/Typography.tsx
+++ b/src/components/Typography.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { styled } from '../css/createStyled';
 import { useTheme } from '../system/themeStore';
 import { useSurface } from './Surface';
+import type { SurfaceState } from './Surface';
 import { preset } from '../css/stylePresets';
 import type { Presettable } from '../types';
 
@@ -50,7 +51,8 @@ export const Typography: React.FC<TypographyProps> = ({
 }) => {
   const Tag = mapping[variant];
   const { theme } = useTheme();
-  const { breakpoint } = useSurface();
+  const surface = useSurface();
+  const breakpoint = surface((s: SurfaceState) => s.breakpoint);
 
   const defaultSize = theme.typography[variant].md;
   let size = autoSize ? theme.typography[variant][breakpoint] : defaultSize;


### PR DESCRIPTION
## Summary
- add per-surface Zustand store tracking child sizes
- auto register styled components with their surface
- constrain Table height using available space
- expose surface store and scrolling behaviour in docs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68572a26b1bc8320acaec7aabcaa8c03