### PR TITLE
Add Snackbar component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. The format 
 - Snackbar component for ephemeral messages
 ### Changed
 - Snackbar now uses the theme background with a primary outline
+- Snackbar outline width doubled for stronger emphasis
 - Snackbar action elements automatically receive left spacing
 ### Fixed
 - Right clicking accordion headers now toggles them instead of showing the browser menu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. The format 
 - Snackbar component for ephemeral messages
 ### Changed
 - Snackbar now uses the theme background with a primary outline
+- Snackbar action elements automatically receive left spacing
 ### Fixed
 - Right clicking accordion headers now toggles them instead of showing the browser menu
 - Long pressing accordion headers on touch devices now toggles them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Added
 - Keep a Changelog 1.1.0 rules in `AGENTS.md`
 - Initial changelog with historical versions
+- Snackbar component for ephemeral messages
 ### Fixed
 - Right clicking accordion headers now toggles them instead of showing the browser menu
 - Long pressing accordion headers on touch devices now toggles them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file. The format 
 - Snackbar now uses the theme background with a primary outline
 - Snackbar outline width doubled for stronger emphasis
 - Snackbar action elements automatically receive left spacing
+- Snackbar now centers relative to its surface with theme-based offset
+- Snackbar fade duration matches surface (200ms)
 ### Fixed
 - Right clicking accordion headers now toggles them instead of showing the browser menu
 - Long pressing accordion headers on touch devices now toggles them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 - Right clicking accordion headers now toggles them instead of showing the browser menu
 - Long pressing accordion headers on touch devices now toggles them
+- Snackbar actions now align correctly in right-anchored positions
 
 ## [v0.5.2]
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file. The format 
 - Right clicking accordion headers now toggles them instead of showing the browser menu
 - Long pressing accordion headers on touch devices now toggles them
 - Snackbar actions now align correctly in right-anchored positions
+- Fix typing issue on `$offset` prop in Snackbar
 
 ## [v0.5.2]
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file. The format 
 - Keep a Changelog 1.1.0 rules in `AGENTS.md`
 - Initial changelog with historical versions
 - Snackbar component for ephemeral messages
