### PR TITLE
Improve tooltip mobile UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ These have been mostly tested in the [Valet Playground](https://github.com/off-c
 | Table              | ✅       | ❌       |        ❌       | ✅         | ❌          | ❌            | Needs mobile support!            |
 | Tabs               | ✅       | ✅       |        ✅       | ✅         | ✅          | ✅            | ----------                       |
 | Textfield          | ✅       | ✅       |        🟡       | ✅         | ✅          | ✅            | ----------                       |
-| Tooltip            | ✅       | ❌       |        ❌       | ✅         | ❌          | ❌            | Needs mobile support!            |
+| Tooltip            | ✅       | ❌       |        ❌       | ✅         | ❌          | ❌            | mobile long-press support        |
 | Typography         | ✅       | ✅       |        🟡       | ✅         | ✅          | ✅            | ----------                       |
 
 ## Hooks

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -80,6 +80,8 @@ const Root = styled('button')<{
 
   -webkit-tap-highlight-color: transparent;
   user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
 
   @media (hover: hover) {
     &:hover:not(:disabled) {

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -82,6 +82,7 @@ const Root = styled('button')<{
   user-select: none;
   -webkit-user-select: none;
   -ms-user-select: none;
+  -webkit-touch-callout: none;
 
   @media (hover: hover) {
     &:hover:not(:disabled) {

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -155,6 +155,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
   const { theme } = useTheme();
   const id        = useId();
   const hasPreset = Boolean(presetKey);
+  const wrapperRef = useRef<HTMLSpanElement>(null);
 
   /* uncontrolled ↔ controlled gate */
   const [internalShow, setInternalShow] = useState(defaultOpen);
@@ -177,6 +178,12 @@ export const Tooltip: React.FC<TooltipProps> = ({
     onOpen?.();
     registerTooltip(close);
   }, [controlled, onOpen, close]);
+
+  const handleOutside = useCallback((e: PointerEvent) => {
+    if (!wrapperRef.current?.contains(e.target as Node)) {
+      close();
+    }
+  }, [close]);
 
   /* listeners */
   const handleEnter = () => {
@@ -229,11 +236,20 @@ export const Tooltip: React.FC<TooltipProps> = ({
     }
   }, [show, controlled, close]);
 
+  useEffect(() => {
+    if (!show) return;
+    document.addEventListener('pointerdown', handleOutside);
+    return () => {
+      document.removeEventListener('pointerdown', handleOutside);
+    };
+  }, [show, handleOutside]);
+
   /* preset classes */
   const presetClasses = presetKey ? preset(presetKey) : '';
 
   return (
     <Wrapper
+      ref={wrapperRef}
       onMouseEnter={!disableHoverListener ? handleEnter : undefined}
       onMouseLeave={!disableHoverListener ? handleLeave : undefined}
       onFocus={!disableFocusListener ? open : undefined}

--- a/src/components/Typography.tsx
+++ b/src/components/Typography.tsx
@@ -88,6 +88,7 @@ export const Typography: React.FC<TypographyProps> = ({
       user-select: none;
       -webkit-user-select: none;
       -ms-user-select: none;
+      -webkit-touch-callout: none;
     `
         : ''};
   `, [Tag]);

--- a/src/components/Typography.tsx
+++ b/src/components/Typography.tsx
@@ -82,6 +82,14 @@ export const Typography: React.FC<TypographyProps> = ({
           ? 'heading'
           : 'body'
       })`};
+    ${({ $variant }) =>
+      $variant === 'button'
+        ? `
+      user-select: none;
+      -webkit-user-select: none;
+      -ms-user-select: none;
+    `
+        : ''};
   `, [Tag]);
 
   return (


### PR DESCRIPTION
## Summary
- support mobile long-press tooltips and pointer events
- mention mobile long-press support in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6857564937808320a2864cd65b69b946