### PR TITLE
Improve surface performance

### DIFF
--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -86,11 +86,14 @@ export const Surface: React.FC<SurfaceProps> = ({
   }, [fontsReady]);
 
   useEffect(() => {
-    if (!fontsReady) {
-      const t = setTimeout(() => setShowSpinner(true), 1250);
-      return () => clearTimeout(t);
+    if (fontsReady) {
+      setShowSpinner(false);
+      return;
     }
-    setShowSpinner(false);
+    const t = setTimeout(() => {
+      if (!useFonts.getState().ready) setShowSpinner(true);
+    }, 1250);
+    return () => clearTimeout(t);
   }, [fontsReady]);
 
   /* Restore defaults explicitly (critical fix) */

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -132,30 +132,28 @@ export function Table<T extends object>({
   useLayoutEffect(() => {
     if (!constrainHeight || !wrapRef.current) return;
     const node = wrapRef.current;
-    const measure = () => {
+    const update = () => {
       const surfEl = surface.element;
       if (!surfEl) return;
-      const rect = node.getBoundingClientRect();
-      const sRect = surfEl.getBoundingClientRect();
-      const top = rect.top - sRect.top + surfEl.scrollTop;
-      surface.updateChild(uniqueId, {
-        width: rect.width,
-        height: rect.height,
-        top,
-        left: rect.left - sRect.left + surfEl.scrollLeft,
-      });
       const other = surfEl.scrollHeight - node.offsetHeight;
       const available = surface.height - other;
       setMaxHeight(Math.max(0, available));
     };
-    surface.registerChild(uniqueId, { width: 0, height: 0, top: 0, left: 0 });
-    const ro = new ResizeObserver(measure);
-    ro.observe(node);
-    measure();
+    surface.registerChild(uniqueId, node, update);
+    update();
     return () => {
-      ro.disconnect();
       surface.unregisterChild(uniqueId);
     };
+  }, [constrainHeight]);
+
+  useLayoutEffect(() => {
+    if (!constrainHeight || !wrapRef.current) return;
+    const node = wrapRef.current;
+    const surfEl = surface.element;
+    if (!surfEl) return;
+    const other = surfEl.scrollHeight - node.offsetHeight;
+    const available = surface.height - other;
+    setMaxHeight(Math.max(0, available));
   }, [constrainHeight, surface.height]);
 
   /* sort state */

--- a/src/css/createStyled.ts
+++ b/src/css/createStyled.ts
@@ -18,11 +18,14 @@ import { SurfaceCtx } from '../system/surfaceStore';
 const styleCache = new Map<string, string>(); // normal rules
 const injected   = new Set<string>();         // injected IDs
 
+/* Single global stylesheet for all rules ------------------------------ */
+const styleEl = document.createElement('style');
+document.head.appendChild(styleEl);
+const globalSheet = styleEl.sheet as CSSStyleSheet;
+
 function inject(cssId: string, css: string) {
   if (injected.has(cssId)) return;
-  const style = document.createElement('style');
-  style.textContent = css;
-  document.head.appendChild(style);
+  globalSheet.insertRule(css, globalSheet.cssRules.length);
   injected.add(cssId);
 }
 
@@ -94,34 +97,11 @@ export function styled<Tag extends keyof JSX.IntrinsicElements>(tag: Tag) {
           const el = localRef.current
           if (!surface || !el) return
           const id = idRef.current
-          const measure = () => {
-            const rect = el.getBoundingClientRect()
-            const sEl = surface.getState().element
-            const sRect = sEl ? sEl.getBoundingClientRect() : { top: 0, left: 0 }
-            const scrollTop = sEl ? sEl.scrollTop : 0
-            const scrollLeft = sEl ? sEl.scrollLeft : 0
-            const top = rect.top - sRect.top + scrollTop
-            const left = rect.left - sRect.left + scrollLeft
-            surface.getState().updateChild(id, {
-              width: rect.width,
-              height: rect.height,
-              top,
-              left,
-            })
-            el.style.setProperty('--valet-el-width', `${rect.width}px`)
-            el.style.setProperty('--valet-el-height', `${rect.height}px`)
-          }
-          surface.getState().registerChild(id, {
-            width: 0,
-            height: 0,
-            top: 0,
-            left: 0,
+          surface.getState().registerChild(id, el, (m) => {
+            el.style.setProperty('--valet-el-width', `${m.width}px`)
+            el.style.setProperty('--valet-el-height', `${m.height}px`)
           })
-          const ro = new ResizeObserver(measure)
-          ro.observe(el)
-          measure()
           return () => {
-            ro.disconnect()
             surface.getState().unregisterChild(id)
           }
         }, [surface])
@@ -171,4 +151,4 @@ export function keyframes(
 }
 
 /*───────────────────────────────────────────────────────────*/
-export { styleCache };
+export { styleCache, globalSheet };

--- a/src/system/surfaceStore.ts
+++ b/src/system/surfaceStore.ts
@@ -19,31 +19,89 @@ export interface SurfaceState {
   breakpoint: Breakpoint
   hasScrollbar: boolean
   element: HTMLDivElement | null
-  children: Record<string, ChildMetrics>
-  registerChild: (id: string, rect: ChildMetrics) => void
-  updateChild: (id: string, rect: ChildMetrics) => void
+  children: Map<string, ChildMetrics>
+  registerChild: (
+    id: string,
+    node: HTMLElement,
+    cb?: (metrics: ChildMetrics) => void,
+  ) => void
   unregisterChild: (id: string) => void
 }
 
 export const createSurfaceStore = () =>
-  create<SurfaceState>((set) => ({
-    width: 0,
-    height: 0,
-    breakpoint: 'xs',
-    hasScrollbar: false,
-    element: null,
-    children: {},
-    registerChild: (id, rect) =>
-      set((s) => ({ children: { ...s.children, [id]: rect } })),
-    updateChild: (id, rect) =>
-      set((s) => ({ children: { ...s.children, [id]: rect } })),
-    unregisterChild: (id) =>
-      set((s) => {
-        const next = { ...s.children }
-        delete next[id]
-        return { children: next }
-      }),
-  }))
+  create<SurfaceState>((set, get) => {
+    const nodes = new Map<string, { node: HTMLElement; cb?: (m: ChildMetrics) => void }>()
+
+    const ro = new ResizeObserver((entries) => {
+      const surfEl = get().element
+      const sRect = surfEl ? surfEl.getBoundingClientRect() : { top: 0, left: 0 }
+      const scrollTop = surfEl ? surfEl.scrollTop : 0
+      const scrollLeft = surfEl ? surfEl.scrollLeft : 0
+
+      for (const entry of entries) {
+        for (const [id, meta] of nodes) {
+          if (meta.node === entry.target) {
+            const rect = entry.target.getBoundingClientRect()
+            const metrics = {
+              width: rect.width,
+              height: rect.height,
+              top: rect.top - sRect.top + scrollTop,
+              left: rect.left - sRect.left + scrollLeft,
+            }
+            set((s) => {
+              const next = new Map(s.children)
+              next.set(id, metrics)
+              return { children: next }
+            })
+            meta.cb?.(metrics)
+            break
+          }
+        }
+      }
+    })
+
+    return {
+      width: 0,
+      height: 0,
+      breakpoint: 'xs',
+      hasScrollbar: false,
+      element: null,
+      children: new Map(),
+      registerChild: (id, node, cb) => {
+        nodes.set(id, { node, cb })
+        ro.observe(node)
+        const surfEl = get().element
+        const sRect = surfEl ? surfEl.getBoundingClientRect() : { top: 0, left: 0 }
+        const scrollTop = surfEl ? surfEl.scrollTop : 0
+        const scrollLeft = surfEl ? surfEl.scrollLeft : 0
+        const rect = node.getBoundingClientRect()
+        const metrics = {
+          width: rect.width,
+          height: rect.height,
+          top: rect.top - sRect.top + scrollTop,
+          left: rect.left - sRect.left + scrollLeft,
+        }
+        set((s) => {
+          const next = new Map(s.children)
+          next.set(id, metrics)
+          return { children: next }
+        })
+        cb?.(metrics)
+      },
+      unregisterChild: (id) => {
+        const entry = nodes.get(id)
+        if (entry) {
+          ro.unobserve(entry.node)
+          nodes.delete(id)
+        }
+        set((s) => {
+          const next = new Map(s.children)
+          next.delete(id)
+          return { children: next }
+        })
+      },
+    }
+  })
 
 export type SurfaceStore = ReturnType<typeof createSurfaceStore>
 


### PR DESCRIPTION
## Summary
- inject all CSS into a single global stylesheet
- manage child element measurements with one ResizeObserver
- track surface children in a `Map`
- update styled elements and Table to use centralized observer
- skip font spinner timers when fonts load fast

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68589eaf05408320b9f51d809855e098