+### Changed
+- Snackbar now uses the theme background with a primary outline
 ### Fixed
 - Right clicking accordion headers now toggles them instead of showing the browser menu
 - Long pressing accordion headers on touch devices now toggles them

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -48,6 +48,7 @@ const Root = styled('div')<{
   box-shadow: 0 2px 5px rgba(0,0,0,0.15);
   background: var(--snackbar-bg);
   color: var(--snackbar-fg);
+  border: 1px solid var(--snackbar-outline);
   z-index: 9999;
   transition: transform 0.25s ease, opacity 0.25s ease;
 
@@ -126,8 +127,9 @@ export const Snackbar: React.FC<SnackbarProps> = ({
       $anchor={finalAnchor}
       className={presetClasses}
       style={{
-        '--snackbar-bg': theme.colors.surface,
+        '--snackbar-bg': theme.colors.background,
         '--snackbar-fg': theme.colors.text,
+        '--snackbar-outline': theme.colors.primary,
       } as React.CSSProperties}
       role="status"
       aria-live="polite"

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -67,8 +67,8 @@ const Root = styled('div')<{
     ${({ $anchor }) => ($anchor.horizontal === 'center' ? '-50%' : '0')},
         ? '20px'
         : '-20px'}
-  const surfaceCtx = useContext(SurfaceCtx);
-  const portalTarget = surfaceCtx?.getState().element ?? document.body;
+export const Snackbar = React.forwardRef<HTMLDivElement, SnackbarProps>(function Snackbar({
+}, ref) {
 
       const t = setTimeout(() => setMount(false), 200);
 
@@ -131,7 +131,8 @@ export const Snackbar: React.FC<SnackbarProps> = ({
 
       $offset={offsetSpacing}
     if (uncontrolled) setOpenState(false);
-    onClose?.();
+      ref={ref}
+});
   };
 
   useLayoutEffect(() => {

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -6,6 +6,7 @@ import React, {
   Children,
   isValidElement,
   cloneElement,
+  useContext,
   useEffect,
   useLayoutEffect,
   useState,
@@ -13,6 +14,7 @@ import React, {
 import { createPortal } from 'react-dom';
 import { styled } from '../css/createStyled';
 import { useTheme } from '../system/themeStore';
+import { SurfaceCtx } from '../system/surfaceStore';
 import { preset } from '../css/stylePresets';
 import type { Presettable } from '../types';
 
@@ -46,6 +48,7 @@ const Root = styled('div')<{
   $open: boolean;
   $anchor: Required<SnackbarAnchor>;
   $gap: string;
+  $offset: string;
 }>`
   position: fixed;
   display: flex;
@@ -57,17 +60,20 @@ const Root = styled('div')<{
   box-shadow: 0 2px 5px rgba(0,0,0,0.15);
   background: var(--snackbar-bg);
   color: var(--snackbar-fg);
-  border: 0.25rem solid var(--snackbar-outline);
-  z-index: 9999;
-  transition: transform 0.25s ease, opacity 0.25s ease;
+  transition: transform 200ms ease, opacity 200ms ease;
+  ${({ $anchor, $offset }) => `${$anchor.vertical}: ${$offset};`}
+      ? 'left: 50%;'
 
-  ${({ $anchor }) => `${$anchor.vertical}: 1rem;`}
-  ${({ $anchor }) =>
-    $anchor.horizontal === 'center'
-      ? 'left: 50%; translate: -50% 0;'
-      : `${$anchor.horizontal}: 1rem;`}
+    ${({ $anchor }) => ($anchor.horizontal === 'center' ? '-50%' : '0')},
+        ? '20px'
+        : '-20px'}
+  const surfaceCtx = useContext(SurfaceCtx);
+  const portalTarget = surfaceCtx?.getState().element ?? document.body;
 
-  opacity: ${({ $open }) => ($open ? 1 : 0)};
+      const t = setTimeout(() => setMount(false), 200);
+
+      $offset={theme.spacing.lg}
+  return createPortal(node, portalTarget);
   transform: translate(
     ${({ $anchor }) =>
       $anchor.horizontal === 'center' ? '-50%' : '0'},

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -57,7 +57,7 @@ const Root = styled('div')<{
   box-shadow: 0 2px 5px rgba(0,0,0,0.15);
   background: var(--snackbar-bg);
   color: var(--snackbar-fg);
-  border: 1px solid var(--snackbar-outline);
+  border: 0.125rem solid var(--snackbar-outline);
   z-index: 9999;
   transition: transform 0.25s ease, opacity 0.25s ease;
 

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -57,7 +57,7 @@ const Root = styled('div')<{
   box-shadow: 0 2px 5px rgba(0,0,0,0.15);
   background: var(--snackbar-bg);
   color: var(--snackbar-fg);
-  border: 0.125rem solid var(--snackbar-outline);
+  border: 0.25rem solid var(--snackbar-outline);
   z-index: 9999;
   transition: transform 0.25s ease, opacity 0.25s ease;
 

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -1,0 +1,143 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/Snackbar.tsx | valet
+// ephemeral bottom overlay message
+// ─────────────────────────────────────────────────────────────
+import React, { useEffect, useLayoutEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { styled } from '../css/createStyled';
+import { useTheme } from '../system/themeStore';
+import { preset } from '../css/stylePresets';
+import type { Presettable } from '../types';
+
+/*───────────────────────────────────────────────────────────*/
+export type SnackbarVertical = 'top' | 'bottom';
+export type SnackbarHorizontal = 'left' | 'center' | 'right';
+export interface SnackbarAnchor {
+  vertical?: SnackbarVertical;
+  horizontal?: SnackbarHorizontal;
+}
+
+export interface SnackbarProps extends Presettable {
+  /** Controlled visibility */
+  open?: boolean;
+  /** Default for uncontrolled */
+  defaultOpen?: boolean;
+  /** Auto dismiss after ms */
+  autoHideDuration?: number;
+  /** Message contents */
+  message: React.ReactNode;
+  /** Optional action node */
+  action?: React.ReactNode;
+  /** Position of snackbar */
+  anchor?: SnackbarAnchor;
+  /** Close callback */
+  onClose?: () => void;
+}
+
+/*───────────────────────────────────────────────────────────*/
+const Root = styled('div')<{
+  $open: boolean;
+  $anchor: Required<SnackbarAnchor>;
+}>`
+  position: fixed;
+  display: flex;
+  align-items: center;
+  max-width: min(24rem, calc(100vw - 2rem));
+  padding: 0.75rem 1rem;
+  border-radius: 4px;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.15);
+  background: var(--snackbar-bg);
+  color: var(--snackbar-fg);
+  z-index: 9999;
+  transition: transform 0.25s ease, opacity 0.25s ease;
+
+  ${({ $anchor }) => `${$anchor.vertical}: 1rem;`}
+  ${({ $anchor }) =>
+    $anchor.horizontal === 'center'
+      ? 'left: 50%; translate: -50% 0;'
+      : `${$anchor.horizontal}: 1rem;`}
+
+  opacity: ${({ $open }) => ($open ? 1 : 0)};
+  transform: translate(
+    ${({ $anchor }) =>
+      $anchor.horizontal === 'center' ? '-50%' : '0'},
+    ${({ $open, $anchor }) =>
+      $open
+        ? '0'
+        : $anchor.vertical === 'bottom'
+          ? '20px'
+          : '-20px'}
+  );
+`;
+
+/*───────────────────────────────────────────────────────────*/
+export const Snackbar: React.FC<SnackbarProps> = ({
+  open: controlled,
+  defaultOpen = false,
+  autoHideDuration,
+  message,
+  action,
+  anchor,
+  onClose,
+  preset: p,
+}) => {
+  const { theme } = useTheme();
+  const presetClasses = p ? preset(p) : '';
+
+  const uncontrolled = controlled === undefined;
+  const [openState, setOpenState] = useState(defaultOpen);
+  const isOpen = uncontrolled ? openState : controlled!;
+  const [mount, setMount] = useState(isOpen);
+
+  const finalAnchor: Required<SnackbarAnchor> = {
+    vertical: anchor?.vertical ?? 'bottom',
+    horizontal: anchor?.horizontal ?? 'center',
+  };
+
+  const requestClose = () => {
+    if (uncontrolled) setOpenState(false);
+    onClose?.();
+  };
+
+  useLayoutEffect(() => {
+    if (isOpen) setMount(true);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (autoHideDuration !== undefined) {
+      const id = setTimeout(requestClose, autoHideDuration);
+      return () => clearTimeout(id);
+    }
+  }, [isOpen, autoHideDuration]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      const t = setTimeout(() => setMount(false), 250);
+      return () => clearTimeout(t);
+    }
+  }, [isOpen]);
+
+  if (!mount) return null;
+
+  const node = (
+    <Root
+      $open={isOpen}
+      $anchor={finalAnchor}
+      className={presetClasses}
+      style={{
+        '--snackbar-bg': theme.colors.surface,
+        '--snackbar-fg': theme.colors.text,
+      } as React.CSSProperties}
+      role="status"
+      aria-live="polite"
+    >
+      <div style={{ flex: 1 }}>{message}</div>
+      {action && <div>{action}</div>}
+    </Root>
+  );
+
+  return createPortal(node, document.body);
+};
+
+export default Snackbar;

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -127,7 +127,7 @@ export const Snackbar: React.FC<SnackbarProps> = ({
       })
     : null;
 
-  const offsetSpacing = theme.spacing.lg
+  const offsetSpacing = theme.spacing.lg;
 
       $offset={offsetSpacing}
     if (uncontrolled) setOpenState(false);

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -2,7 +2,14 @@
 // src/components/Snackbar.tsx | valet
 // ephemeral bottom overlay message
 // ─────────────────────────────────────────────────────────────
-import React, { useEffect, useLayoutEffect, useState } from 'react';
+import React, {
+  Children,
+  isValidElement,
+  cloneElement,
+  useEffect,
+  useLayoutEffect,
+  useState,
+} from 'react';
 import { createPortal } from 'react-dom';
 import { styled } from '../css/createStyled';
 import { useTheme } from '../system/themeStore';
@@ -95,6 +102,23 @@ export const Snackbar: React.FC<SnackbarProps> = ({
     horizontal: anchor?.horizontal ?? 'center',
   };
 
+  const actionNode = action
+    ? Children.map(action, (child, idx) => {
+        if (idx === 0) {
+          if (isValidElement(child)) {
+            return cloneElement(child as React.ReactElement<any>, {
+              style: {
+                marginLeft: theme.spacing.sm,
+                ...((child as any).props?.style ?? {}),
+              },
+            });
+          }
+          return <span style={{ marginLeft: theme.spacing.sm }}>{child}</span>;
+        }
+        return child;
+      })
+    : null;
+
   const requestClose = () => {
     if (uncontrolled) setOpenState(false);
     onClose?.();
@@ -135,7 +159,7 @@ export const Snackbar: React.FC<SnackbarProps> = ({
       aria-live="polite"
     >
       <div style={{ flex: 1 }}>{message}</div>
-      {action && <div>{action}</div>}
+      {actionNode && <div>{actionNode}</div>}
     </Root>
   );
 

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -45,10 +45,12 @@ export interface SnackbarProps extends Presettable {
 const Root = styled('div')<{
   $open: boolean;
   $anchor: Required<SnackbarAnchor>;
+  $gap: string;
 }>`
   position: fixed;
   display: flex;
   align-items: center;
+  gap: ${({ $gap }) => $gap};
   max-width: min(24rem, calc(100vw - 2rem));
   padding: 0.75rem 1rem;
   border-radius: 4px;
@@ -149,6 +151,7 @@ export const Snackbar: React.FC<SnackbarProps> = ({
     <Root
       $open={isOpen}
       $anchor={finalAnchor}
+      $gap={theme.spacing.sm}
       className={presetClasses}
       style={{
         '--snackbar-bg': theme.colors.background,

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -127,7 +127,9 @@ export const Snackbar: React.FC<SnackbarProps> = ({
       })
     : null;
 
-  const requestClose = () => {
+  const offsetSpacing = theme.spacing.lg
+
+      $offset={offsetSpacing}
     if (uncontrolled) setOpenState(false);
     onClose?.();
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ export type {
 } from './components/Select';
 export * from './components/Surface';
 export * from './components/LoadingBackdrop';
+export * from './components/Snackbar';
 export * from './components/Switch';
 export * from './components/Tabs';
 export * from './components/TextField';


### PR DESCRIPTION
## Summary
- add a Snackbar component for ephemeral messages
- export it from the package
- document it in the changelog

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685b6708f9488320bf23864e122c3bf5