### PR TITLE
Switch to siphash for readable classnames

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@emotion/hash": "^0.9.2",
     "@iconify/react": "^6.0.0",
+    "siphash": "^1.2.0",
     "zustand": "^4.5.7"
   },
   "peerDependencies": {

--- a/src/css/createStyled.ts
+++ b/src/css/createStyled.ts
@@ -10,7 +10,11 @@
 // © 2025 Off-Court Creations – MIT licence
 // ─────────────────────────────────────────────────────────────
 import React, { useContext, useLayoutEffect, useRef } from 'react';
-import hash  from '@emotion/hash';
+import { hashStr } from './hash';
+
+function labelize(raw: string) {
+  return raw.toLowerCase().replace(/[^a-z0-9_-]+/g, '') || 'el';
+}
 import { SurfaceCtx } from '../system/surfaceStore';
 
 /*───────────────────────────────────────────────────────────*/
@@ -85,7 +89,12 @@ export function styled<Tag extends keyof JSX.IntrinsicElements>(tag: Tag) {
         const normalized = normalizeCSS(rawCSS);
         let className = styleCache.get(normalized);
         if (!className) {
-          className = `z-${hash(normalized)}`;
+          const rawLabel =
+            typeof tag === 'string'
+              ? tag
+              : (tag as any).displayName || (tag as any).name || 'el';
+          const label = labelize(rawLabel);
+          className = `z-${label}-${hashStr(normalized)}`;
           inject(`.${className}`, `.${className}{${normalized}}`);
           styleCache.set(normalized, className);
         }
@@ -137,7 +146,7 @@ export function keyframes(
   }
 
   const normalized = normalizeCSS(rawCSS);
-  const animName   = `z-kf-${hash(normalized)}`;
+  const animName   = `z-kf-${hashStr(normalized)}`;
 
   /* Only inject once --------------------------------------------------- */
   if (!injected.has(animName)) {

--- a/src/css/hash.ts
+++ b/src/css/hash.ts
@@ -1,0 +1,11 @@
+// ─────────────────────────────────────────────────────────────
+// src/css/hash.ts  | valet
+// Siphash-based hash util for stable class names
+// ─────────────────────────────────────────────────────────────
+import * as siphash from 'siphash';
+
+const KEY = siphash.string16_to_key('valet-hash-key!1');
+
+export function hashStr(str: string): string {
+  return siphash.hash_uint(KEY, str).toString(36);
+}

--- a/src/css/stylePresets.ts
+++ b/src/css/stylePresets.ts
@@ -2,7 +2,7 @@
 // src/css/stylePresets.ts  | valet
 // registry of reusable style presets via definePreset()
 // ─────────────────────────────────────────────────────────────
-import hash                 from '@emotion/hash';
+import { hashStr }          from './hash';
 import { Theme, useTheme }  from '../system/themeStore';
 import { styleCache, globalSheet } from './createStyled';
 
@@ -42,8 +42,9 @@ export function definePreset(name: string, cssFn: CSSFn) {
 
   ensureSubscription();
 
-  /* Stable class name = hash of the preset name (not the CSS) */
-  const className = `zp-${hash(name)}`;
+  /* Stable class name = readable prefix + hash */
+  const prefix    = name.toLowerCase().replace(/[^a-z0-9_-]+/g, '');
+  const className = `zp-${prefix}-${hashStr(name)}`;
 
   /* Initial render */
   const { theme } = useTheme.getState();


### PR DESCRIPTION
## Summary
- replace `@emotion/hash` with `siphash`
- generate more readable class names using the component label
- keep keyframe and style preset names stable with new hash util

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685c79b105bc8320a926d8aefbfe4a87