### PR TITLE
Switch theme spacing to unit system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,9 +104,28 @@ Unless otherwise specified by user directive, pull requests should be made from 
 
 ## Building the Project
 
-1. Install dependencies with `npm install`.
-2. Build the library with `npm run build`.
-3. For development, use `npm run dev` to start a watch build.
+1. Install dependencies with: 
+
+```shell
+cd valet
+npm install
+cd docs
+npm install
+```
+
+2. You can build the library and docs with `npm run build`.
+
+3. To test WIP changes in the components or system code using a page from the docs, use an NPM link:
+
+```shell
+cd valet
+npm link
+npm run dev
+# Second terminal emulator, or use TMUX
+cd valet
+cd docs
+npm link @archway/valet
+npm run dev
 
 ## CHANGELOG
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Replaced spacing size tokens (sm, md, lg, xl) with units (1, 2, 3)
 
 ## [v0.6.1]
 ### Changed

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ npm run dev
 ```shell
 cd YourReactLibraryThatUses_valet
 npm link @archway/valet
+npm run dev
 ```
 
 ## Build

--- a/docs/src/pages/AccordionDemo.tsx
+++ b/docs/src/pages/AccordionDemo.tsx
@@ -35,7 +35,7 @@ export default function AccordionDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         {/* Header --------------------------------------------------------- */}
@@ -138,7 +138,7 @@ export default function AccordionDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing(3) }}
+          style={{ marginTop: theme.spacing(1) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/AccordionDemo.tsx
+++ b/docs/src/pages/AccordionDemo.tsx
@@ -35,7 +35,7 @@ export default function AccordionDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         {/* Header --------------------------------------------------------- */}
@@ -138,7 +138,7 @@ export default function AccordionDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing['lg'] }}
+          style={{ marginTop: theme.spacing(3) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/AppBarDemo.tsx
+++ b/docs/src/pages/AppBarDemo.tsx
@@ -9,7 +9,7 @@ export default function AppBarDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         <Typography variant="h2" bold>
@@ -23,7 +23,7 @@ export default function AppBarDemoPage() {
           <Typography variant="h6">Fixed</Typography>
         </AppBar>
 
-        <Stack spacing={3}>
+        <Stack spacing={1}>
           <Typography variant="h1">
             placeholder
           </Typography>

--- a/docs/src/pages/AppBarDemo.tsx
+++ b/docs/src/pages/AppBarDemo.tsx
@@ -9,7 +9,7 @@ export default function AppBarDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         <Typography variant="h2" bold>
@@ -23,7 +23,7 @@ export default function AppBarDemoPage() {
           <Typography variant="h6">Fixed</Typography>
         </AppBar>
 
-        <Stack spacing="lg">
+        <Stack spacing={3}>
           <Typography variant="h1">
             placeholder
           </Typography>

--- a/docs/src/pages/BoxDemo.tsx
+++ b/docs/src/pages/BoxDemo.tsx
@@ -21,8 +21,8 @@ definePreset('fancyBox', (t) => `
     color        : ${t.colors['primaryText']};
     border-radius: 20px;
     box-shadow   : 0 6px 16px ${t.colors['text']}22;
-    padding      : ${t.spacing['lg']};
-    margin       : ${t.spacing['lg']};
+    padding      : ${t.spacing(3)};
+    margin       : ${t.spacing(3)};
   `);
 
 // Frosted-glass effect (needs backdrop-filter support)
@@ -30,7 +30,7 @@ definePreset('glassBox', (t) => `
     background      : ${t.colors['background']}CC;
     backdrop-filter : blur(6px) saturate(180%);
     border          : 1px solid ${t.colors['text']}22;
-    padding         : ${t.spacing['lg']};
+    padding         : ${t.spacing(3)};
     border-radius   : 12px;
   `);
 
@@ -52,7 +52,7 @@ export default function BoxDemoPage() {
   return (
     <Surface /* Surface already defaults to theme background */>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         {/* Page header ----------------------------------------------------- */}
@@ -71,7 +71,7 @@ export default function BoxDemoPage() {
 
         {/* 2. Background prop with auto-text detection --------------------- */}
         <Typography variant="h3">2. background&nbsp;prop</Typography>
-        <Stack spacing="md">
+        <Stack spacing={2}>
           <Box background={theme.colors['primary']}>
             <Typography variant="h4">{`background={theme.colors.primary}`}</Typography>
           </Box>
@@ -88,7 +88,7 @@ export default function BoxDemoPage() {
         <Box
           background={"#333333"}
           textColor={theme.colors['tertiary']}
-          style={{ padding: theme.spacing['md'] }}
+          style={{ padding: theme.spacing(2) }}
         >
           <Typography>
             Greetings Programs!
@@ -103,7 +103,7 @@ export default function BoxDemoPage() {
           background={theme.colors['tertiary']}
           style={{
             border: `2px dashed ${theme.colors['text']}`,
-            padding: theme.spacing['lg'],
+            padding: theme.spacing(3),
             borderRadius: 12,
           }}
         >
@@ -112,8 +112,8 @@ export default function BoxDemoPage() {
 
         {/* 5. Nested Boxes & CSS custom props ------------------------------ */}
         <Typography variant="h3">5. Nested Boxes</Typography>
-        <Box background={theme.colors['primary']} style={{ padding: theme.spacing['md'] }}>
-          <Box background={theme.colors['secondary']} style={{ padding: theme.spacing['sm'] }}>
+        <Box background={theme.colors['primary']} style={{ padding: theme.spacing(2) }}>
+          <Box background={theme.colors['secondary']} style={{ padding: theme.spacing(1) }}>
             <Typography>
               Child automatically receives&nbsp;
               <code style={{ color: 'var(--zero-text-color)' }}>--zero-text-color</code>
@@ -123,7 +123,7 @@ export default function BoxDemoPage() {
 
         {/* 6. Presets ------------------------------------------------------- */}
         <Typography variant="h3">6. Presets</Typography>
-        <Stack spacing="md">
+        <Stack spacing={2}>
           <Box preset="fancyBox">
             <Typography>preset="fancyBox"</Typography>
           </Box>
@@ -149,7 +149,7 @@ export default function BoxDemoPage() {
         <Button variant="outlined" onClick={toggleMode}>Toggle light / dark mode</Button>
 
         {/* Back nav -------------------------------------------------------- */}
-        <Button size="lg" onClick={() => navigate(-1)} style={{ marginTop: theme.spacing['lg'] }}>
+        <Button size="lg" onClick={() => navigate(-1)} style={{ marginTop: theme.spacing(3) }}>
           ← Back
         </Button>
       </Stack>

--- a/docs/src/pages/BoxDemo.tsx
+++ b/docs/src/pages/BoxDemo.tsx
@@ -21,8 +21,8 @@ definePreset('fancyBox', (t) => `
     color        : ${t.colors['primaryText']};
     border-radius: 20px;
     box-shadow   : 0 6px 16px ${t.colors['text']}22;
-    padding      : ${t.spacing(3)};
-    margin       : ${t.spacing(3)};
+    padding      : ${t.spacing(1)};
+    margin       : ${t.spacing(1)};
   `);
 
 // Frosted-glass effect (needs backdrop-filter support)
@@ -30,7 +30,7 @@ definePreset('glassBox', (t) => `
     background      : ${t.colors['background']}CC;
     backdrop-filter : blur(6px) saturate(180%);
     border          : 1px solid ${t.colors['text']}22;
