### PR TITLE
Right click toggles accordion headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file. The format 
 ### Added
 - Keep a Changelog 1.1.0 rules in `AGENTS.md`
 - Initial changelog with historical versions
+### Fixed
+- Right clicking accordion headers now toggles them instead of showing the browser menu
 
 ## [v0.5.2]
 ### Other

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -233,6 +233,10 @@ const AccordionItem: React.FC<AccordionItemProps> = ({
           aria-controls={panelId}
           disabled={disabled}
           onClick={() => toggle(index)}
+          onContextMenu={(e) => {
+            e.preventDefault();
+            if (!disabled) toggle(index);
+          }}
           $open={isOpen}
           $primary={theme.colors.primary}
           $disabledColor={disabledColor}


### PR DESCRIPTION
## Summary
- block default context menu on Accordion header right-click
- update changelog

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685b4d8a94a483209561c050c95b1adf