### PR TITLE
Disable context menu on buttons

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -208,6 +208,7 @@ export const Button: React.FC<ButtonProps> = ({
   return (
     <Root
       {...rest}
+      onContextMenu={(e) => e.preventDefault()}
       style={{ '--valet-text-color': labelColor } as React.CSSProperties}
       className={[presetClasses, className].filter(Boolean).join(' ')}
       $variant={variant}

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -132,6 +132,7 @@ export const IconButton: React.FC<IconButtonProps> = ({
     <Skin
       type="button"
       {...rest}
+      onContextMenu={(e) => e.preventDefault()}
       $variant={variant}
       $primary={theme.colors.primary}
       $text={theme.colors.text}


### PR DESCRIPTION
## Summary
- add onContextMenu handler to Button and IconButton to prevent default context menu

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a06f4a7a0832092f9da54e7d58a62