### PR TITLE
Implement per-surface store and auto scroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ cd YourReactLibraryThatUses_valet
 npm link @archway/valet
 ```
 
+## Surface state and child registry
+
+Each `<Surface>` instance now owns a Zustand store that tracks its screen size
+and every registered child element. Components created with `createStyled`
+register themselves automatically and expose `--valet-el-width` and
+`--valet-el-height` CSS variables. The surface exposes
+`--valet-screen-width` and `--valet-screen-height` on its root element.
+Nested `<Surface>` components are disallowed.
+
+Tables respect available height by default. Their content scrolls inside the
+component rather than the page. Pass `constrainHeight={false}` to opt out.
+
 ## Build
 
 Run `npm run build` to generate the `dist` folder for publishing. Use `npm run dev` during development for a live rebuild.

--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -2,26 +2,15 @@
 // src/components/Surface.tsx  | valet
 // top-level wrapper that applies theme backgrounds and breakpoints
 // ─────────────────────────────────────────────────────────────
-import React, {
-  createContext,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { useContext, useEffect, useRef } from 'react';
 import { Breakpoint, useTheme } from '../system/themeStore';
+import {
+  createSurfaceStore,
+  SurfaceCtx,
+  useSurface as useSurfaceState,
+} from '../system/surfaceStore';
 import { preset } from '../css/stylePresets';
 import type { Presettable } from '../types';
-
-/** Surface Context definition */
-export interface SurfaceContext {
-  width: number;
-  height: number;
-  breakpoint: Breakpoint;
-  hasScrollbar: boolean;
-}
-
-const SurfaceCtx = createContext<SurfaceContext | null>(null);
 
 /** Surface Props definition */
 export interface SurfaceProps
@@ -39,16 +28,16 @@ export const Surface: React.FC<SurfaceProps> = ({
   ...props
 }) => {
   const ref = useRef<HTMLDivElement>(null);
+  const parent = useContext(SurfaceCtx);
+  if (parent) throw new Error('Nested <Surface> components are not allowed');
+
+  const storeRef = useRef<ReturnType<typeof createSurfaceStore>>();
+  if (!storeRef.current) storeRef.current = createSurfaceStore();
+  const useStore = storeRef.current;
   const { theme } = useTheme();
   const presetClasses = p ? preset(p) : '';
 
-  /* Viewport metrics */
-  const [state, setState] = useState<SurfaceContext>({
-    width: 0,
-    height: 0,
-    breakpoint: 'xs',
-    hasScrollbar: false,
-  });
+  const { width, height } = useStore((s) => ({ width: s.width, height: s.height }));
 
   const bpFor = (w: number): Breakpoint =>
     (Object.entries(theme.breakpoints) as [Breakpoint, number][]).reduce<Breakpoint>(
@@ -56,23 +45,26 @@ export const Surface: React.FC<SurfaceProps> = ({
     );
 
   useEffect(() => {
-    if (!ref.current) return;
     const node = ref.current;
-
-    const ro = new ResizeObserver(([entry]) => {
-      const { width, height } = entry.contentRect;
-      setState({
-        width,
-        height,
+    if (!node) return;
+    useStore.setState((s) => ({ ...s, element: node }));
+    const measure = () => {
+      const rect = node.getBoundingClientRect();
+      useStore.setState((s) => ({
+        ...s,
+        width: rect.width,
+        height: rect.height,
         hasScrollbar:
           node.scrollHeight > node.clientHeight ||
           node.scrollWidth > node.clientWidth,
-        breakpoint: bpFor(width),
-      });
-    });
+        breakpoint: bpFor(rect.width),
+      }));
+    };
+    const ro = new ResizeObserver(measure);
     ro.observe(node);
+    measure();
     return () => ro.disconnect();
-  }, [theme.breakpoints]);
+  }, [theme.breakpoints, useStore]);
 
   /* Restore defaults explicitly (critical fix) */
   const defaults: React.CSSProperties = {
@@ -102,7 +94,7 @@ export const Surface: React.FC<SurfaceProps> = ({
     : { width: '100%', height: 'auto', position: 'relative' };
 
   return (
-    <SurfaceCtx.Provider value={state}>
+    <SurfaceCtx.Provider value={useStore}>
       <div
         ref={ref}
         className={[presetClasses, className].filter(Boolean).join(' ')}
@@ -110,8 +102,10 @@ export const Surface: React.FC<SurfaceProps> = ({
           ...layoutStyles, // first apply layout rules
           ...defaults,     // then explicitly apply default colors (critical fix)
           ...cssVars,      // then fonts and other variables
+          '--valet-screen-width': `${width}px`,
+          '--valet-screen-height': `${height}px`,
           ...style,        // finally allow external overrides
-        }}
+        } as any}
         {...props}
       >
         {children}
@@ -122,9 +116,4 @@ export const Surface: React.FC<SurfaceProps> = ({
 
 export default Surface;
 
-export const useSurface = () => {
-  const ctx = useContext(SurfaceCtx);
-  if (!ctx)
-    throw new Error('useSurface must be used within a <Surface> component');
-  return ctx;
-};
+export { useSurfaceState as useSurface };

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -2,9 +2,10 @@
 // src/components/Table.tsx  | valet
 // Row-hover highlight fixed and now more saturated hover colour.
 // ─────────────────────────────────────────────────────────────
-import React, { useMemo, useState, useEffect } from 'react';
+import React, { useMemo, useState, useEffect, useLayoutEffect, useRef, useId } from 'react';
 import { styled }                 from '../css/createStyled';
 import { useTheme }               from '../system/themeStore';
+import { useSurface }             from '../system/surfaceStore';
 import { preset }                 from '../css/stylePresets';
 import { Checkbox }               from './Checkbox';
 import { stripe, toRgb, mix, toHex } from '../helpers/color';
@@ -34,10 +35,15 @@ export interface TableProps<T>
   initialSort?: { index:number; desc?:boolean };
   onSortChange?: (index:number, desc:boolean)=>void;
   onSelectionChange?: (selected:T[])=>void;
+  constrainHeight?: boolean;
 }
 
 /*───────────────────────────────────────────────────────────*/
 /* Styled primitives                                          */
+const Wrapper = styled('div')`
+  width:100%;
+  display:block;
+`;
 const Root = styled('table')<{
   $striped:boolean; $hover:boolean; $lines:boolean;
   $border:string; $stripe:string; $hoverBg:string;
@@ -111,12 +117,44 @@ export function Table<T extends object>({
   initialSort,
   onSortChange,
   onSelectionChange,
+  constrainHeight = true,
   preset:p,
   className,
   style,
   ...rest
 }:TableProps<T>) {
   const { theme } = useTheme();
+  const surface = useSurface();
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const uniqueId = useId();
+  const [maxHeight,setMaxHeight] = useState<number>();
+
+  useLayoutEffect(() => {
+    if (!constrainHeight || !wrapRef.current) return;
+    const node = wrapRef.current;
+    const measure = () => {
+      const surfEl = surface.element;
+      if (!surfEl) return;
+      const rect = node.getBoundingClientRect();
+      const sRect = surfEl.getBoundingClientRect();
+      const top = rect.top - sRect.top;
+      surface.updateChild(uniqueId, {
+        width: rect.width,
+        height: rect.height,
+        top,
+        left: rect.left - sRect.left,
+      });
+      setMaxHeight(Math.max(0, surface.height - top));
+    };
+    surface.registerChild(uniqueId, { width: 0, height: 0, top: 0, left: 0 });
+    const ro = new ResizeObserver(measure);
+    ro.observe(node);
+    measure();
+    return () => {
+      ro.disconnect();
+      surface.unregisterChild(uniqueId);
+    };
+  }, [constrainHeight, surface.height]);
 
   /* sort state */
   const [sort,setSort] =
@@ -189,6 +227,14 @@ export function Table<T extends object>({
 
   /*─────────────────────────────────────────────────────────*/
   return (
+    <Wrapper
+      ref={wrapRef}
+      style={
+        constrainHeight
+          ? { overflow: 'auto', maxHeight }
+          : undefined
+      }
+    >
     <Root
       {...rest}
       $striped={striped}
@@ -264,6 +310,7 @@ export function Table<T extends object>({
         ))}
       </tbody>
     </Root>
+    </Wrapper>
   );
 }
 

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -144,7 +144,9 @@ export function Table<T extends object>({
         top,
         left: rect.left - sRect.left + surfEl.scrollLeft,
       });
-      setMaxHeight(Math.max(0, surface.height - top));
+      const other = surfEl.scrollHeight - node.offsetHeight;
+      const available = surface.height - other;
+      setMaxHeight(Math.max(0, available));
     };
     surface.registerChild(uniqueId, { width: 0, height: 0, top: 0, left: 0 });
     const ro = new ResizeObserver(measure);

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -137,12 +137,12 @@ export function Table<T extends object>({
       if (!surfEl) return;
       const rect = node.getBoundingClientRect();
       const sRect = surfEl.getBoundingClientRect();
-      const top = rect.top - sRect.top;
+      const top = rect.top - sRect.top + surfEl.scrollTop;
       surface.updateChild(uniqueId, {
         width: rect.width,
         height: rect.height,
         top,
-        left: rect.left - sRect.left,
+        left: rect.left - sRect.left + surfEl.scrollLeft,
       });
       setMaxHeight(Math.max(0, surface.height - top));
     };

--- a/src/components/Typography.tsx
+++ b/src/components/Typography.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { styled } from '../css/createStyled';
 import { useTheme } from '../system/themeStore';
-import { useSurface } from './Surface';
+import { useSurface } from '../system/surfaceStore';
 import { preset } from '../css/stylePresets';
 import type { Presettable } from '../types';
 

--- a/src/css/createStyled.ts
+++ b/src/css/createStyled.ts
@@ -98,8 +98,10 @@ export function styled<Tag extends keyof JSX.IntrinsicElements>(tag: Tag) {
             const rect = el.getBoundingClientRect()
             const sEl = surface.getState().element
             const sRect = sEl ? sEl.getBoundingClientRect() : { top: 0, left: 0 }
-            const top = rect.top - sRect.top
-            const left = rect.left - sRect.left
+            const scrollTop = sEl ? sEl.scrollTop : 0
+            const scrollLeft = sEl ? sEl.scrollLeft : 0
+            const top = rect.top - sRect.top + scrollTop
+            const left = rect.left - sRect.left + scrollLeft
             surface.getState().updateChild(id, {
               width: rect.width,
               height: rect.height,

--- a/src/css/createStyled.ts
+++ b/src/css/createStyled.ts
@@ -9,8 +9,9 @@
 //
 // © 2025 Off-Court Creations – MIT licence
 // ─────────────────────────────────────────────────────────────
-import React from 'react';
+import React, { useContext, useLayoutEffect, useRef } from 'react';
 import hash  from '@emotion/hash';
+import { SurfaceCtx } from '../system/surfaceStore';
 
 /*───────────────────────────────────────────────────────────*/
 /* Internal caches                                           */
@@ -61,6 +62,10 @@ export function styled<Tag extends keyof JSX.IntrinsicElements>(tag: Tag) {
 
     const StyledComponent = React.forwardRef<DomRef, StyledProps>(
       (props, ref) => {
+        const localRef = useRef<DomRef | null>(null)
+        const surface = useContext(SurfaceCtx)
+        const idRef = useRef(`el-${Math.random().toString(36).slice(2)}`)
+
         /* Build raw CSS string (inc. interpolations) ------------------- */
         let rawCSS = '';
         for (let i = 0; i < strings.length; i++) {
@@ -82,14 +87,52 @@ export function styled<Tag extends keyof JSX.IntrinsicElements>(tag: Tag) {
           styleCache.set(normalized, className);
         }
 
-        const merged = [className, props.className].filter(Boolean).join(' ');
-        const domProps = filterStyledProps(props);
+        const merged = [className, props.className].filter(Boolean).join(' ')
+        const domProps = filterStyledProps(props)
+
+        useLayoutEffect(() => {
+          const el = localRef.current
+          if (!surface || !el) return
+          const id = idRef.current
+          const measure = () => {
+            const rect = el.getBoundingClientRect()
+            const sEl = surface.getState().element
+            const sRect = sEl ? sEl.getBoundingClientRect() : { top: 0, left: 0 }
+            const top = rect.top - sRect.top
+            const left = rect.left - sRect.left
+            surface.getState().updateChild(id, {
+              width: rect.width,
+              height: rect.height,
+              top,
+              left,
+            })
+            el.style.setProperty('--valet-el-width', `${rect.width}px`)
+            el.style.setProperty('--valet-el-height', `${rect.height}px`)
+          }
+          surface.getState().registerChild(id, {
+            width: 0,
+            height: 0,
+            top: 0,
+            left: 0,
+          })
+          const ro = new ResizeObserver(measure)
+          ro.observe(el)
+          measure()
+          return () => {
+            ro.disconnect()
+            surface.getState().unregisterChild(id)
+          }
+        }, [surface])
 
         return React.createElement(tag, {
           ...domProps,
           className: merged,
-          ref,
-        });
+          ref: (node: DomRef | null) => {
+            localRef.current = node
+            if (typeof ref === 'function') ref(node)
+            else if (ref) (ref as any).current = node
+          },
+        })
       },
     );
 

--- a/src/system/surfaceStore.ts
+++ b/src/system/surfaceStore.ts
@@ -1,0 +1,57 @@
+// ─────────────────────────────────────────────────────────────
+// src/system/surfaceStore.ts | valet
+// per-surface Zustand store tracking size & children
+// ─────────────────────────────────────────────────────────────
+import React from 'react'
+import { create } from 'zustand'
+import type { Breakpoint } from './themeStore'
+
+export interface ChildMetrics {
+  width: number
+  height: number
+  top: number
+  left: number
+}
+
+export interface SurfaceState {
+  width: number
+  height: number
+  breakpoint: Breakpoint
+  hasScrollbar: boolean
+  element: HTMLDivElement | null
+  children: Record<string, ChildMetrics>
+  registerChild: (id: string, rect: ChildMetrics) => void
+  updateChild: (id: string, rect: ChildMetrics) => void
+  unregisterChild: (id: string) => void
+}
+
+export const createSurfaceStore = () =>
+  create<SurfaceState>((set) => ({
+    width: 0,
+    height: 0,
+    breakpoint: 'xs',
+    hasScrollbar: false,
+    element: null,
+    children: {},
+    registerChild: (id, rect) =>
+      set((s) => ({ children: { ...s.children, [id]: rect } })),
+    updateChild: (id, rect) =>
+      set((s) => ({ children: { ...s.children, [id]: rect } })),
+    unregisterChild: (id) =>
+      set((s) => {
+        const next = { ...s.children }
+        delete next[id]
+        return { children: next }
+      }),
+  }))
+
+export type SurfaceStore = ReturnType<typeof createSurfaceStore>
+
+export const SurfaceCtx = React.createContext<SurfaceStore | null>(null)
+
+export const useSurface = () => {
+  const store = React.useContext(SurfaceCtx)
+  if (!store)
+    throw new Error('useSurface must be used within a <Surface> component')
+  return store()
+}


### PR DESCRIPTION
## Summary
- add `surfaceStore` with child registry
- block nested surfaces and expose screen CSS variables
- auto‑register styled elements to the surface
- add optional table height constraint
- document new surface store and table scrolling

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68572a26b1bc8320acaec7aabcaa8c03