-    padding         : ${t.spacing(3)};
+    padding         : ${t.spacing(1)};
     border-radius   : 12px;
   `);
 
@@ -52,7 +52,7 @@ export default function BoxDemoPage() {
   return (
     <Surface /* Surface already defaults to theme background */>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         {/* Page header ----------------------------------------------------- */}
@@ -71,7 +71,7 @@ export default function BoxDemoPage() {
 
         {/* 2. Background prop with auto-text detection --------------------- */}
         <Typography variant="h3">2. background&nbsp;prop</Typography>
-        <Stack spacing={2}>
+        <Stack spacing={1}>
           <Box background={theme.colors['primary']}>
             <Typography variant="h4">{`background={theme.colors.primary}`}</Typography>
           </Box>
@@ -88,7 +88,7 @@ export default function BoxDemoPage() {
         <Box
           background={"#333333"}
           textColor={theme.colors['tertiary']}
-          style={{ padding: theme.spacing(2) }}
+          style={{ padding: theme.spacing(1) }}
         >
           <Typography>
             Greetings Programs!
@@ -103,7 +103,7 @@ export default function BoxDemoPage() {
           background={theme.colors['tertiary']}
           style={{
             border: `2px dashed ${theme.colors['text']}`,
-            padding: theme.spacing(3),
+            padding: theme.spacing(1),
             borderRadius: 12,
           }}
         >
@@ -112,7 +112,7 @@ export default function BoxDemoPage() {
 
         {/* 5. Nested Boxes & CSS custom props ------------------------------ */}
         <Typography variant="h3">5. Nested Boxes</Typography>
-        <Box background={theme.colors['primary']} style={{ padding: theme.spacing(2) }}>
+        <Box background={theme.colors['primary']} style={{ padding: theme.spacing(1) }}>
           <Box background={theme.colors['secondary']} style={{ padding: theme.spacing(1) }}>
             <Typography>
               Child automatically receives&nbsp;
@@ -123,7 +123,7 @@ export default function BoxDemoPage() {
 
         {/* 6. Presets ------------------------------------------------------- */}
         <Typography variant="h3">6. Presets</Typography>
-        <Stack spacing={2}>
+        <Stack spacing={1}>
           <Box preset="fancyBox">
             <Typography>preset="fancyBox"</Typography>
           </Box>
@@ -149,7 +149,7 @@ export default function BoxDemoPage() {
         <Button variant="outlined" onClick={toggleMode}>Toggle light / dark mode</Button>
 
         {/* Back nav -------------------------------------------------------- */}
-        <Button size="lg" onClick={() => navigate(-1)} style={{ marginTop: theme.spacing(3) }}>
+        <Button size="lg" onClick={() => navigate(-1)} style={{ marginTop: theme.spacing(1) }}>
           ← Back
         </Button>
       </Stack>

--- a/docs/src/pages/ButtonDemoPage.tsx
+++ b/docs/src/pages/ButtonDemoPage.tsx
@@ -19,7 +19,7 @@ export default function ButtonDemoPage() {
 
   return (
     <Surface>
-      <Stack spacing={3} preset="showcaseStack">
+      <Stack spacing={1} preset="showcaseStack">
         {/* Header ------------------------------------------------------- */}
         <Typography variant="h2" bold>
           Button Showcase
@@ -30,14 +30,14 @@ export default function ButtonDemoPage() {
 
         {/* 1 ▸ Variants -------------------------------------------------- */}
         <Typography variant="h3">1. Variants</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <Button>contained (default)</Button>
           <Button variant="outlined">outlined</Button>
         </Stack>
 
         {/* 2 ▸ Sizes ----------------------------------------------------- */}
         <Typography variant="h3">2. Sizes</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <Button size="sm">sm</Button>
           <Button>md (default)</Button>
           <Button size="lg">lg</Button>
@@ -51,7 +51,7 @@ export default function ButtonDemoPage() {
 
         {/* 4 ▸ Palette tokens ------------------------------------------ */}
         <Typography variant="h3">4. Palette tokens</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <Button color="primary">primary</Button>
           <Button color="secondary">secondary</Button>
           <Button color="tertiary">tertiary</Button>
@@ -59,14 +59,14 @@ export default function ButtonDemoPage() {
 
         {/* 5 ▸ Custom colours ------------------------------------------ */}
         <Typography variant="h3">5. Custom backgrounds</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <Button color="#9C27B0">#9C27B0</Button>
           <Button color="#00BFA5">#00BFA5</Button>
         </Stack>
 
         {/* 6 ▸ Outlined overrides -------------------------------------- */}
         <Typography variant="h3">6. Outlined colour override</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <Button variant="outlined">default outline</Button>
           <Button variant="outlined" color="secondary">secondary outline</Button>
           <Button variant="outlined" color="tertiary">tertiary outline</Button>
@@ -77,7 +77,7 @@ export default function ButtonDemoPage() {
 
         {/* 7 ▸ Disabled ------------------------------------------------- */}
         <Typography variant="h3">7. Disabled</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <Button disabled>contained</Button>
           <Button variant="outlined" disabled>outlined</Button>
           <Button color="secondary" disabled>palette</Button>
@@ -85,7 +85,7 @@ export default function ButtonDemoPage() {
 
         {/* 8 ▸ Custom label variants ----------------------------------- */}
         <Typography variant="h3">8. Custom label variants</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <Button><Typography variant="h4">h4 in button</Typography></Button>
           <Button><Typography variant="subtitle">subtitle text</Typography></Button>
           <Button variant="outlined">
@@ -99,7 +99,7 @@ export default function ButtonDemoPage() {
           Toggle light / dark mode
         </Button>
 
-        <Button size="lg" onClick={() => navigate(-1)} style={{ marginTop: theme.spacing(3) }}>
+        <Button size="lg" onClick={() => navigate(-1)} style={{ marginTop: theme.spacing(1) }}>
           ← Back
         </Button>
       </Stack>

--- a/docs/src/pages/ButtonDemoPage.tsx
+++ b/docs/src/pages/ButtonDemoPage.tsx
@@ -19,7 +19,7 @@ export default function ButtonDemoPage() {
 
   return (
     <Surface>
-      <Stack spacing="lg" preset="showcaseStack">
+      <Stack spacing={3} preset="showcaseStack">
         {/* Header ------------------------------------------------------- */}
         <Typography variant="h2" bold>
           Button Showcase
@@ -30,14 +30,14 @@ export default function ButtonDemoPage() {
 
         {/* 1 ▸ Variants -------------------------------------------------- */}
         <Typography variant="h3">1. Variants</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <Button>contained (default)</Button>
           <Button variant="outlined">outlined</Button>
         </Stack>
 
         {/* 2 ▸ Sizes ----------------------------------------------------- */}
         <Typography variant="h3">2. Sizes</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <Button size="sm">sm</Button>
           <Button>md (default)</Button>
           <Button size="lg">lg</Button>
@@ -51,7 +51,7 @@ export default function ButtonDemoPage() {
 
         {/* 4 ▸ Palette tokens ------------------------------------------ */}
         <Typography variant="h3">4. Palette tokens</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <Button color="primary">primary</Button>
           <Button color="secondary">secondary</Button>
           <Button color="tertiary">tertiary</Button>
@@ -59,14 +59,14 @@ export default function ButtonDemoPage() {
 
         {/* 5 ▸ Custom colours ------------------------------------------ */}
         <Typography variant="h3">5. Custom backgrounds</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <Button color="#9C27B0">#9C27B0</Button>
           <Button color="#00BFA5">#00BFA5</Button>
         </Stack>
 
         {/* 6 ▸ Outlined overrides -------------------------------------- */}
         <Typography variant="h3">6. Outlined colour override</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <Button variant="outlined">default outline</Button>
           <Button variant="outlined" color="secondary">secondary outline</Button>
           <Button variant="outlined" color="tertiary">tertiary outline</Button>
@@ -77,7 +77,7 @@ export default function ButtonDemoPage() {
 
         {/* 7 ▸ Disabled ------------------------------------------------- */}
         <Typography variant="h3">7. Disabled</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <Button disabled>contained</Button>
           <Button variant="outlined" disabled>outlined</Button>
           <Button color="secondary" disabled>palette</Button>
@@ -85,7 +85,7 @@ export default function ButtonDemoPage() {
 
         {/* 8 ▸ Custom label variants ----------------------------------- */}
         <Typography variant="h3">8. Custom label variants</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <Button><Typography variant="h4">h4 in button</Typography></Button>
           <Button><Typography variant="subtitle">subtitle text</Typography></Button>
           <Button variant="outlined">
@@ -99,7 +99,7 @@ export default function ButtonDemoPage() {
           Toggle light / dark mode
         </Button>
 
-        <Button size="lg" onClick={() => navigate(-1)} style={{ marginTop: theme.spacing['lg'] }}>
+        <Button size="lg" onClick={() => navigate(-1)} style={{ marginTop: theme.spacing(3) }}>
           ← Back
         </Button>
       </Stack>

--- a/docs/src/pages/CheckBoxDemo.tsx
+++ b/docs/src/pages/CheckBoxDemo.tsx
@@ -41,7 +41,7 @@ export default function CheckboxDemoPage() {
   return (
     <Surface /* Surface already defaults to theme background */>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         {/* Page header ----------------------------------------------------- */}
@@ -54,7 +54,7 @@ export default function CheckboxDemoPage() {
 
         {/* 1. Uncontrolled -------------------------------------------------- */}
         <Typography variant="h3">1. Uncontrolled</Typography>
-        <Stack spacing={2}>
+        <Stack spacing={1}>
           <Checkbox name="uc1" label="Default unchecked" />
           <Checkbox
             name="uc2"
@@ -74,7 +74,7 @@ export default function CheckboxDemoPage() {
 
         {/* 3. Sizes --------------------------------------------------------- */}
         <Typography variant="h3">3. Sizes</Typography>
-        <Stack spacing={2}>
+        <Stack spacing={1}>
           <Checkbox name="sm" size="sm" defaultChecked label="size='sm'" />
           <Checkbox name="md" size="md" defaultChecked label="size='md'" />
           <Checkbox name="lg" size="lg" defaultChecked label="size='lg'" />
@@ -82,7 +82,7 @@ export default function CheckboxDemoPage() {
 
         {/* 4. Disabled ------------------------------------------------------ */}
         <Typography variant="h3">4. Disabled</Typography>
-        <Stack spacing={2}>
+        <Stack spacing={1}>
           <Checkbox
             name="d1"
             defaultChecked
@@ -97,7 +97,7 @@ export default function CheckboxDemoPage() {
         <FormControl
           useStore={useSignupForm}
           onSubmitValues={handleSubmit}
-          style={{ display: 'flex', flexDirection: 'column', gap: theme.spacing(2) }}
+          style={{ display: 'flex', flexDirection: 'column', gap: theme.spacing(1) }}
         >
           <Checkbox
             name="terms"
@@ -123,7 +123,7 @@ export default function CheckboxDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing(3) }}
+          style={{ marginTop: theme.spacing(1) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/CheckBoxDemo.tsx
+++ b/docs/src/pages/CheckBoxDemo.tsx
@@ -41,7 +41,7 @@ export default function CheckboxDemoPage() {
   return (
     <Surface /* Surface already defaults to theme background */>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         {/* Page header ----------------------------------------------------- */}
@@ -54,7 +54,7 @@ export default function CheckboxDemoPage() {
 
         {/* 1. Uncontrolled -------------------------------------------------- */}
         <Typography variant="h3">1. Uncontrolled</Typography>
-        <Stack spacing="md">
+        <Stack spacing={2}>
           <Checkbox name="uc1" label="Default unchecked" />
           <Checkbox
             name="uc2"
@@ -74,7 +74,7 @@ export default function CheckboxDemoPage() {
 
         {/* 3. Sizes --------------------------------------------------------- */}
         <Typography variant="h3">3. Sizes</Typography>
-        <Stack spacing="md">
+        <Stack spacing={2}>
           <Checkbox name="sm" size="sm" defaultChecked label="size='sm'" />
           <Checkbox name="md" size="md" defaultChecked label="size='md'" />
           <Checkbox name="lg" size="lg" defaultChecked label="size='lg'" />
@@ -82,7 +82,7 @@ export default function CheckboxDemoPage() {
 
         {/* 4. Disabled ------------------------------------------------------ */}
         <Typography variant="h3">4. Disabled</Typography>
-        <Stack spacing="md">
+        <Stack spacing={2}>
           <Checkbox
             name="d1"
             defaultChecked
@@ -97,7 +97,7 @@ export default function CheckboxDemoPage() {
         <FormControl
           useStore={useSignupForm}
           onSubmitValues={handleSubmit}
-          style={{ display: 'flex', flexDirection: 'column', gap: theme.spacing['md'] }}
+          style={{ display: 'flex', flexDirection: 'column', gap: theme.spacing(2) }}
         >
           <Checkbox
             name="terms"
@@ -123,7 +123,7 @@ export default function CheckboxDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing['lg'] }}
+          style={{ marginTop: theme.spacing(3) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/DrawerDemo.tsx
+++ b/docs/src/pages/DrawerDemo.tsx
@@ -21,8 +21,8 @@ export default function DrawerDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
-        style={{ padding: theme.spacing(3), maxWidth: 980, margin: '0 auto' }}
+        spacing={1}
+        style={{ padding: theme.spacing(1), maxWidth: 980, margin: '0 auto' }}
       >
         <Typography variant="h2" bold>
           Drawer Showcase
@@ -35,7 +35,7 @@ export default function DrawerDemoPage() {
         <Typography variant="h3">1. Left drawer</Typography>
         <Button onClick={() => setLeftOpen(true)}>Open left drawer</Button>
         <Drawer open={leftOpen} onClose={() => setLeftOpen(false)}>
-          <Stack spacing={2} style={{ padding: theme.spacing(2) }}>
+          <Stack spacing={1} style={{ padding: theme.spacing(1) }}>
             <Typography variant="h4" bold>
               Left Drawer
             </Typography>
@@ -45,12 +45,12 @@ export default function DrawerDemoPage() {
 
         {/* 2. Controlled right drawer */}
         <Typography variant="h3">2. Controlled right drawer</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <Button onClick={() => setRightOpen(true)}>Open</Button>
           <Button onClick={() => setRightOpen(false)}>Close</Button>
         </Stack>
         <Drawer anchor="right" open={rightOpen} onClose={() => setRightOpen(false)}>
-          <Stack spacing={2} style={{ padding: theme.spacing(2) }}>
+          <Stack spacing={1} style={{ padding: theme.spacing(1) }}>
             <Typography variant="h4" bold>
               Controlled Drawer
             </Typography>
@@ -68,7 +68,7 @@ export default function DrawerDemoPage() {
           disableBackdropClick
           disableEscapeKeyDown
         >
-          <Stack spacing={2} style={{ padding: theme.spacing(2) }}>
+          <Stack spacing={1} style={{ padding: theme.spacing(1) }}>
             <Typography variant="h4" bold>
               Can't close via backdrop or ESC
             </Typography>
@@ -77,7 +77,7 @@ export default function DrawerDemoPage() {
         </Drawer>
 
         {/* Theme toggle + back nav */}
-        <Stack direction="row" spacing={3}>
+        <Stack direction="row" spacing={1}>
           <Button variant="outlined" onClick={toggleMode}>
             Toggle light / dark
           </Button>

--- a/docs/src/pages/DrawerDemo.tsx
+++ b/docs/src/pages/DrawerDemo.tsx
@@ -21,8 +21,8 @@ export default function DrawerDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
-        style={{ padding: theme.spacing['lg'], maxWidth: 980, margin: '0 auto' }}
+        spacing={3}
+        style={{ padding: theme.spacing(3), maxWidth: 980, margin: '0 auto' }}
       >
         <Typography variant="h2" bold>
           Drawer Showcase
@@ -35,7 +35,7 @@ export default function DrawerDemoPage() {
         <Typography variant="h3">1. Left drawer</Typography>
         <Button onClick={() => setLeftOpen(true)}>Open left drawer</Button>
         <Drawer open={leftOpen} onClose={() => setLeftOpen(false)}>
-          <Stack spacing="md" style={{ padding: theme.spacing['md'] }}>
+          <Stack spacing={2} style={{ padding: theme.spacing(2) }}>
             <Typography variant="h4" bold>
               Left Drawer
             </Typography>
@@ -45,12 +45,12 @@ export default function DrawerDemoPage() {
 
         {/* 2. Controlled right drawer */}
         <Typography variant="h3">2. Controlled right drawer</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <Button onClick={() => setRightOpen(true)}>Open</Button>
           <Button onClick={() => setRightOpen(false)}>Close</Button>
         </Stack>
         <Drawer anchor="right" open={rightOpen} onClose={() => setRightOpen(false)}>
-          <Stack spacing="md" style={{ padding: theme.spacing['md'] }}>
+          <Stack spacing={2} style={{ padding: theme.spacing(2) }}>
             <Typography variant="h4" bold>
               Controlled Drawer
             </Typography>
@@ -68,7 +68,7 @@ export default function DrawerDemoPage() {
           disableBackdropClick
           disableEscapeKeyDown
         >
-          <Stack spacing="md" style={{ padding: theme.spacing['md'] }}>
+          <Stack spacing={2} style={{ padding: theme.spacing(2) }}>
             <Typography variant="h4" bold>
               Can't close via backdrop or ESC
             </Typography>
@@ -77,7 +77,7 @@ export default function DrawerDemoPage() {
         </Drawer>
 
         {/* Theme toggle + back nav */}
-        <Stack direction="row" spacing="lg">
+        <Stack direction="row" spacing={3}>
           <Button variant="outlined" onClick={toggleMode}>
             Toggle light / dark
           </Button>

--- a/docs/src/pages/FormDemoPage.tsx
+++ b/docs/src/pages/FormDemoPage.tsx
@@ -32,7 +32,7 @@ const useContactForm = createFormStore<ContactValues>({
 definePreset('cardForm', (t) => `
   background:${t.colors['primary']};
   border-radius:16px;
-  padding:${t.spacing(3)};
+  padding:${t.spacing(1)};
 `);
 
 definePreset('underlineField', (t) => `
