### PR TITLE
Update container defaults

### DIFF
--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -39,9 +39,13 @@ const useAccordion = () => {
 
 /*───────────────────────────────────────────────────────────*/
 /* Styled primitives                                         */
-const Root = styled('div')`
+const Root = styled('div')<{ $gap: string }>`
   width      : 100%;
   box-sizing : border-box;
+  margin     : ${({ $gap }) => $gap};
+  & > * {
+    padding: ${({ $gap }) => $gap};
+  }
 `;
 
 const ItemWrapper = styled('div')`
@@ -141,6 +145,7 @@ export const Accordion: React.FC<AccordionProps> & {
   children,
   ...divProps
 }) => {
+  const { theme } = useTheme();
   const controlled = openProp !== undefined;
   const toArray = (v?: number | number[]) =>
     v === undefined ? [] : Array.isArray(v) ? v : [v];
@@ -179,6 +184,7 @@ export const Accordion: React.FC<AccordionProps> & {
     <AccordionCtx.Provider value={ctx}>
       <Root
         {...divProps}
+        $gap={theme.spacing(1)}
         className={[presetClasses, className].filter(Boolean).join(' ')}
       >
         {React.Children.map(children, (child, idx) =>

--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -22,12 +22,17 @@ export interface AppBarProps
 const Bar = styled('header')<{
   $bg: string;
   $text: string;
+  $gap: string;
 }>`
   box-sizing: border-box;
   display: flex;
   align-items: center;
   justify-content: space-between;
+  margin: ${({ $gap }) => $gap};
   padding: 0.5rem 1rem;
+  & > * {
+    padding: ${({ $gap }) => $gap};
+  }
   position: fixed;
   top: 0;
   left: 0;
@@ -66,12 +71,14 @@ export const AppBar: React.FC<AppBarProps> = ({
       ? theme.colors[`${textColor}Text`]
       : textColor;
   const presetClass = p ? preset(p) : '';
+  const gap = theme.spacing(1);
 
   return (
     <Bar
       {...rest}
       $bg={bg}
       $text={text}
+      $gap={gap}
       className={[presetClass, className].filter(Boolean).join(' ')}
       style={style}
     >

--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -27,9 +27,15 @@ const Base = styled('div')<{
   $bg?: string;
   $text?: string;
   $center?: boolean;
+  $margin: string;
+  $pad: string;
 }>`
   box-sizing: border-box;
   display: ${({ $center }) => ($center ? 'flex' : 'block')};
+  margin: ${({ $margin }) => $margin};
+  & > * {
+    padding: ${({ $pad }) => $pad};
+  }
   ${({ $center }) =>
     $center &&
     `
@@ -73,12 +79,16 @@ export const Box: React.FC<BoxProps> = ({
         : undefined; // defer to cascade / presets
   }
 
+  const gap = theme.spacing(1);
+
   return (
     <Base
       {...rest}
       $bg={background}
       $text={resolvedText}
       $center={centered}
+      $margin={gap}
+      $pad={gap}
       style={style}
       className={[presetClass, className].filter(Boolean).join(' ')}
     />

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -17,10 +17,14 @@ export interface GridProps
 }
 
 /*───────────────────────────────────────────────────────────*/
-const Root = styled('div')<{ $cols: number; $gap: string }>`
+const Root = styled('div')<{ $cols: number; $gap: string; $pad: string }>`
   display: grid;
   grid-template-columns: repeat(${({ $cols }) => $cols}, 1fr);
   gap: ${({ $gap }) => $gap};
+  margin: ${({ $pad }) => $pad};
+  & > * {
+    padding: ${({ $pad }) => $pad};
+  }
 `;
 
 /*───────────────────────────────────────────────────────────*/
@@ -42,6 +46,8 @@ export const Grid: React.FC<GridProps> = ({
     g = String(gap);
   }
 
+  const pad = theme.spacing(1);
+
   const presetClass = p ? preset(p) : '';
 
   return (
@@ -49,6 +55,7 @@ export const Grid: React.FC<GridProps> = ({
       {...rest}
       $cols={columns}
       $gap={g}
+      $pad={pad}
       style={style}
       className={[presetClass, className].filter(Boolean).join(' ')}
     >

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -38,6 +38,7 @@ import React, {
     $fade: boolean;
     $maxW?: string | number;
     $full: boolean;
+    $gap: string;
   }>`
     position: fixed;
     top: 50%;
@@ -49,6 +50,10 @@ import React, {
   
     max-width: ${({ $maxW, $full }) => ($full ? 'none' : $maxW || '32rem')};
     width: ${({ $full }) => ($full ? 'calc(100% - 2rem)' : 'auto')};
+    margin: ${({ $gap }) => $gap};
+    & > * {
+      padding: ${({ $gap }) => $gap};
+    }
   
     background: ${({ $bg }) => $bg};
     color: ${({ $text }) => $text};
@@ -220,6 +225,7 @@ import React, {
           $fade={fade}
           $maxW={maxWidth as any}
           $full={fullWidth}
+          $gap={theme.spacing(1)}
           className={presetClasses}
         >
           {title && <Header id={idTitle}>{title}</Header>}

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -29,6 +29,7 @@ const Base = styled('div')<{
   $outline?: string;
   $bg?: string;
   $text?: string;
+  $gap: string;
 }>`
   box-sizing: border-box;
   vertical-align: top;
@@ -36,6 +37,10 @@ const Base = styled('div')<{
   display      : ${({ $full }) => ($full ? 'block' : 'inline-block')};
   width        : ${({ $full }) => ($full ? '100%'  : 'auto')};
   align-self   : ${({ $full }) => ($full ? 'stretch' : 'flex-start')};
+  margin       : ${({ $gap }) => $gap};
+  & > * {
+    padding: ${({ $gap }) => $gap};
+  }
 
   /* Only emit a background when we’ve actually been given one */
   ${({ $variant, $bg }) =>
@@ -98,6 +103,7 @@ export const Panel: React.FC<PanelProps> = ({
   }
 
   const presetClasses = p ? preset(p) : '';
+  const gap = theme.spacing(1);
 
   return (
     <Base
@@ -107,6 +113,7 @@ export const Panel: React.FC<PanelProps> = ({
       $outline={theme.colors.backgroundAlt}
       $bg={bg}
       $text={textColour}
+      $gap={gap}
       style={style}
       className={[presetClasses, className].filter(Boolean).join(' ')}
     >

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -27,11 +27,16 @@ const StackContainer = styled('div')<{
   $dir: 'row' | 'column';
   $gap: string;
   $wrap: boolean;
+  $pad: string;
 }>`
   display: flex;
   flex-direction: ${({ $dir }) => $dir};
   gap: ${({ $gap }) => $gap};
   ${({ $wrap }) => ($wrap ? 'flex-wrap: wrap;' : '')}
+  margin: ${({ $pad }) => $pad};
+  & > * {
+    padding: ${({ $pad }) => $pad};
+  }
 `;
 
 /*───────────────────────────────────────────────────────────*/
@@ -62,6 +67,7 @@ export const Stack: React.FC<StackProps> = ({
   const shouldWrap = typeof wrap === 'boolean' ? wrap : direction === 'row';
 
   const presetClasses = p ? preset(p) : '';
+  const pad = theme.spacing(1);
 
   return (
     <StackContainer
@@ -69,6 +75,7 @@ export const Stack: React.FC<StackProps> = ({
       $dir={direction}
       $gap={gap}
       $wrap={shouldWrap}
+      $pad={pad}
       className={[presetClasses, className].filter(Boolean).join(' ')}
       style={style}
     >

--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -122,6 +122,7 @@ export const Surface: React.FC<SurfaceProps> = ({
         overflow: 'auto',
       }
     : { width: '100%', height: 'auto', position: 'relative' };
+  const gap = theme.spacing(1);
 
   return (
     <SurfaceCtx.Provider value={useStore}>
@@ -134,6 +135,7 @@ export const Surface: React.FC<SurfaceProps> = ({
           ...cssVars,      // then fonts and other variables
           '--valet-screen-width': `${width}px`,
           '--valet-screen-height': `${Math.round(height)}px`,
+          margin: gap,
           ...style,        // finally allow external overrides
         } as any}
         {...props}
@@ -141,7 +143,7 @@ export const Surface: React.FC<SurfaceProps> = ({
         {showBackdrop && (
           <LoadingBackdrop fading={fade} showSpinner={showSpinner} />
         )}
-        <div style={{ visibility: fontsReady ? 'visible' : 'hidden' }}>{children}</div>
+        <div style={{ visibility: fontsReady ? 'visible' : 'hidden', padding: gap }}>{children}</div>
       </div>
     </SurfaceCtx.Provider>
   );

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -40,9 +40,14 @@ const useTabs = () => {
 const Root = styled('div')<{
   $orientation: 'horizontal' | 'vertical';
   $placement : 'top' | 'bottom' | 'left' | 'right';
+  $gap: string;
 }>`
   width: 100%;
   display: grid;
+  margin: ${({ $gap }) => $gap};
+  & > * {
+    padding: ${({ $gap }) => $gap};
+  }
 
   ${({ $orientation, $placement }) =>
     $orientation === 'horizontal'
@@ -162,6 +167,7 @@ export const Tabs: React.FC<TabsProps> & {
   children,
   ...divProps
 }) => {
+  const { theme } = useTheme();
   const placement =
     placementProp ?? (orientation === 'horizontal' ? 'top' : 'left');
 
@@ -206,6 +212,7 @@ export const Tabs: React.FC<TabsProps> & {
   );
 
   const cls = [p ? preset(p) : '', className].filter(Boolean).join(' ');
+  const gap = theme.spacing(1);
   const stripFirst =
     (orientation === 'horizontal' && placement === 'top') ||
     (orientation === 'vertical'   && placement === 'left');
@@ -216,6 +223,7 @@ export const Tabs: React.FC<TabsProps> & {
         {...divProps}
         $orientation={orientation}
         $placement={placement}
+        $gap={gap}
         className={cls}
       >
         {stripFirst && <TabList $orientation={orientation}>{tabs}</TabList>}


### PR DESCRIPTION
## Summary
- add margin and child padding defaults to container components
- wire up theme spacing for each container

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686590bfe6108320a729573a37af37b1