@@ -53,7 +53,7 @@ export default function FormDemoPage() {
   return (
     <Surface style={{ backgroundColor: theme.colors['background'] }}>
       <Box preset="cardForm">
-        <Typography variant="h3" style={{ marginBottom: theme.spacing(3) }}>
+        <Typography variant="h3" style={{ marginBottom: theme.spacing(1) }}>
           Contact Form Demo
         </Typography>
 
@@ -65,7 +65,7 @@ export default function FormDemoPage() {
             setSubmitted(values);
           }}
         >
-          <Stack spacing={2}>
+          <Stack spacing={1}>
             <TextField
               name="name"
               label="Name"
@@ -99,7 +99,7 @@ export default function FormDemoPage() {
 
       {/* Echo submitted payload */}
       {submitted && (
-        <Box style={{ padding: theme.spacing(3) }}>
+        <Box style={{ padding: theme.spacing(1) }}>
           <Typography variant="h4">Server Echo</Typography>
           <pre style={{ color: theme.colors['text'] }}>
             {JSON.stringify(submitted, null, 2)}
@@ -108,7 +108,7 @@ export default function FormDemoPage() {
       )}
 
       {/* Nav back */}
-      <Stack direction="row" spacing={2} style={{ padding: theme.spacing(2) }}>
+      <Stack direction="row" spacing={1} style={{ padding: theme.spacing(1) }}>
         <Button variant="contained" size="lg" onClick={() => navigate(-1)}>
           Go Back
         </Button>

--- a/docs/src/pages/FormDemoPage.tsx
+++ b/docs/src/pages/FormDemoPage.tsx
@@ -32,7 +32,7 @@ const useContactForm = createFormStore<ContactValues>({
 definePreset('cardForm', (t) => `
   background:${t.colors['primary']};
   border-radius:16px;
-  padding:${t.spacing['lg']};
+  padding:${t.spacing(3)};
 `);
 
 definePreset('underlineField', (t) => `
@@ -53,7 +53,7 @@ export default function FormDemoPage() {
   return (
     <Surface style={{ backgroundColor: theme.colors['background'] }}>
       <Box preset="cardForm">
-        <Typography variant="h3" style={{ marginBottom: theme.spacing['lg'] }}>
+        <Typography variant="h3" style={{ marginBottom: theme.spacing(3) }}>
           Contact Form Demo
         </Typography>
 
@@ -65,7 +65,7 @@ export default function FormDemoPage() {
             setSubmitted(values);
           }}
         >
-          <Stack spacing="md">
+          <Stack spacing={2}>
             <TextField
               name="name"
               label="Name"
@@ -99,7 +99,7 @@ export default function FormDemoPage() {
 
       {/* Echo submitted payload */}
       {submitted && (
-        <Box style={{ padding: theme.spacing['lg'] }}>
+        <Box style={{ padding: theme.spacing(3) }}>
           <Typography variant="h4">Server Echo</Typography>
           <pre style={{ color: theme.colors['text'] }}>
             {JSON.stringify(submitted, null, 2)}
@@ -108,7 +108,7 @@ export default function FormDemoPage() {
       )}
 
       {/* Nav back */}
-      <Stack direction="row" spacing="md" style={{ padding: theme.spacing['md'] }}>
+      <Stack direction="row" spacing={2} style={{ padding: theme.spacing(2) }}>
         <Button variant="contained" size="lg" onClick={() => navigate(-1)}>
           Go Back
         </Button>

--- a/docs/src/pages/GridDemo.tsx
+++ b/docs/src/pages/GridDemo.tsx
@@ -9,33 +9,33 @@ export default function GridDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         <Typography variant="h2" bold>Grid Showcase</Typography>
         <Typography variant="subtitle">Responsive column layout</Typography>
 
         <Typography variant="h3">1. Two columns</Typography>
-        <Grid columns={2} gap="md">
-          <Box style={{ background: theme.colors['primary'] as string, color: theme.colors['primaryText'] as string, padding: theme.spacing['md'] }}>A</Box>
-          <Box style={{ background: theme.colors['secondary'] as string, color: theme.colors['secondaryText'] as string, padding: theme.spacing['md'] }}>B</Box>
+        <Grid columns={2} gap={2}>
+          <Box style={{ background: theme.colors['primary'] as string, color: theme.colors['primaryText'] as string, padding: theme.spacing(2) }}>A</Box>
+          <Box style={{ background: theme.colors['secondary'] as string, color: theme.colors['secondaryText'] as string, padding: theme.spacing(2) }}>B</Box>
         </Grid>
 
         <Typography variant="h3">2. Four columns</Typography>
-        <Grid columns={4} gap="sm">
+        <Grid columns={4} gap={1}>
           {['1', '2', '3', '4', '5', '6', '7', '8'].map(n => (
-            <Box key={n} style={{ background: theme.colors['primary'] as string, color: theme.colors['primaryText'] as string, padding: theme.spacing['sm'], textAlign: 'center' }}>{n}</Box>
+            <Box key={n} style={{ background: theme.colors['primary'] as string, color: theme.colors['primaryText'] as string, padding: theme.spacing(1), textAlign: 'center' }}>{n}</Box>
           ))}
         </Grid>
 
         <Typography variant="h3">2. Eight columns</Typography>
-        <Grid columns={8} gap="sm">
+        <Grid columns={8} gap={1}>
           {['1', '2', '3', '4', '5', '6', '7', '8'].map(n => (
-            <Box key={n} style={{ background: theme.colors['primary'] as string, color: theme.colors['primaryText'] as string, padding: theme.spacing['sm'], textAlign: 'center' }}>{n}</Box>
+            <Box key={n} style={{ background: theme.colors['primary'] as string, color: theme.colors['primaryText'] as string, padding: theme.spacing(1), textAlign: 'center' }}>{n}</Box>
           ))}
         </Grid>
 
-        <Stack direction="row" spacing="lg">
+        <Stack direction="row" spacing={3}>
           <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
           <Button onClick={() => navigate(-1)}>← Back</Button>
         </Stack>

--- a/docs/src/pages/GridDemo.tsx
+++ b/docs/src/pages/GridDemo.tsx
@@ -9,7 +9,7 @@ export default function GridDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         <Typography variant="h2" bold>Grid Showcase</Typography>
@@ -17,8 +17,8 @@ export default function GridDemoPage() {
 
         <Typography variant="h3">1. Two columns</Typography>
         <Grid columns={2} gap={2}>
-          <Box style={{ background: theme.colors['primary'] as string, color: theme.colors['primaryText'] as string, padding: theme.spacing(2) }}>A</Box>
-          <Box style={{ background: theme.colors['secondary'] as string, color: theme.colors['secondaryText'] as string, padding: theme.spacing(2) }}>B</Box>
+          <Box style={{ background: theme.colors['primary'] as string, color: theme.colors['primaryText'] as string, padding: theme.spacing(1) }}>A</Box>
+          <Box style={{ background: theme.colors['secondary'] as string, color: theme.colors['secondaryText'] as string, padding: theme.spacing(1) }}>B</Box>
         </Grid>
 
         <Typography variant="h3">2. Four columns</Typography>
@@ -35,7 +35,7 @@ export default function GridDemoPage() {
           ))}
         </Grid>
 
-        <Stack direction="row" spacing={3}>
+        <Stack direction="row" spacing={1}>
           <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
           <Button onClick={() => navigate(-1)}>← Back</Button>
         </Stack>

--- a/docs/src/pages/IconButtonDemoPage.tsx
+++ b/docs/src/pages/IconButtonDemoPage.tsx
@@ -19,12 +19,12 @@ import { useNavigate } from 'react-router-dom';
 /* Style preset showcasing IconButton inside a card                            */
 definePreset('actionCard', t => `
     background   : ${t.colors['backgroundAlt']};
-    padding      : ${t.spacing['lg']};
+    padding      : ${t.spacing(3)};
     border-radius: 16px;
     box-shadow   : 0 4px 12px ${t.colors['text']}22;
     display      : flex;
     align-items  : center;
-    gap          : ${t.spacing['md']};
+    gap          : ${t.spacing(2)};
   `);
 
 /*─────────────────────────────────────────────────────────────────────────────*/
@@ -46,7 +46,7 @@ export default function IconButtonDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         {/* Page header ----------------------------------------------------- */}
@@ -59,7 +59,7 @@ export default function IconButtonDemoPage() {
 
         {/* 1. Contained sizes --------------------------------------------- */}
         <Typography variant="h3">1. Contained sizes</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <IconButton icon="mdi:play" size="sm" aria-label="Play small" />
           <IconButton icon="mdi:play" size="md" aria-label="Play medium" />
           <IconButton icon="mdi:play" size="lg" aria-label="Play large" />
@@ -67,7 +67,7 @@ export default function IconButtonDemoPage() {
 
         {/* 2. Outlined sizes ---------------------------------------------- */}
         <Typography variant="h3">2. Outlined sizes</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <IconButton
             variant="outlined"
             icon="mdi:pause"
@@ -90,7 +90,7 @@ export default function IconButtonDemoPage() {
 
         {/* 3. Colour override --------------------------------------------- */}
         <Typography variant="h3">3. Icon colour override</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <IconButton
             icon="mdi:heart"
             iconColor="#ff5e5e"
@@ -106,7 +106,7 @@ export default function IconButtonDemoPage() {
 
         {/* 4. Custom SVG --------------------------------------------------- */}
         <Typography variant="h3">4. Custom SVG graphics</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <IconButton svg={HeartSvg} aria-label="Heart" />
         </Stack>
 
@@ -141,7 +141,7 @@ export default function IconButtonDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing['lg'] }}
+          style={{ marginTop: theme.spacing(3) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/IconButtonDemoPage.tsx
+++ b/docs/src/pages/IconButtonDemoPage.tsx
@@ -19,12 +19,12 @@ import { useNavigate } from 'react-router-dom';
 /* Style preset showcasing IconButton inside a card                            */
 definePreset('actionCard', t => `
     background   : ${t.colors['backgroundAlt']};
-    padding      : ${t.spacing(3)};
+    padding      : ${t.spacing(1)};
     border-radius: 16px;
     box-shadow   : 0 4px 12px ${t.colors['text']}22;
     display      : flex;
     align-items  : center;
-    gap          : ${t.spacing(2)};
+    gap          : ${t.spacing(1)};
   `);
 
 /*─────────────────────────────────────────────────────────────────────────────*/
@@ -46,7 +46,7 @@ export default function IconButtonDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         {/* Page header ----------------------------------------------------- */}
@@ -59,7 +59,7 @@ export default function IconButtonDemoPage() {
 
         {/* 1. Contained sizes --------------------------------------------- */}
         <Typography variant="h3">1. Contained sizes</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <IconButton icon="mdi:play" size="sm" aria-label="Play small" />
           <IconButton icon="mdi:play" size="md" aria-label="Play medium" />
           <IconButton icon="mdi:play" size="lg" aria-label="Play large" />
@@ -67,7 +67,7 @@ export default function IconButtonDemoPage() {
 
         {/* 2. Outlined sizes ---------------------------------------------- */}
         <Typography variant="h3">2. Outlined sizes</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <IconButton
             variant="outlined"
             icon="mdi:pause"
@@ -90,7 +90,7 @@ export default function IconButtonDemoPage() {
 
         {/* 3. Colour override --------------------------------------------- */}
         <Typography variant="h3">3. Icon colour override</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <IconButton
             icon="mdi:heart"
             iconColor="#ff5e5e"
@@ -106,7 +106,7 @@ export default function IconButtonDemoPage() {
 
         {/* 4. Custom SVG --------------------------------------------------- */}
         <Typography variant="h3">4. Custom SVG graphics</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <IconButton svg={HeartSvg} aria-label="Heart" />
         </Stack>
 
@@ -141,7 +141,7 @@ export default function IconButtonDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing(3) }}
+          style={{ marginTop: theme.spacing(1) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/IconDemoPage.tsx
+++ b/docs/src/pages/IconDemoPage.tsx
@@ -19,12 +19,12 @@ import { useNavigate } from 'react-router-dom';
 definePreset('iconCard', t => `
     background   : ${t.colors['secondary']};
     color        : ${t.colors['secondaryText']};
-    padding      : ${t.spacing(3)};
+    padding      : ${t.spacing(1)};
     border-radius: 16px;
     box-shadow   : 0 4px 12px ${t.colors['text']}22;
     display      : inline-flex;
     align-items  : center;
-    gap          : ${t.spacing(2)};
+    gap          : ${t.spacing(1)};
   `);
 
 /*─────────────────────────────────────────────────────────────────────────────*/
@@ -47,7 +47,7 @@ export default function IconDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         {/* Page header ----------------------------------------------------- */}
@@ -68,7 +68,7 @@ export default function IconDemoPage() {
 
         {/* 2. Sizing -------------------------------------------------------- */}
         <Typography variant="h3">2. Size prop</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <Icon icon="mdi:home" size={16} aria-label="home-sm" />
           <Icon icon="mdi:home" size="24px" aria-label="home-md" />
           <Icon icon="mdi:home" size="2.5rem" aria-label="home-lg" />
@@ -77,7 +77,7 @@ export default function IconDemoPage() {
 
         {/* 3. Color override ---------------------------------------------- */}
         <Typography variant="h3">3. Colour override</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <Icon icon="carbon:warning-filled" color={theme.colors['primary']} size={32} />
           <Icon icon="carbon:warning-filled" color="#ff6b6b" size={32} />
           <Icon icon="carbon:warning-filled" color="gold" size={32} />
@@ -98,7 +98,7 @@ export default function IconDemoPage() {
 
         {/* 7. Icon inside Button ------------------------------------------- */}
         <Typography variant="h3">6. Icon in other components</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <Button>
             <Icon icon="mdi:thumb-up" size={18} style={{ marginRight: 8 }} />
             Like
@@ -119,7 +119,7 @@ export default function IconDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing(3) }}
+          style={{ marginTop: theme.spacing(1) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/IconDemoPage.tsx
+++ b/docs/src/pages/IconDemoPage.tsx
@@ -19,12 +19,12 @@ import { useNavigate } from 'react-router-dom';
 definePreset('iconCard', t => `
     background   : ${t.colors['secondary']};
     color        : ${t.colors['secondaryText']};
-    padding      : ${t.spacing['lg']};
+    padding      : ${t.spacing(3)};
     border-radius: 16px;
     box-shadow   : 0 4px 12px ${t.colors['text']}22;
     display      : inline-flex;
     align-items  : center;
-    gap          : ${t.spacing['md']};
+    gap          : ${t.spacing(2)};
   `);
 
 /*─────────────────────────────────────────────────────────────────────────────*/
@@ -47,7 +47,7 @@ export default function IconDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         {/* Page header ----------------------------------------------------- */}
@@ -68,7 +68,7 @@ export default function IconDemoPage() {
 
         {/* 2. Sizing -------------------------------------------------------- */}
         <Typography variant="h3">2. Size prop</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <Icon icon="mdi:home" size={16} aria-label="home-sm" />
           <Icon icon="mdi:home" size="24px" aria-label="home-md" />
           <Icon icon="mdi:home" size="2.5rem" aria-label="home-lg" />
@@ -77,7 +77,7 @@ export default function IconDemoPage() {
 
         {/* 3. Color override ---------------------------------------------- */}
         <Typography variant="h3">3. Colour override</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <Icon icon="carbon:warning-filled" color={theme.colors['primary']} size={32} />
           <Icon icon="carbon:warning-filled" color="#ff6b6b" size={32} />
           <Icon icon="carbon:warning-filled" color="gold" size={32} />
@@ -98,7 +98,7 @@ export default function IconDemoPage() {
 
         {/* 7. Icon inside Button ------------------------------------------- */}
         <Typography variant="h3">6. Icon in other components</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <Button>
             <Icon icon="mdi:thumb-up" size={18} style={{ marginRight: 8 }} />
             Like
@@ -119,7 +119,7 @@ export default function IconDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing['lg'] }}
+          style={{ marginTop: theme.spacing(3) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/ListDemoPage.tsx
+++ b/docs/src/pages/ListDemoPage.tsx
@@ -49,7 +49,7 @@ export default function ListDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         {/* Header --------------------------------------------------------- */}
@@ -68,8 +68,8 @@ export default function ListDemoPage() {
 
         {/* 2. striped & hoverable props ---------------------------------- */}
         <Typography variant="h3">2. <code>striped</code> & <code>hoverable</code></Typography>
-        <Panel variant="alt" style={{ padding: theme.spacing['md'] }}>
-          <Stack direction="row" spacing="md" wrap={false}>
+        <Panel variant="alt" style={{ padding: theme.spacing(2) }}>
+          <Stack direction="row" spacing={2} wrap={false}>
             <Checkbox
               label="striped"
               checked={striped}
@@ -128,7 +128,7 @@ export default function ListDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing['lg'] }}
+          style={{ marginTop: theme.spacing(3) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/ListDemoPage.tsx
+++ b/docs/src/pages/ListDemoPage.tsx
@@ -49,7 +49,7 @@ export default function ListDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         {/* Header --------------------------------------------------------- */}
@@ -68,8 +68,8 @@ export default function ListDemoPage() {
 
         {/* 2. striped & hoverable props ---------------------------------- */}
         <Typography variant="h3">2. <code>striped</code> & <code>hoverable</code></Typography>
-        <Panel variant="alt" style={{ padding: theme.spacing(2) }}>
-          <Stack direction="row" spacing={2} wrap={false}>
+        <Panel variant="alt" style={{ padding: theme.spacing(1) }}>
+          <Stack direction="row" spacing={1} wrap={false}>
             <Checkbox
               label="striped"
               checked={striped}
@@ -128,7 +128,7 @@ export default function ListDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing(3) }}
+          style={{ marginTop: theme.spacing(1) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/MainPage.tsx
+++ b/docs/src/pages/MainPage.tsx
@@ -8,202 +8,202 @@ export default function MainPage() {
 
   return (
     <Surface>
-      <Box style={{ margin: theme.spacing(2) }} centered>
+      <Box style={{ margin: theme.spacing(1) }} centered>
         <Typography variant="h1"><b>zeroui</b> Demo</Typography>
       </Box>
 
-      <Box style={{ margin: theme.spacing(2) }} centered>
+      <Box style={{ margin: theme.spacing(1) }} centered> 
         <Stack>
-          <Panel style={{ margin: theme.spacing(2), padding: theme.spacing(2) }} variant="alt">
+          <Panel style={{ margin: theme.spacing(1), padding: theme.spacing(1) }} variant="alt">
             <Box centered>
               <Typography variant="h2">Components</Typography>
             </Box>
 
-            <Stack direction="row" spacing={3} style={{ marginTop: theme.spacing(3) }}>
+            <Stack direction="row" spacing={1} style={{ marginTop: theme.spacing(1) }}>
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/accordion-demo')}
               >
                 Accordion
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/box-demo')}
               >
                 Box
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/button-demo')}
               >
                 Button
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/checkbox-demo')}
               >
                 Checkbox
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/drawer-demo')}
               >
                 Drawer
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/text-form-demo')}
               >
                 FormControl + Textfield
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/grid-demo')}
               >
                 Grid
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/icon-demo')}
               >
                 Icon
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/icon-button-demo')}
               >
                 Icon Button
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/list-demo')}
               >
                 List
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/modal-demo')}
               >
                 Modal
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/pagination-demo')}
               >
                 Pagination
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/panel-demo')}
               >
                 Panel
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/progress-demo')}
               >
                 Progress
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/radio-demo')}
               >
                 Radio Group
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/slider-demo')}
               >
                 Slider
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/select-demo')}
               >
                 Select
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/snackbar-demo')}
               >
                 Snackbar
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/switch-demo')}
               >
                 Switch
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/table-demo')}
               >
                 Table
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/tabs-demo')}
               >
                 Tabs
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/tooltip-demo')}
               >
                 Tooltip
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/typography')}
               >
                 Typography
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/video-demo')}
               >
                 Video
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/appbar-demo')}
               >
                 AppBar
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/speeddial-demo')}
               >
                 Speed Dial
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/stepper-demo')}
               >
                 Stepper
@@ -211,33 +211,33 @@ export default function MainPage() {
             </Stack>
           </Panel>
 
-          <Panel style={{ margin: theme.spacing(2), padding: theme.spacing(2) }}>
+          <Panel style={{ margin: theme.spacing(1), padding: theme.spacing(1) }}>
             <Typography variant="h2">Demos</Typography>
 
-            <Stack direction="row" spacing={3} style={{ marginTop: theme.spacing(3) }}>
+            <Stack direction="row" spacing={1} style={{ marginTop: theme.spacing(1) }}>
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/presets')}
               >
                 Presets
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/form')}
               >
                 Form
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/parallax')}
               >
                 Parallax
               </Button>
 
               <Button
-                size="lg"
+                size="md"
                 onClick={() => navigate('/test')}
               >
                 Radio Button
@@ -246,13 +246,13 @@ export default function MainPage() {
           </Panel>
 
           <Box
-            style={{ margin: theme.spacing(2) }}
+            style={{ margin: theme.spacing(1) }}
           >
             <Button
-              size="lg"
+              size="md"
               variant='outlined'
               onClick={toggleMode}
-              style={{ margin: theme.spacing(2) }}
+              style={{ margin: theme.spacing(1) }}
             >
               Switch to {mode === 'light' ? 'dark' : 'light'} mode
             </Button>

--- a/docs/src/pages/MainPage.tsx
+++ b/docs/src/pages/MainPage.tsx
@@ -8,18 +8,18 @@ export default function MainPage() {
 
   return (
     <Surface>
-      <Box style={{ margin: theme.spacing['md'] }} centered>
+      <Box style={{ margin: theme.spacing(2) }} centered>
         <Typography variant="h1"><b>zeroui</b> Demo</Typography>
       </Box>
 
-      <Box style={{ margin: theme.spacing['md'] }} centered>
+      <Box style={{ margin: theme.spacing(2) }} centered>
         <Stack>
-          <Panel style={{ margin: theme.spacing['md'], padding: theme.spacing['md'] }} variant="alt">
+          <Panel style={{ margin: theme.spacing(2), padding: theme.spacing(2) }} variant="alt">
             <Box centered>
               <Typography variant="h2">Components</Typography>
             </Box>
 
-            <Stack direction="row" spacing="lg" style={{ marginTop: theme.spacing['lg'] }}>
+            <Stack direction="row" spacing={3} style={{ marginTop: theme.spacing(3) }}>
               <Button
                 size="lg"
                 onClick={() => navigate('/accordion-demo')}
@@ -211,10 +211,10 @@ export default function MainPage() {
             </Stack>
           </Panel>
 
-          <Panel style={{ margin: theme.spacing['md'], padding: theme.spacing['md'] }}>
+          <Panel style={{ margin: theme.spacing(2), padding: theme.spacing(2) }}>
             <Typography variant="h2">Demos</Typography>
 
-            <Stack direction="row" spacing="lg" style={{ marginTop: theme.spacing['lg'] }}>
+            <Stack direction="row" spacing={3} style={{ marginTop: theme.spacing(3) }}>
               <Button
                 size="lg"
                 onClick={() => navigate('/presets')}
@@ -246,13 +246,13 @@ export default function MainPage() {
           </Panel>
 
           <Box
-            style={{ margin: theme.spacing['md'] }}
+            style={{ margin: theme.spacing(2) }}
           >
             <Button
               size="lg"
               variant='outlined'
               onClick={toggleMode}
-              style={{ margin: theme.spacing['md'] }}
+              style={{ margin: theme.spacing(2) }}
             >
               Switch to {mode === 'light' ? 'dark' : 'light'} mode
             </Button>

--- a/docs/src/pages/ModalDemo.tsx
+++ b/docs/src/pages/ModalDemo.tsx
@@ -40,7 +40,7 @@ export default function ModalDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         <Typography variant="h2" bold>
@@ -102,7 +102,7 @@ export default function ModalDemoPage() {
 
         {/* 3. Controlled modal -------------------------------------------- */}
         <Typography variant="h3">3. Controlled modal</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <Button onClick={() => setControlledOpen(true)}>Open</Button>
           <Button onClick={() => setControlledOpen(false)}>Close</Button>
         </Stack>
@@ -135,7 +135,7 @@ export default function ModalDemoPage() {
 
         {/* 5. Size props --------------------------------------------------- */}
         <Typography variant="h3">5. maxWidth & fullWidth</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <Button onClick={() => setDialogOpen(true)}>maxWidth (default)</Button>
           <Button onClick={() => setControlledOpen(true)}>fullWidth</Button>
         </Stack>
@@ -148,7 +148,7 @@ export default function ModalDemoPage() {
         </Button>
 
         {/* Back nav -------------------------------------------------------- */}
-        <Button size="lg" onClick={() => navigate(-1)} style={{ marginTop: theme.spacing(3) }}>
+        <Button size="lg" onClick={() => navigate(-1)} style={{ marginTop: theme.spacing(1) }}>
           ← Back
         </Button>
       </Stack>

--- a/docs/src/pages/ModalDemo.tsx
+++ b/docs/src/pages/ModalDemo.tsx
@@ -40,7 +40,7 @@ export default function ModalDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         <Typography variant="h2" bold>
@@ -102,7 +102,7 @@ export default function ModalDemoPage() {
 
         {/* 3. Controlled modal -------------------------------------------- */}
         <Typography variant="h3">3. Controlled modal</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <Button onClick={() => setControlledOpen(true)}>Open</Button>
           <Button onClick={() => setControlledOpen(false)}>Close</Button>
         </Stack>
@@ -135,7 +135,7 @@ export default function ModalDemoPage() {
 
         {/* 5. Size props --------------------------------------------------- */}
         <Typography variant="h3">5. maxWidth & fullWidth</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <Button onClick={() => setDialogOpen(true)}>maxWidth (default)</Button>
           <Button onClick={() => setControlledOpen(true)}>fullWidth</Button>
         </Stack>
@@ -148,7 +148,7 @@ export default function ModalDemoPage() {
         </Button>
 
         {/* Back nav -------------------------------------------------------- */}
-        <Button size="lg" onClick={() => navigate(-1)} style={{ marginTop: theme.spacing['lg'] }}>
+        <Button size="lg" onClick={() => navigate(-1)} style={{ marginTop: theme.spacing(3) }}>
           ← Back
         </Button>
       </Stack>

--- a/docs/src/pages/PaginationDemo.tsx
+++ b/docs/src/pages/PaginationDemo.tsx
@@ -11,7 +11,7 @@ export default function PaginationDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         <Typography variant="h2" bold>Pagination Showcase</Typography>
@@ -20,7 +20,7 @@ export default function PaginationDemoPage() {
         <Pagination count={5} page={page} onChange={setPage} />
         <Typography variant="body">Current page: {page}</Typography>
 
-        <Stack direction="row" spacing="lg">
+        <Stack direction="row" spacing={3}>
           <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
           <Button onClick={() => navigate(-1)}>← Back</Button>
         </Stack>

--- a/docs/src/pages/PaginationDemo.tsx
+++ b/docs/src/pages/PaginationDemo.tsx
@@ -11,7 +11,7 @@ export default function PaginationDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         <Typography variant="h2" bold>Pagination Showcase</Typography>
@@ -20,7 +20,7 @@ export default function PaginationDemoPage() {
         <Pagination count={5} page={page} onChange={setPage} />
         <Typography variant="body">Current page: {page}</Typography>
 
-        <Stack direction="row" spacing={3}>
+        <Stack direction="row" spacing={1}>
           <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
           <Button onClick={() => navigate(-1)}>← Back</Button>
         </Stack>

--- a/docs/src/pages/PanelDemo.tsx
+++ b/docs/src/pages/PanelDemo.tsx
@@ -22,7 +22,7 @@ definePreset('fancyPanel', (t) => `
   background   : ${t.colors['backgroundAlt']};
   border-radius: 16px;
   box-shadow   : 0 4px 14px ${t.colors['text']}22;
-  padding      : ${t.spacing['lg']};
+  padding      : ${t.spacing(3)};
 `);
 
 // Frosted glass (requires backdrop-filter support)
@@ -31,7 +31,7 @@ definePreset('glassPanel', (t) => `
   backdrop-filter : blur(8px) saturate(160%);
   border          : 1px solid ${t.colors['text']}33;
   border-radius   : 12px;
-  padding         : ${t.spacing['lg']};
+  padding         : ${t.spacing(3)};
 `);
 
 // Loud gradient banner
@@ -53,7 +53,7 @@ export default function PanelDemoPage() {
   return (
     <Surface /* Surface already defaults to theme background */>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         {/* Page header ----------------------------------------------------- */}
@@ -66,22 +66,22 @@ export default function PanelDemoPage() {
 
         {/* 1. Default Panel ------------------------------------------------- */}
         <Typography variant="h3">1. Default Panel (variant=&quot;main&quot;)</Typography>
-        <Panel style={{ padding: theme.spacing['md'] }}>
+        <Panel style={{ padding: theme.spacing(2) }}>
           <Typography>(no props) — inherits theme backgroundAlt &amp; text</Typography>
         </Panel>
 
         {/* 2. alt variant --------------------------------------------------- */}
         <Typography variant="h3">2. variant=&quot;alt&quot;</Typography>
-        <Panel variant="alt" style={{ padding: theme.spacing['md'] }}>
+        <Panel variant="alt" style={{ padding: theme.spacing(2) }}>
           <Typography>Transparent with outline by default</Typography>
         </Panel>
 
         {/* 3. background override ------------------------------------------ */}
         <Typography variant="h3">3. background&nbsp;prop</Typography>
-        <Stack spacing="md">
+        <Stack spacing={2}>
           <Panel
             background={theme.colors['primary']}
-            style={{ padding: theme.spacing['md'] }}
+            style={{ padding: theme.spacing(2) }}
           >
             <Typography>{`background=${theme.colors['primary']}`}</Typography>
           </Panel>
@@ -92,7 +92,7 @@ export default function PanelDemoPage() {
         <Panel
           fullWidth
           style={{
-            padding: theme.spacing['md'],
+            padding: theme.spacing(2),
             textAlign: 'center',
           }}
         >
@@ -103,7 +103,7 @@ export default function PanelDemoPage() {
         <Typography variant="h3">5. Inline style</Typography>
         <Panel
           style={{
-            padding      : theme.spacing['lg'],
+            padding      : theme.spacing(3),
             borderRadius : 12,
             border       : `2px dashed ${theme.colors['text']}`,
           }}
@@ -113,8 +113,8 @@ export default function PanelDemoPage() {
 
         {/* 6. Nested Panels & colour inheritance --------------------------- */}
         <Typography variant="h3">6. Nested Panels</Typography>
-        <Panel background={theme.colors['primary']} style={{ padding: theme.spacing['md'] }}>
-          <Panel variant="alt" fullWidth style={{ padding: theme.spacing['sm'] }}>
+        <Panel background={theme.colors['primary']} style={{ padding: theme.spacing(2) }}>
+          <Panel variant="alt" fullWidth style={{ padding: theme.spacing(1) }}>
             <Typography>
               Parent sets&nbsp;
               <code style={{ color: 'var(--zero-text-color)' }}>--zero-text-color</code>
@@ -125,7 +125,7 @@ export default function PanelDemoPage() {
 
         {/* 7. Preset demos -------------------------------------------------- */}
         <Typography variant="h3">7. Presets</Typography>
-        <Stack spacing="md">
+        <Stack spacing={2}>
           <Panel preset="fancyPanel">
             <Typography>preset=&quot;fancyPanel&quot;</Typography>
           </Panel>
@@ -156,7 +156,7 @@ export default function PanelDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing['lg'] }}
+          style={{ marginTop: theme.spacing(3) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/PanelDemo.tsx
+++ b/docs/src/pages/PanelDemo.tsx
@@ -22,7 +22,7 @@ definePreset('fancyPanel', (t) => `
   background   : ${t.colors['backgroundAlt']};
   border-radius: 16px;
   box-shadow   : 0 4px 14px ${t.colors['text']}22;
-  padding      : ${t.spacing(3)};
+  padding      : ${t.spacing(1)};
 `);
 
 // Frosted glass (requires backdrop-filter support)
@@ -31,7 +31,7 @@ definePreset('glassPanel', (t) => `
   backdrop-filter : blur(8px) saturate(160%);
   border          : 1px solid ${t.colors['text']}33;
   border-radius   : 12px;
-  padding         : ${t.spacing(3)};
+  padding         : ${t.spacing(1)};
 `);
 
 // Loud gradient banner
@@ -53,7 +53,7 @@ export default function PanelDemoPage() {
   return (
     <Surface /* Surface already defaults to theme background */>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         {/* Page header ----------------------------------------------------- */}
@@ -66,22 +66,22 @@ export default function PanelDemoPage() {
 
         {/* 1. Default Panel ------------------------------------------------- */}
         <Typography variant="h3">1. Default Panel (variant=&quot;main&quot;)</Typography>
-        <Panel style={{ padding: theme.spacing(2) }}>
+        <Panel style={{ padding: theme.spacing(1) }}>
           <Typography>(no props) — inherits theme backgroundAlt &amp; text</Typography>
         </Panel>
 
         {/* 2. alt variant --------------------------------------------------- */}
         <Typography variant="h3">2. variant=&quot;alt&quot;</Typography>
-        <Panel variant="alt" style={{ padding: theme.spacing(2) }}>
+        <Panel variant="alt" style={{ padding: theme.spacing(1) }}>
           <Typography>Transparent with outline by default</Typography>
         </Panel>
 
         {/* 3. background override ------------------------------------------ */}
         <Typography variant="h3">3. background&nbsp;prop</Typography>
-        <Stack spacing={2}>
+        <Stack spacing={1}>
           <Panel
             background={theme.colors['primary']}
-            style={{ padding: theme.spacing(2) }}
+            style={{ padding: theme.spacing(1) }}
           >
             <Typography>{`background=${theme.colors['primary']}`}</Typography>
           </Panel>
@@ -92,7 +92,7 @@ export default function PanelDemoPage() {
         <Panel
           fullWidth
           style={{
-            padding: theme.spacing(2),
+            padding: theme.spacing(1),
             textAlign: 'center',
           }}
         >
@@ -103,7 +103,7 @@ export default function PanelDemoPage() {
         <Typography variant="h3">5. Inline style</Typography>
         <Panel
           style={{
-            padding      : theme.spacing(3),
+            padding      : theme.spacing(1),
             borderRadius : 12,
             border       : `2px dashed ${theme.colors['text']}`,
           }}
@@ -113,7 +113,7 @@ export default function PanelDemoPage() {
 
         {/* 6. Nested Panels & colour inheritance --------------------------- */}
         <Typography variant="h3">6. Nested Panels</Typography>
-        <Panel background={theme.colors['primary']} style={{ padding: theme.spacing(2) }}>
+        <Panel background={theme.colors['primary']} style={{ padding: theme.spacing(1) }}>
           <Panel variant="alt" fullWidth style={{ padding: theme.spacing(1) }}>
             <Typography>
               Parent sets&nbsp;
@@ -125,7 +125,7 @@ export default function PanelDemoPage() {
 
         {/* 7. Preset demos -------------------------------------------------- */}
         <Typography variant="h3">7. Presets</Typography>
-        <Stack spacing={2}>
+        <Stack spacing={1}>
           <Panel preset="fancyPanel">
             <Typography>preset=&quot;fancyPanel&quot;</Typography>
           </Panel>
@@ -156,7 +156,7 @@ export default function PanelDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing(3) }}
+          style={{ marginTop: theme.spacing(1) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/PresetDemoPage.tsx
+++ b/docs/src/pages/PresetDemoPage.tsx
@@ -21,8 +21,8 @@ definePreset('cardBox', t => `
   background: ${t.colors['background']};
   border-radius: 20px;
   box-shadow: 0 6px 16px ${t.colors['text']}22;
-  padding: ${t.spacing(3)};
-  margin: ${t.spacing(3)};
+  padding: ${t.spacing(1)};
+  margin: ${t.spacing(1)};
 `);
 
 definePreset('accentText', t => `
@@ -38,7 +38,7 @@ definePreset('ghostButton', t => `
 definePreset('pillStack', t => `
   background: ${t.colors['tertiary']}33;
   border-radius: 9999px;
-  padding: ${t.spacing(2)};
+  padding: ${t.spacing(1)};
 `);
 
 /*───────────────────────────────────────────────────────────────*/
@@ -56,13 +56,13 @@ export default function PresetDemoPage() {
           Preset Showcase
         </Typography>
 
-        <Typography variant="body" style={{ marginBottom: theme.spacing(2) }}>
+        <Typography variant="body" style={{ marginBottom: theme.spacing(1) }}>
           Every component below uses a different <code>preset</code>.
         </Typography>
 
         {/* “Pill” Stack containing ghost buttons */}
-        <Stack direction="row" spacing={2} preset="pillStack">
-          <Button preset="ghostButton" size="md" style={{ marginLeft: theme.spacing(2) }}>
+        <Stack direction="row" spacing={1} preset="pillStack">
+          <Button preset="ghostButton" size="md" style={{ marginLeft: theme.spacing(1) }}>
             Ghost 1
           </Button>
           <Button preset="ghostButton" size="md">
@@ -72,12 +72,12 @@ export default function PresetDemoPage() {
       </Box>
 
       {/* Default-styled Box for contrast */}
-      <Box style={{ padding: theme.spacing(3) }}>
+      <Box style={{ padding: theme.spacing(1) }}>
         <Typography>Default Box (no preset)</Typography>
       </Box>
 
       {/* Navigation */}
-      <Stack direction="row" spacing={2} style={{ padding: theme.spacing(2) }}>
+      <Stack direction="row" spacing={1} style={{ padding: theme.spacing(1) }}>
         <Button variant="contained" size="lg" preset="ghostButton" onClick={() => navigate(-1)}>
           Go Back
         </Button>

--- a/docs/src/pages/PresetDemoPage.tsx
+++ b/docs/src/pages/PresetDemoPage.tsx
@@ -21,8 +21,8 @@ definePreset('cardBox', t => `
   background: ${t.colors['background']};
   border-radius: 20px;
   box-shadow: 0 6px 16px ${t.colors['text']}22;
-  padding: ${t.spacing['lg']};
-  margin: ${t.spacing['lg']};
+  padding: ${t.spacing(3)};
+  margin: ${t.spacing(3)};
 `);
 
 definePreset('accentText', t => `
@@ -38,7 +38,7 @@ definePreset('ghostButton', t => `
 definePreset('pillStack', t => `
   background: ${t.colors['tertiary']}33;
   border-radius: 9999px;
-  padding: ${t.spacing['md']};
+  padding: ${t.spacing(2)};
 `);
 
 /*───────────────────────────────────────────────────────────────*/
@@ -56,13 +56,13 @@ export default function PresetDemoPage() {
           Preset Showcase
         </Typography>
 
-        <Typography variant="body" style={{ marginBottom: theme.spacing['md'] }}>
+        <Typography variant="body" style={{ marginBottom: theme.spacing(2) }}>
           Every component below uses a different <code>preset</code>.
         </Typography>
 
         {/* “Pill” Stack containing ghost buttons */}
-        <Stack direction="row" spacing="md" preset="pillStack">
-          <Button preset="ghostButton" size="md" style={{ marginLeft: theme.spacing['md'] }}>
+        <Stack direction="row" spacing={2} preset="pillStack">
+          <Button preset="ghostButton" size="md" style={{ marginLeft: theme.spacing(2) }}>
             Ghost 1
           </Button>
           <Button preset="ghostButton" size="md">
@@ -72,12 +72,12 @@ export default function PresetDemoPage() {
       </Box>
 
       {/* Default-styled Box for contrast */}
-      <Box style={{ padding: theme.spacing['lg'] }}>
+      <Box style={{ padding: theme.spacing(3) }}>
         <Typography>Default Box (no preset)</Typography>
       </Box>
 
       {/* Navigation */}
-      <Stack direction="row" spacing="md" style={{ padding: theme.spacing['md'] }}>
+      <Stack direction="row" spacing={2} style={{ padding: theme.spacing(2) }}>
         <Button variant="contained" size="lg" preset="ghostButton" onClick={() => navigate(-1)}>
           Go Back
         </Button>

--- a/docs/src/pages/ProgressDemo.tsx
+++ b/docs/src/pages/ProgressDemo.tsx
@@ -47,7 +47,7 @@ export default function ProgressDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         {/* Page header ----------------------------------------------------- */}
@@ -60,7 +60,7 @@ export default function ProgressDemoPage() {
 
         {/* 1. Circular indeterminate -------------------------------------- */}
         <Typography variant="h3">1. Circular – indeterminate</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <Progress variant="circular" mode="indeterminate" />
           <Progress variant="circular" mode="indeterminate" size="lg" />
           <Progress
@@ -73,7 +73,7 @@ export default function ProgressDemoPage() {
 
         {/* 2. Circular determinate (controlled) --------------------------- */}
         <Typography variant="h3">2. Circular – determinate (controlled)</Typography>
-        <Stack direction="row" spacing={2} style={{ alignItems: 'center' }}>
+        <Stack direction="row" spacing={1} style={{ alignItems: 'center' }}>
           <Progress
             variant="circular"
             mode="determinate"
@@ -104,11 +104,11 @@ export default function ProgressDemoPage() {
 
         {/* 6. Interactive controls ---------------------------------------- */}
         <Typography variant="h3">6. Play with value</Typography>
-        <Stack spacing={2}>
+        <Stack spacing={1}>
           <Box style={{ maxWidth: 480 }}>
             <Slider value={value} onChange={setValue} />
           </Box>
-          <Stack direction="row" spacing={2}>
+          <Stack direction="row" spacing={1}>
             <Button onClick={() => setValue((v) => Math.max(0, v - 10))}>
               –10
             </Button>
@@ -128,7 +128,7 @@ export default function ProgressDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing(3) }}
+          style={{ marginTop: theme.spacing(1) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/ProgressDemo.tsx
+++ b/docs/src/pages/ProgressDemo.tsx
@@ -47,7 +47,7 @@ export default function ProgressDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         {/* Page header ----------------------------------------------------- */}
@@ -60,7 +60,7 @@ export default function ProgressDemoPage() {
 
         {/* 1. Circular indeterminate -------------------------------------- */}
         <Typography variant="h3">1. Circular – indeterminate</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <Progress variant="circular" mode="indeterminate" />
           <Progress variant="circular" mode="indeterminate" size="lg" />
           <Progress
@@ -73,7 +73,7 @@ export default function ProgressDemoPage() {
 
         {/* 2. Circular determinate (controlled) --------------------------- */}
         <Typography variant="h3">2. Circular – determinate (controlled)</Typography>
-        <Stack direction="row" spacing="md" style={{ alignItems: 'center' }}>
+        <Stack direction="row" spacing={2} style={{ alignItems: 'center' }}>
           <Progress
             variant="circular"
             mode="determinate"
@@ -104,11 +104,11 @@ export default function ProgressDemoPage() {
 
         {/* 6. Interactive controls ---------------------------------------- */}
         <Typography variant="h3">6. Play with value</Typography>
-        <Stack spacing="md">
+        <Stack spacing={2}>
           <Box style={{ maxWidth: 480 }}>
             <Slider value={value} onChange={setValue} />
           </Box>
-          <Stack direction="row" spacing="md">
+          <Stack direction="row" spacing={2}>
             <Button onClick={() => setValue((v) => Math.max(0, v - 10))}>
               –10
             </Button>
@@ -128,7 +128,7 @@ export default function ProgressDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing['lg'] }}
+          style={{ marginTop: theme.spacing(3) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/RadioGroupDemo.tsx
+++ b/docs/src/pages/RadioGroupDemo.tsx
@@ -23,7 +23,7 @@ import { useNavigate } from 'react-router-dom';
 /* Style Presets                                                              */
 /*  Chip-style radios (pill background, hover/selected colour swap)           */
 definePreset('chipRadio', (t) => `
-  padding         : ${t.spacing['sm']} ${t.spacing['md']};
+  padding         : ${t.spacing(1)} ${t.spacing(2)};
   border-radius   : 9999px;
   background      : ${t.colors['backgroundAlt']};
   transition      : background 0.2s ease, color 0.2s ease, filter 0.2s ease;
@@ -63,7 +63,7 @@ export default function RadioGroupDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         {/* Page header ----------------------------------------------------- */}
@@ -99,7 +99,7 @@ export default function RadioGroupDemoPage() {
 
         {/* 3. Sizes --------------------------------------------------------- */}
         <Typography variant="h3">3. Sizes</Typography>
-        <Stack direction="row" spacing="lg">
+        <Stack direction="row" spacing={3}>
           <RadioGroup defaultValue="sm" size="sm">
             <Radio value="sm" label="size='sm'" />
             <Radio value="sm2" label="size='sm'" />
@@ -146,7 +146,7 @@ export default function RadioGroupDemoPage() {
         <FormControl
           useStore={useSurveyForm}
           onSubmitValues={handleSubmit}
-          style={{ display: 'flex', flexDirection: 'column', gap: theme.spacing['md'] }}
+          style={{ display: 'flex', flexDirection: 'column', gap: theme.spacing(2) }}
         >
           <Typography bold>Favourite colour?</Typography>
           <RadioGroup name="color" row>
@@ -177,7 +177,7 @@ export default function RadioGroupDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing['lg'] }}
+          style={{ marginTop: theme.spacing(3) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/RadioGroupDemo.tsx
+++ b/docs/src/pages/RadioGroupDemo.tsx
@@ -23,7 +23,7 @@ import { useNavigate } from 'react-router-dom';
 /* Style Presets                                                              */
 /*  Chip-style radios (pill background, hover/selected colour swap)           */
 definePreset('chipRadio', (t) => `
-  padding         : ${t.spacing(1)} ${t.spacing(2)};
+  padding         : ${t.spacing(1)} ${t.spacing(1)};
   border-radius   : 9999px;
   background      : ${t.colors['backgroundAlt']};
   transition      : background 0.2s ease, color 0.2s ease, filter 0.2s ease;
@@ -63,7 +63,7 @@ export default function RadioGroupDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         {/* Page header ----------------------------------------------------- */}
@@ -99,7 +99,7 @@ export default function RadioGroupDemoPage() {
 
         {/* 3. Sizes --------------------------------------------------------- */}
         <Typography variant="h3">3. Sizes</Typography>
-        <Stack direction="row" spacing={3}>
+        <Stack direction="row" spacing={1}>
           <RadioGroup defaultValue="sm" size="sm">
             <Radio value="sm" label="size='sm'" />
             <Radio value="sm2" label="size='sm'" />
@@ -146,7 +146,7 @@ export default function RadioGroupDemoPage() {
         <FormControl
           useStore={useSurveyForm}
           onSubmitValues={handleSubmit}
-          style={{ display: 'flex', flexDirection: 'column', gap: theme.spacing(2) }}
+          style={{ display: 'flex', flexDirection: 'column', gap: theme.spacing(1) }}
         >
           <Typography bold>Favourite colour?</Typography>
           <RadioGroup name="color" row>
@@ -177,7 +177,7 @@ export default function RadioGroupDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing(3) }}
+          style={{ marginTop: theme.spacing(1) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/SelectDemo.tsx
+++ b/docs/src/pages/SelectDemo.tsx
@@ -43,7 +43,7 @@ export default function SelectDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         <Typography variant="h2" bold>Select Playground</Typography>
@@ -61,7 +61,7 @@ export default function SelectDemoPage() {
 
         {/* ————————————————— Controlled single */}
         <Typography variant="h3">2. Controlled – single</Typography>
-        <Stack direction="row" spacing="md" style={{ alignItems: 'center' }}>
+        <Stack direction="row" spacing={2} style={{ alignItems: 'center' }}>
           <Select value={pet} onChange={(v) => setPet(v as string)}>
             <Select.Option value="cat">Cat</Select.Option>
             <Select.Option value="dog">Dog</Select.Option>
@@ -72,7 +72,7 @@ export default function SelectDemoPage() {
 
         {/* ————————————————— Controlled multiple */}
         <Typography variant="h3">3. Controlled – multiple</Typography>
-        <Stack direction="row" spacing="md" style={{ alignItems: 'center' }}>
+        <Stack direction="row" spacing={2} style={{ alignItems: 'center' }}>
           <Select
             multiple
             value={langs}
@@ -92,7 +92,7 @@ export default function SelectDemoPage() {
 
         {/* ————————————————— Sizes */}
         <Typography variant="h3">4. Size variants</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           {(['sm', 'md', 'lg'] as const).map((s) => (
             <Select key={s} size={s} placeholder={s.toUpperCase()}>
               <Select.Option value="a">A</Select.Option>
@@ -103,7 +103,7 @@ export default function SelectDemoPage() {
 
         {/* ————————————————— Disabled / preset */}
         <Typography variant="h3">5. Disabled & preset</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <Select disabled placeholder="Disabled">
             <Select.Option value="x">X</Select.Option>
           </Select>
@@ -120,7 +120,7 @@ export default function SelectDemoPage() {
           useStore={useDemoForm}
           onSubmitValues={(vals) => setSubmitted(vals)}
         >
-          <Stack spacing="md">
+          <Stack spacing={2}>
             <Select
               name="country"
               placeholder="Country"
@@ -152,7 +152,7 @@ export default function SelectDemoPage() {
           <Box
             style={{
               background   : theme.colors['surfaceElevated'],
-              padding      : theme.spacing['md'],
+              padding      : theme.spacing(2),
               borderRadius : 6,
               whiteSpace   : 'pre',
               fontFamily   : 'monospace',
@@ -169,7 +169,7 @@ export default function SelectDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing['lg'] }}
+          style={{ marginTop: theme.spacing(3) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/SelectDemo.tsx
+++ b/docs/src/pages/SelectDemo.tsx
@@ -43,7 +43,7 @@ export default function SelectDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         <Typography variant="h2" bold>Select Playground</Typography>
@@ -61,7 +61,7 @@ export default function SelectDemoPage() {
 
         {/* ————————————————— Controlled single */}
         <Typography variant="h3">2. Controlled – single</Typography>
-        <Stack direction="row" spacing={2} style={{ alignItems: 'center' }}>
+        <Stack direction="row" spacing={1} style={{ alignItems: 'center' }}>
           <Select value={pet} onChange={(v) => setPet(v as string)}>
             <Select.Option value="cat">Cat</Select.Option>
             <Select.Option value="dog">Dog</Select.Option>
@@ -72,7 +72,7 @@ export default function SelectDemoPage() {
 
         {/* ————————————————— Controlled multiple */}
         <Typography variant="h3">3. Controlled – multiple</Typography>
-        <Stack direction="row" spacing={2} style={{ alignItems: 'center' }}>
+        <Stack direction="row" spacing={1} style={{ alignItems: 'center' }}>
           <Select
             multiple
             value={langs}
@@ -92,7 +92,7 @@ export default function SelectDemoPage() {
 
         {/* ————————————————— Sizes */}
         <Typography variant="h3">4. Size variants</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           {(['sm', 'md', 'lg'] as const).map((s) => (
             <Select key={s} size={s} placeholder={s.toUpperCase()}>
               <Select.Option value="a">A</Select.Option>
@@ -103,7 +103,7 @@ export default function SelectDemoPage() {
 
         {/* ————————————————— Disabled / preset */}
         <Typography variant="h3">5. Disabled & preset</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <Select disabled placeholder="Disabled">
             <Select.Option value="x">X</Select.Option>
           </Select>
@@ -120,7 +120,7 @@ export default function SelectDemoPage() {
           useStore={useDemoForm}
           onSubmitValues={(vals) => setSubmitted(vals)}
         >
-          <Stack spacing={2}>
+          <Stack spacing={1}>
             <Select
               name="country"
               placeholder="Country"
@@ -152,7 +152,7 @@ export default function SelectDemoPage() {
           <Box
             style={{
               background   : theme.colors['surfaceElevated'],
-              padding      : theme.spacing(2),
+              padding      : theme.spacing(1),
               borderRadius : 6,
               whiteSpace   : 'pre',
               fontFamily   : 'monospace',
@@ -169,7 +169,7 @@ export default function SelectDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing(3) }}
+          style={{ marginTop: theme.spacing(1) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/SliderDemo.tsx
+++ b/docs/src/pages/SliderDemo.tsx
@@ -32,7 +32,7 @@ export default function SliderDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         {/* Header */}
@@ -118,7 +118,7 @@ export default function SliderDemoPage() {
         />
 
         {/* Theme toggle + back nav ----------------------------------------- */}
-        <Stack direction="row" spacing={3}>
+        <Stack direction="row" spacing={1}>
           <Button variant="outlined" onClick={toggleMode}>
             Toggle light / dark
           </Button>

--- a/docs/src/pages/SliderDemo.tsx
+++ b/docs/src/pages/SliderDemo.tsx
@@ -32,7 +32,7 @@ export default function SliderDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         {/* Header */}
@@ -49,7 +49,7 @@ export default function SliderDemoPage() {
 
         {/* 2. Controlled ---------------------------------------------------- */}
         <Typography variant="h3">2. Controlled</Typography>
-        <Stack spacing="sm">
+        <Stack spacing={1}>
           <Slider
             value={ctlValue}
             onChange={setCtlValue}
@@ -118,7 +118,7 @@ export default function SliderDemoPage() {
         />
 
         {/* Theme toggle + back nav ----------------------------------------- */}
-        <Stack direction="row" spacing="lg">
+        <Stack direction="row" spacing={3}>
           <Button variant="outlined" onClick={toggleMode}>
             Toggle light / dark
           </Button>

--- a/docs/src/pages/SnackbarDemo.tsx
+++ b/docs/src/pages/SnackbarDemo.tsx
@@ -40,7 +40,7 @@ export default function SnackbarDemoPage() {
 
   return (
     <Surface>
-      <Stack spacing={3} preset="showcaseStack">
+      <Stack spacing={1} preset="showcaseStack">
         {/* Header --------------------------------------------------------- */}
         <Typography variant="h2" bold>
           Snackbar Showcase
@@ -116,7 +116,7 @@ export default function SnackbarDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing(3) }}
+          style={{ marginTop: theme.spacing(1) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/SnackbarDemo.tsx
+++ b/docs/src/pages/SnackbarDemo.tsx
@@ -40,7 +40,7 @@ export default function SnackbarDemoPage() {
 
   return (
     <Surface>
-      <Stack spacing="lg" preset="showcaseStack">
+      <Stack spacing={3} preset="showcaseStack">
         {/* Header --------------------------------------------------------- */}
         <Typography variant="h2" bold>
           Snackbar Showcase
@@ -76,7 +76,7 @@ export default function SnackbarDemoPage() {
           open={ctrlOpen}
           onClose={() => setCtrlOpen(false)}
         >
-          <Stack direction="row" spacing="sm" wrap={false}>
+          <Stack direction="row" spacing={1} wrap={false}>
             <Typography variant="body" autoSize>
               Draft saved – click to dismiss
             </Typography>
@@ -116,7 +116,7 @@ export default function SnackbarDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing['lg'] }}
+          style={{ marginTop: theme.spacing(3) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/SpeedDialDemo.tsx
+++ b/docs/src/pages/SpeedDialDemo.tsx
@@ -15,7 +15,7 @@ export default function SpeedDialDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         <Typography variant="h2" bold>SpeedDial Showcase</Typography>
@@ -25,7 +25,7 @@ export default function SpeedDialDemoPage() {
         <Typography variant="body">Click the fab to reveal actions.</Typography>
         <SpeedDial icon={<Icon icon="mdi:plus" />} actions={actions} />
 
-        <Stack direction="row" spacing="lg">
+        <Stack direction="row" spacing={3}>
           <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
           <Button onClick={() => navigate(-1)}>← Back</Button>
         </Stack>

--- a/docs/src/pages/SpeedDialDemo.tsx
+++ b/docs/src/pages/SpeedDialDemo.tsx
@@ -15,7 +15,7 @@ export default function SpeedDialDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         <Typography variant="h2" bold>SpeedDial Showcase</Typography>
@@ -25,7 +25,7 @@ export default function SpeedDialDemoPage() {
         <Typography variant="body">Click the fab to reveal actions.</Typography>
         <SpeedDial icon={<Icon icon="mdi:plus" />} actions={actions} />
 
-        <Stack direction="row" spacing={3}>
+        <Stack direction="row" spacing={1}>
           <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
           <Button onClick={() => navigate(-1)}>← Back</Button>
         </Stack>

--- a/docs/src/pages/StepperDemo.tsx
+++ b/docs/src/pages/StepperDemo.tsx
@@ -13,19 +13,19 @@ export default function StepperDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         <Typography variant="h2" bold>Stepper Showcase</Typography>
         <Typography variant="subtitle">Simple progress indicator</Typography>
 
         <Stepper steps={steps} active={active} />
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <Button onClick={() => setActive((a) => Math.max(0, a - 1))}>Back</Button>
           <Button onClick={() => setActive((a) => Math.min(steps.length - 1, a + 1))}>Next</Button>
         </Stack>
 
-        <Stack direction="row" spacing="lg">
+        <Stack direction="row" spacing={3}>
           <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
           <Button onClick={() => navigate(-1)}>← Back</Button>
         </Stack>

--- a/docs/src/pages/StepperDemo.tsx
+++ b/docs/src/pages/StepperDemo.tsx
@@ -13,19 +13,19 @@ export default function StepperDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         <Typography variant="h2" bold>Stepper Showcase</Typography>
         <Typography variant="subtitle">Simple progress indicator</Typography>
 
         <Stepper steps={steps} active={active} />
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <Button onClick={() => setActive((a) => Math.max(0, a - 1))}>Back</Button>
           <Button onClick={() => setActive((a) => Math.min(steps.length - 1, a + 1))}>Next</Button>
         </Stack>
 
-        <Stack direction="row" spacing={3}>
+        <Stack direction="row" spacing={1}>
           <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
           <Button onClick={() => navigate(-1)}>← Back</Button>
         </Stack>

--- a/docs/src/pages/SwitchDemo.tsx
+++ b/docs/src/pages/SwitchDemo.tsx
@@ -34,7 +34,7 @@ interface RowProps {
 const Row = ({ label, control }: RowProps) => (
   <Stack
     direction="row"
-    spacing="md"
+    spacing={2}
     style={{ maxWidth: 360 }}
   >
     {control}
@@ -59,7 +59,7 @@ export default function SwitchDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         {/* Page header ----------------------------------------------------- */}
@@ -72,7 +72,7 @@ export default function SwitchDemoPage() {
 
         {/* 1. Uncontrolled -------------------------------------------------- */}
         <Typography variant="h3">1. Uncontrolled</Typography>
-        <Stack spacing="md">
+        <Stack spacing={2}>
           <Row
             label="Default unchecked"
             control={<Switch name="uc1" />}
@@ -98,7 +98,7 @@ export default function SwitchDemoPage() {
 
         {/* 3. Sizes --------------------------------------------------------- */}
         <Typography variant="h3">3. Sizes</Typography>
-        <Stack spacing="md">
+        <Stack spacing={2}>
           <Row
             label="size='sm'"
             control={<Switch name="sm" size="sm" defaultChecked />}
@@ -115,7 +115,7 @@ export default function SwitchDemoPage() {
 
         {/* 4. Disabled ------------------------------------------------------ */}
         <Typography variant="h3">4. Disabled</Typography>
-        <Stack spacing="md">
+        <Stack spacing={2}>
           <Row
             label="disabled & checked"
             control={<Switch name="d1" defaultChecked disabled />}
@@ -134,7 +134,7 @@ export default function SwitchDemoPage() {
           style={{
             display      : 'flex',
             flexDirection: 'column',
-            gap          : theme.spacing['md'],
+            gap          : theme.spacing(2),
           }}
         >
           <Row
@@ -160,7 +160,7 @@ export default function SwitchDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing['lg'] }}
+          style={{ marginTop: theme.spacing(3) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/SwitchDemo.tsx
+++ b/docs/src/pages/SwitchDemo.tsx
@@ -34,7 +34,7 @@ interface RowProps {
 const Row = ({ label, control }: RowProps) => (
   <Stack
     direction="row"
-    spacing={2}
+    spacing={1}
     style={{ maxWidth: 360 }}
   >
     {control}
@@ -59,7 +59,7 @@ export default function SwitchDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         {/* Page header ----------------------------------------------------- */}
@@ -72,7 +72,7 @@ export default function SwitchDemoPage() {
 
         {/* 1. Uncontrolled -------------------------------------------------- */}
         <Typography variant="h3">1. Uncontrolled</Typography>
-        <Stack spacing={2}>
+        <Stack spacing={1}>
           <Row
             label="Default unchecked"
             control={<Switch name="uc1" />}
@@ -98,7 +98,7 @@ export default function SwitchDemoPage() {
 
         {/* 3. Sizes --------------------------------------------------------- */}
         <Typography variant="h3">3. Sizes</Typography>
-        <Stack spacing={2}>
+        <Stack spacing={1}>
           <Row
             label="size='sm'"
             control={<Switch name="sm" size="sm" defaultChecked />}
@@ -115,7 +115,7 @@ export default function SwitchDemoPage() {
 
         {/* 4. Disabled ------------------------------------------------------ */}
         <Typography variant="h3">4. Disabled</Typography>
-        <Stack spacing={2}>
+        <Stack spacing={1}>
           <Row
             label="disabled & checked"
             control={<Switch name="d1" defaultChecked disabled />}
@@ -134,7 +134,7 @@ export default function SwitchDemoPage() {
           style={{
             display      : 'flex',
             flexDirection: 'column',
-            gap          : theme.spacing(2),
+            gap          : theme.spacing(1),
           }}
         >
           <Row
@@ -160,7 +160,7 @@ export default function SwitchDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing(3) }}
+          style={{ marginTop: theme.spacing(1) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/TableDemo.tsx
+++ b/docs/src/pages/TableDemo.tsx
@@ -111,14 +111,14 @@ export default function TableDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         {/* Header bar ------------------------------------------------------- */}
         <Panel variant="alt" fullWidth>
           <Stack
             direction="row"
-            spacing={3}
+            spacing={1}
             style={{ alignItems: 'center', flexWrap: 'wrap' }}
           >
             <Typography variant="h2" bold>
@@ -220,7 +220,7 @@ export default function TableDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing(3) }}
+          style={{ marginTop: theme.spacing(1) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/TableDemo.tsx
+++ b/docs/src/pages/TableDemo.tsx
@@ -111,14 +111,14 @@ export default function TableDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         {/* Header bar ------------------------------------------------------- */}
         <Panel variant="alt" fullWidth>
           <Stack
             direction="row"
-            spacing="lg"
+            spacing={3}
             style={{ alignItems: 'center', flexWrap: 'wrap' }}
           >
             <Typography variant="h2" bold>
@@ -137,7 +137,7 @@ export default function TableDemoPage() {
         <Panel variant="alt" fullWidth>
           <Stack
             direction="row"
-            spacing="xl"
+            spacing={4}
             style={{ flexWrap: 'wrap', alignItems: 'flex-end' }}
           >
             <TextField
@@ -220,7 +220,7 @@ export default function TableDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing['lg'] }}
+          style={{ marginTop: theme.spacing(3) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/TabsDemo.tsx
+++ b/docs/src/pages/TabsDemo.tsx
@@ -33,7 +33,7 @@ export default function TabsDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         <Typography variant="h2" bold>
@@ -129,7 +129,7 @@ export default function TabsDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing['lg'] }}
+          style={{ marginTop: theme.spacing(3) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/TabsDemo.tsx
+++ b/docs/src/pages/TabsDemo.tsx
@@ -33,7 +33,7 @@ export default function TabsDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         <Typography variant="h2" bold>
@@ -129,7 +129,7 @@ export default function TabsDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing(3) }}
+          style={{ marginTop: theme.spacing(1) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/Test.tsx
+++ b/docs/src/pages/Test.tsx
@@ -18,7 +18,7 @@ export default function TestPage() {
 
     return (
         <Surface style={{ backgroundColor: theme.colors['background'] }}>
-            <Stack direction="row" spacing="sm">
+            <Stack direction="row" spacing={1}>
                 <Button>
                     <Typography>
                         Really Long Button
@@ -43,7 +43,7 @@ export default function TestPage() {
 
             <br />
 
-            <Panel style={{ padding: theme.spacing['sm'], margin: theme.spacing['sm'], borderRadius: theme.spacing['sm'] }}>
+            <Panel style={{ padding: theme.spacing(1), margin: theme.spacing(1), borderRadius: theme.spacing(1) }}>
                 <RadioGroup
                     name="shipping"
                     value={method}
@@ -51,7 +51,7 @@ export default function TestPage() {
                     row
                     size="lg"
                 >
-                    <Stack direction="column" spacing="sm">
+                    <Stack direction="column" spacing={1}>
                         <Radio value="standard" label="Standard (3–5 days)" />
                         <Radio value="express" label="Express (1–2 days)" />
                         <Radio value="overnight" label="Overnight" disabled />

--- a/docs/src/pages/TextFormDemo.tsx
+++ b/docs/src/pages/TextFormDemo.tsx
@@ -41,7 +41,7 @@ export default function TextFieldDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         {/* Page header --------------------------------------------------- */}
@@ -54,7 +54,7 @@ export default function TextFieldDemoPage() {
 
         {/* 1. Basic stand-alone fields ---------------------------------- */}
         <Typography variant="h3">1. Stand-alone TextField</Typography>
-        <Stack spacing="md">
+        <Stack spacing={2}>
           {/* uncontrolled */}
           <TextField name="basic" placeholder="Uncontrolled" />
 
@@ -79,11 +79,11 @@ export default function TextFieldDemoPage() {
 
         {/* 2. TextFields inside a FormControl --------------------------- */}
         <Typography variant="h3">2. FormControl demo</Typography>
-        <Panel variant="alt" style={{ padding: theme.spacing['lg'] }}>
+        <Panel variant="alt" style={{ padding: theme.spacing(3) }}>
           <FormControl
             useStore={useContactForm}
             onSubmitValues={(vals) => alert(JSON.stringify(vals, null, 2))}
-            style={{ display: 'flex', flexDirection: 'column', gap: theme.spacing['md'] }}
+            style={{ display: 'flex', flexDirection: 'column', gap: theme.spacing(2) }}
           >
             <TextField name="name" label="Name" placeholder="Jane Doe" />
             <TextField
@@ -116,7 +116,7 @@ export default function TextFieldDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing['lg'] }}
+          style={{ marginTop: theme.spacing(3) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/TextFormDemo.tsx
+++ b/docs/src/pages/TextFormDemo.tsx
@@ -41,7 +41,7 @@ export default function TextFieldDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         {/* Page header --------------------------------------------------- */}
@@ -54,7 +54,7 @@ export default function TextFieldDemoPage() {
 
         {/* 1. Basic stand-alone fields ---------------------------------- */}
         <Typography variant="h3">1. Stand-alone TextField</Typography>
-        <Stack spacing={2}>
+        <Stack spacing={1}>
           {/* uncontrolled */}
           <TextField name="basic" placeholder="Uncontrolled" />
 
@@ -79,11 +79,11 @@ export default function TextFieldDemoPage() {
 
         {/* 2. TextFields inside a FormControl --------------------------- */}
         <Typography variant="h3">2. FormControl demo</Typography>
-        <Panel variant="alt" style={{ padding: theme.spacing(3) }}>
+        <Panel variant="alt" style={{ padding: theme.spacing(1) }}>
           <FormControl
             useStore={useContactForm}
             onSubmitValues={(vals) => alert(JSON.stringify(vals, null, 2))}
-            style={{ display: 'flex', flexDirection: 'column', gap: theme.spacing(2) }}
+            style={{ display: 'flex', flexDirection: 'column', gap: theme.spacing(1) }}
           >
             <TextField name="name" label="Name" placeholder="Jane Doe" />
             <TextField
@@ -116,7 +116,7 @@ export default function TextFieldDemoPage() {
         <Button
           size="lg"
           onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing(3) }}
+          style={{ marginTop: theme.spacing(1) }}
         >
           ← Back
         </Button>

--- a/docs/src/pages/TooltipDemo.tsx
+++ b/docs/src/pages/TooltipDemo.tsx
@@ -45,7 +45,7 @@ export default function TooltipDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
         {/* Page header ----------------------------------------------------- */}
@@ -64,7 +64,7 @@ export default function TooltipDemoPage() {
 
         {/* 2. Placements ---------------------------------------------------- */}
         <Typography variant="h3">2. Placements</Typography>
-        <Stack direction="row" wrap spacing="md">
+        <Stack direction="row" wrap spacing={2}>
           {placements.map(({ key, label }) => (
             <Tooltip key={key} placement={key as any} title={`placement="${key}"`}>
               <Button>{label}</Button>
@@ -74,7 +74,7 @@ export default function TooltipDemoPage() {
 
         {/* 3. Arrow toggle -------------------------------------------------- */}
         <Typography variant="h3">3. Arrow toggle</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <Tooltip title="Default arrow (true)">
             <IconButton icon="mdi:home" />
           </Tooltip>
@@ -85,7 +85,7 @@ export default function TooltipDemoPage() {
 
         {/* 4. Controlled visibility ---------------------------------------- */}
         <Typography variant="h3">4. Controlled visibility</Typography>
-        <Stack direction="row" spacing="md">
+        <Stack direction="row" spacing={2}>
           <Tooltip
             open={controlledOpen}
             onClose={() => setControlledOpen(false)}
@@ -118,7 +118,7 @@ export default function TooltipDemoPage() {
         </Button>
 
         {/* Back nav --------------------------------------------------------- */}
-        <Button size="lg" onClick={() => navigate(-1)} style={{ marginTop: theme.spacing['lg'] }}>
+        <Button size="lg" onClick={() => navigate(-1)} style={{ marginTop: theme.spacing(3) }}>
           ← Back
         </Button>
       </Stack>

--- a/docs/src/pages/TooltipDemo.tsx
+++ b/docs/src/pages/TooltipDemo.tsx
@@ -45,7 +45,7 @@ export default function TooltipDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
         {/* Page header ----------------------------------------------------- */}
@@ -64,7 +64,7 @@ export default function TooltipDemoPage() {
 
         {/* 2. Placements ---------------------------------------------------- */}
         <Typography variant="h3">2. Placements</Typography>
-        <Stack direction="row" wrap spacing={2}>
+        <Stack direction="row" wrap spacing={1}>
           {placements.map(({ key, label }) => (
             <Tooltip key={key} placement={key as any} title={`placement="${key}"`}>
               <Button>{label}</Button>
@@ -74,7 +74,7 @@ export default function TooltipDemoPage() {
 
         {/* 3. Arrow toggle -------------------------------------------------- */}
         <Typography variant="h3">3. Arrow toggle</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <Tooltip title="Default arrow (true)">
             <IconButton icon="mdi:home" />
           </Tooltip>
@@ -85,7 +85,7 @@ export default function TooltipDemoPage() {
 
         {/* 4. Controlled visibility ---------------------------------------- */}
         <Typography variant="h3">4. Controlled visibility</Typography>
-        <Stack direction="row" spacing={2}>
+        <Stack direction="row" spacing={1}>
           <Tooltip
             open={controlledOpen}
             onClose={() => setControlledOpen(false)}
@@ -118,7 +118,7 @@ export default function TooltipDemoPage() {
         </Button>
 
         {/* Back nav --------------------------------------------------------- */}
-        <Button size="lg" onClick={() => navigate(-1)} style={{ marginTop: theme.spacing(3) }}>
+        <Button size="lg" onClick={() => navigate(-1)} style={{ marginTop: theme.spacing(1) }}>
           ← Back
         </Button>
       </Stack>

--- a/docs/src/pages/TypographyDemoPage.tsx
+++ b/docs/src/pages/TypographyDemoPage.tsx
@@ -16,10 +16,10 @@ export default function TypographyDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing={3}
+        spacing={1}
         preset="showcaseStack"
       >
-        <Panel style={{ padding: theme.spacing(2) }}>
+        <Panel style={{ padding: theme.spacing(1) }}>
           <Typography variant="h1">
             zeroui h1
           </Typography>
@@ -45,10 +45,10 @@ export default function TypographyDemoPage() {
           </Typography>
         </Panel>
 
-        <Panel style={{ padding: theme.spacing(2) }}>
+        <Panel style={{ padding: theme.spacing(1) }}>
           <Typography
             variant="body"
-            style={{ margin: `${theme.spacing(2)} 0` }
+            style={{ margin: `${theme.spacing(1)} 0` }
             }>
             This is a body copy example.
           </Typography>
@@ -62,7 +62,7 @@ export default function TypographyDemoPage() {
           <Typography
             variant="body"
             bold
-            style={{ margin: `${theme.spacing(2)} 0` }
+            style={{ margin: `${theme.spacing(1)} 0` }
             }>
             This is a bold body copy example.
           </Typography>
@@ -77,7 +77,7 @@ export default function TypographyDemoPage() {
           <Typography
             variant="body"
             italic
-            style={{ margin: `${theme.spacing(2)} 0` }
+            style={{ margin: `${theme.spacing(1)} 0` }
             }>
             This is an italic body copy example.
           </Typography>
@@ -93,7 +93,7 @@ export default function TypographyDemoPage() {
             variant="body"
             italic
             bold
-            style={{ margin: `${theme.spacing(2)} 0` }
+            style={{ margin: `${theme.spacing(1)} 0` }
             }>
             This is a bold italic body copy example.
           </Typography>
@@ -107,7 +107,7 @@ export default function TypographyDemoPage() {
           </Typography>
         </Panel>
 
-        <Panel style={{ padding: theme.spacing(2) }}>
+        <Panel style={{ padding: theme.spacing(1) }}>
           <Typography>
             Default Typography
           </Typography>
@@ -126,7 +126,7 @@ export default function TypographyDemoPage() {
         </Panel>
       </Stack>
 
-      <Stack direction='row' spacing={2} style={{ padding: theme.spacing(2) }}>
+      <Stack direction='row' spacing={1} style={{ padding: theme.spacing(1) }}>
         <Button size="lg" variant="outlined" onClick={() => navigate(-1)}>
           Go Back
         </Button>

--- a/docs/src/pages/TypographyDemoPage.tsx
+++ b/docs/src/pages/TypographyDemoPage.tsx
@@ -16,10 +16,10 @@ export default function TypographyDemoPage() {
   return (
     <Surface>
       <Stack
-        spacing="lg"
+        spacing={3}
         preset="showcaseStack"
       >
-        <Panel style={{ padding: theme.spacing['md'] }}>
+        <Panel style={{ padding: theme.spacing(2) }}>
           <Typography variant="h1">
             zeroui h1
           </Typography>
@@ -45,10 +45,10 @@ export default function TypographyDemoPage() {
           </Typography>
         </Panel>
 
-        <Panel style={{ padding: theme.spacing['md'] }}>
+        <Panel style={{ padding: theme.spacing(2) }}>
           <Typography
             variant="body"
-            style={{ margin: `${theme.spacing['md']} 0` }
+            style={{ margin: `${theme.spacing(2)} 0` }
             }>
             This is a body copy example.
           </Typography>
@@ -62,7 +62,7 @@ export default function TypographyDemoPage() {
           <Typography
             variant="body"
             bold
-            style={{ margin: `${theme.spacing['md']} 0` }
+            style={{ margin: `${theme.spacing(2)} 0` }
             }>
             This is a bold body copy example.
           </Typography>
@@ -77,7 +77,7 @@ export default function TypographyDemoPage() {
           <Typography
             variant="body"
             italic
-            style={{ margin: `${theme.spacing['md']} 0` }
+            style={{ margin: `${theme.spacing(2)} 0` }
             }>
             This is an italic body copy example.
           </Typography>
@@ -93,7 +93,7 @@ export default function TypographyDemoPage() {
             variant="body"
             italic
             bold
-            style={{ margin: `${theme.spacing['md']} 0` }
+            style={{ margin: `${theme.spacing(2)} 0` }
             }>
             This is a bold italic body copy example.
           </Typography>
@@ -107,7 +107,7 @@ export default function TypographyDemoPage() {
           </Typography>
         </Panel>
 
-        <Panel style={{ padding: theme.spacing['md'] }}>
+        <Panel style={{ padding: theme.spacing(2) }}>
           <Typography>
             Default Typography
           </Typography>
@@ -126,7 +126,7 @@ export default function TypographyDemoPage() {
         </Panel>
       </Stack>
 
-      <Stack direction='row' spacing="md" style={{ padding: theme.spacing['md'] }}>
+      <Stack direction='row' spacing={2} style={{ padding: theme.spacing(2) }}>
         <Button size="lg" variant="outlined" onClick={() => navigate(-1)}>
           Go Back
         </Button>

--- a/docs/src/pages/VideoDemo.tsx
+++ b/docs/src/pages/VideoDemo.tsx
@@ -18,9 +18,9 @@ import {
     return (
       <Surface>
         <Stack
-          spacing={3}
+          spacing={1}
           style={{
-            padding : theme.spacing(3),
+            padding : theme.spacing(1),
             maxWidth: 1024,
             margin  : '0 auto',
           }}

--- a/docs/src/pages/VideoDemo.tsx
+++ b/docs/src/pages/VideoDemo.tsx
@@ -18,9 +18,9 @@ import {
     return (
       <Surface>
         <Stack
-          spacing="lg"
+          spacing={3}
           style={{
-            padding : theme.spacing['lg'],
+            padding : theme.spacing(3),
             maxWidth: 1024,
             margin  : '0 auto',
           }}

--- a/docs/src/presets/globalPresets.ts
+++ b/docs/src/presets/globalPresets.ts
@@ -12,5 +12,5 @@ import { definePreset } from '@archway/valet';
 definePreset('showcaseStack', (t) => `
   max-width : 85%;
   margin    : 0 auto;
-  padding   : ${t.spacing['lg']};
+  padding   : ${t.spacing(3)};
 `);

--- a/docs/src/presets/globalPresets.ts
+++ b/docs/src/presets/globalPresets.ts
@@ -12,5 +12,5 @@ import { definePreset } from '@archway/valet';
 definePreset('showcaseStack', (t) => `
   max-width : 85%;
   margin    : 0 auto;
-  padding   : ${t.spacing(3)};
+  padding   : ${t.spacing(1)};
 `);

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -27,9 +27,9 @@ export interface ButtonProps
 
 /*───────────────────────────────────────────────────────────*/
 const createSizeMap = (t: Theme) => ({
-  sm: { padV: t.spacing(1), padH: t.spacing(2), font: '0.75rem',  height: '2rem'  },
-  md: { padV: t.spacing(1), padH: t.spacing(3), font: '0.875rem', height: '2.5rem'},
-  lg: { padV: t.spacing(2), padH: t.spacing(3), font: '1rem',     height: '3rem'  },
+  sm: { padV: t.spacing(1), padH: t.spacing(1), font: '1rem',  height: '2rem'  },
+  md: { padV: t.spacing(1), padH: t.spacing(1), font: '1rem', height: '2.5rem'},
+  lg: { padV: t.spacing(1), padH: t.spacing(1), font: '1rem',     height: '3rem'  },
 } as const);
 
 /*───────────────────────────────────────────────────────────*/

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -27,9 +27,9 @@ export interface ButtonProps
 
 /*───────────────────────────────────────────────────────────*/
 const createSizeMap = (t: Theme) => ({
-  sm: { padV: t.spacing.sm, padH: t.spacing.md, font: '0.75rem',  height: '2rem'  },
-  md: { padV: t.spacing.sm, padH: t.spacing.lg, font: '0.875rem', height: '2.5rem'},
-  lg: { padV: t.spacing.md, padH: t.spacing.lg, font: '1rem',     height: '3rem'  },
+  sm: { padV: t.spacing(1), padH: t.spacing(2), font: '0.75rem',  height: '2rem'  },
+  md: { padV: t.spacing(1), padH: t.spacing(3), font: '0.875rem', height: '2.5rem'},
+  lg: { padV: t.spacing(2), padH: t.spacing(3), font: '1rem',     height: '3rem'  },
 } as const);
 
 /*───────────────────────────────────────────────────────────*/

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -41,8 +41,8 @@ export interface CheckboxProps
 /* Size map helper                                                          */
 const createSizeMap = (t: Theme) => ({
   sm : { box: '16px', tick: '10px', gap: t.spacing(1) },
-  md : { box: '20px', tick: '12px', gap: t.spacing(2) },
-  lg : { box: '24px', tick: '14px', gap: t.spacing(3) },
+  md : { box: '20px', tick: '12px', gap: t.spacing(1) },
+  lg : { box: '24px', tick: '14px', gap: t.spacing(1) },
 } as const);
 
 /*───────────────────────────────────────────────────────────────────────────*/

--- a/src/components/Checkbox.tsx
+++ b/src/components/Checkbox.tsx
@@ -40,9 +40,9 @@ export interface CheckboxProps
 /*───────────────────────────────────────────────────────────────────────────*/
 /* Size map helper                                                          */
 const createSizeMap = (t: Theme) => ({
-  sm : { box: '16px', tick: '10px', gap: t.spacing.sm },
-  md : { box: '20px', tick: '12px', gap: t.spacing.md },
-  lg : { box: '24px', tick: '14px', gap: t.spacing.lg },
+  sm : { box: '16px', tick: '10px', gap: t.spacing(1) },
+  md : { box: '20px', tick: '12px', gap: t.spacing(2) },
+  lg : { box: '24px', tick: '14px', gap: t.spacing(3) },
 } as const);
 
 /*───────────────────────────────────────────────────────────────────────────*/

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -13,7 +13,7 @@ export interface GridProps
   extends React.HTMLAttributes<HTMLDivElement>,
     Presettable {
   columns?: number;
-  gap?: keyof ReturnType<typeof useTheme.getState>['theme']['spacing'] | string;
+  gap?: number | string;
 }
 
 /*───────────────────────────────────────────────────────────*/
@@ -26,7 +26,7 @@ const Root = styled('div')<{ $cols: number; $gap: string }>`
 /*───────────────────────────────────────────────────────────*/
 export const Grid: React.FC<GridProps> = ({
   columns = 2,
-  gap = 'md',
+  gap = 2,
   preset: p,
   style,
   className,
@@ -36,8 +36,8 @@ export const Grid: React.FC<GridProps> = ({
   const { theme } = useTheme();
 
   let g: string;
-  if (typeof gap === 'string' && gap in theme.spacing) {
-    g = theme.spacing[gap as keyof typeof theme.spacing];
+  if (typeof gap === 'number') {
+    g = theme.spacing(gap);
   } else {
     g = String(gap);
   }

--- a/src/components/RadioGroup.tsx
+++ b/src/components/RadioGroup.tsx
@@ -2,7 +2,7 @@
 // src/components/RadioGroup.tsx | valet
 // Theme-aware radio groups with keyboard nav & refined spacing
 // • Disabled state now mirrors Accordion / Checkbox colour recipe
-// • Inner (radio–label) gap tight; option gap = theme.spacing.sm
+// • Inner (radio–label) gap tight; option gap = theme.spacing(1)
 // ─────────────────────────────────────────────────────────────
 import React, {
   ReactNode,
@@ -44,9 +44,9 @@ const useRadioGroup = () => {
 /*───────────────────────────────────────────────────────────*/
 /* Size map helper                                           */
 const createSizeMap = (t: Theme) => ({
-  sm: { indicator: '16px', dot: '8px',  gapInner: t.spacing.xs },
-  md: { indicator: '20px', dot: '10px', gapInner: t.spacing.xs },
-  lg: { indicator: '24px', dot: '12px', gapInner: t.spacing.sm },
+  sm: { indicator: '16px', dot: '8px',  gapInner: t.spacing(0.5) },
+  md: { indicator: '20px', dot: '10px', gapInner: t.spacing(0.5) },
+  lg: { indicator: '24px', dot: '12px', gapInner: t.spacing(1) },
 });
 
 /*───────────────────────────────────────────────────────────*/
@@ -90,7 +90,7 @@ export interface RadioGroupProps
   row?          : boolean;
   size?         : RadioSize;
   /** Gap between options */
-  spacing?      : keyof Theme['spacing'] | string;
+  spacing?      : number | string;
   onChange?     : (val: string) => void;
   children      : ReactNode;
 }
@@ -150,9 +150,8 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
 
   /* Gap between radio items ------------------------------------------- */
   let gapCss: string;
-  if (spacing === undefined) gapCss = theme.spacing.sm;
-  else if (typeof spacing === 'string' && spacing in theme.spacing)
-    gapCss = theme.spacing[spacing as keyof Theme['spacing']];
+  if (spacing === undefined) gapCss = theme.spacing(1);
+  else if (typeof spacing === 'number') gapCss = theme.spacing(spacing);
   else gapCss = String(spacing);
 
   /* Keyboard navigation (roving radio) -------------------------------- */

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -3,7 +3,7 @@
 // Fully-typed, theme-aware snackbar with fade + auto-dismiss
 // – Uncontrolled or controlled (via `open` / `onClose`)
 // – 200 ms fade-in / fade-out to match font + surface loads
-// – Horizontal flex “stack” by default (gap = theme.spacing(2))
+// – Horizontal flex “stack” by default (gap = theme.spacing(1))
 // – `noStack` disables flex layout entirely
 // – Auto-hide (default 4 s) or user-managed lifetime
 // – Exposes `useSnackbar()` hook so nested buttons can dismiss
@@ -170,7 +170,7 @@ export const Snackbar: React.FC<SnackbarProps> = ({
         {...rest}
         $visible={!exiting && visible}
         $flex={!noStack}
-        $spacing={theme.spacing(2)}
+        $spacing={theme.spacing(1)}
         $outline={theme.colors.primary}
         $bg={theme.colors.background}
         className={classes}

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -3,7 +3,7 @@
 // Fully-typed, theme-aware snackbar with fade + auto-dismiss
 // – Uncontrolled or controlled (via `open` / `onClose`)
 // – 200 ms fade-in / fade-out to match font + surface loads
-// – Horizontal flex “stack” by default (gap = theme.spacing.md)
+// – Horizontal flex “stack” by default (gap = theme.spacing(2))
 // – `noStack` disables flex layout entirely
 // – Auto-hide (default 4 s) or user-managed lifetime
 // – Exposes `useSnackbar()` hook so nested buttons can dismiss
@@ -170,7 +170,7 @@ export const Snackbar: React.FC<SnackbarProps> = ({
         {...rest}
         $visible={!exiting && visible}
         $flex={!noStack}
-        $spacing={theme.spacing.md}
+        $spacing={theme.spacing(2)}
         $outline={theme.colors.primary}
         $bg={theme.colors.background}
         className={classes}

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -4,7 +4,7 @@
 // ─────────────────────────────────────────────────────────────
 import React from 'react';
 import { styled }            from '../css/createStyled';
-import { useTheme, Theme }   from '../system/themeStore';
+import { useTheme }   from '../system/themeStore';
 import { preset }            from '../css/stylePresets';
 import type { Presettable }  from '../types';
 
@@ -14,8 +14,8 @@ export interface StackProps
   extends React.HTMLAttributes<HTMLDivElement>,
     Presettable {
   direction?: 'row' | 'column';
-  /** Accepts a theme spacing token or any CSS length. */
-  spacing?: keyof Theme['spacing'] | string | undefined;
+  /** Number of spacing units or any CSS length. */
+  spacing?: number | string | undefined;
   /** If `true`, children wrap when they run out of space. Defaults to
    *  `true` for `row`, `false` for `column`. */
   wrap?: boolean;
@@ -48,12 +48,12 @@ export const Stack: React.FC<StackProps> = ({
 }) => {
   const { theme } = useTheme();
 
-  /* Resolve theme spacing token → actual CSS length */
+  /* Resolve number → theme spacing */
   let gap: string;
   if (spacing === undefined) {
     gap = '0';
-  } else if (typeof spacing === 'string' && spacing in theme.spacing) {
-    gap = theme.spacing[spacing as keyof Theme['spacing']];
+  } else if (typeof spacing === 'number') {
+    gap = theme.spacing(spacing);
   } else {
     gap = String(spacing);
   }

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -42,7 +42,7 @@ interface StyledFieldProps {
 }
 
 const sharedFieldCSS = ({ theme, $error }: StyledFieldProps) => `
-  padding: ${theme.spacing(1)} ${theme.spacing(2)};
+  padding: ${theme.spacing(1)} ${theme.spacing(1)};
   border: 1px solid ${($error ? theme.colors.secondary : theme.colors.text) + '44'};
   border-radius: 4px;
   background: ${theme.colors.background};

--- a/src/components/TextField.tsx
+++ b/src/components/TextField.tsx
@@ -42,7 +42,7 @@ interface StyledFieldProps {
 }
 
 const sharedFieldCSS = ({ theme, $error }: StyledFieldProps) => `
-  padding: ${theme.spacing.sm} ${theme.spacing.md};
+  padding: ${theme.spacing(1)} ${theme.spacing(2)};
   border: 1px solid ${($error ? theme.colors.secondary : theme.colors.text) + '44'};
   border-radius: 4px;
   background: ${theme.colors.background};
@@ -67,7 +67,7 @@ const FieldTextarea = styled('textarea')<StyledFieldProps>`
 const Wrapper = styled('div')<{ theme: Theme }>`
   display: flex;
   flex-direction: column;
-  gap: ${({ theme }) => theme.spacing.sm};
+  gap: ${({ theme }) => theme.spacing(1)};
 `;
 
 const Label = styled('label')<{ theme: Theme }>`

--- a/src/system/themeStore.ts
+++ b/src/system/themeStore.ts
@@ -8,7 +8,10 @@ export type ThemeMode  = 'light' | 'dark';
 
 export interface Theme {
   colors: Record<string, string>;
-  spacing: Record<string, string>;
+  /** Returns a CSS length for the given number of spacing units */
+  spacing: (units: number) => string;
+  /** Base unit used by the spacing helper */
+  spacingUnit: string;
   breakpoints: Record<Breakpoint, number>;
   typography: Record<string, Record<Breakpoint, string>>;
   fonts: {
@@ -27,10 +30,11 @@ interface ThemeStore {
   setTheme: (patch: Partial<Theme>) => void;
 }
 
+const spacingUnit = '1rem';
+const unitSuffix = spacingUnit.replace(/^[0-9.]+/, '');
 const common: Omit<Theme, 'colors'> = {
-  spacing: {
-    xs: '0.25rem', sm: '0.5rem', md: '1rem', lg: '1.5rem', xl: '2rem',
-  },
+  spacing: (u: number) => `${u}${unitSuffix}`,
+  spacingUnit,
   breakpoints: {
     xs: 0, sm: 600, md: 960, lg: 1280, xl: 1920,
   },


### PR DESCRIPTION
## Summary
- refactor theme spacing to use numeric units
- update Stack spacing prop to accept numbers
- migrate components to the new spacing helper
- replace spacing tokens in documentation with numeric units

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864bde2d368832098885612dd1e506a