### PR TITLE
Add compact prop to containers

### DIFF
--- a/docs/src/pages/MainPage.tsx
+++ b/docs/src/pages/MainPage.tsx
@@ -10,8 +10,8 @@ export default function MainPage() {
     <Surface>
       <Typography variant="h1" centered><b>zeroui</b> Demo</Typography>
 
-      <Box centered style={{ margin: 0, padding: 0 }}>
-        <Stack style={{ margin: 0, padding: 0 }}>
+      <Box centered compact>
+        <Stack compact>
           <Panel variant="alt">
             <Typography variant="h2" centered>Components</Typography>
 
@@ -210,7 +210,7 @@ export default function MainPage() {
           <Panel>
             <Typography centered variant="h2">Demos</Typography>
 
-            <Stack direction="row" spacing={1} style={{ margin: 0, padding: 0 }}>
+            <Stack direction="row" spacing={1} compact>
               <Button
                 size="md"
                 onClick={() => navigate('/presets')}
@@ -241,7 +241,7 @@ export default function MainPage() {
             </Stack>
           </Panel>
 
-          <Box style={{margin: 0}}>
+          <Box compact>
             <Button
               size="lg"
               variant='outlined'

--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -19,6 +19,8 @@ export interface BoxProps
   textColor?: string | undefined;
   /** Centre contents & propagate intent via CSS var */
   centered?: boolean;
+  /** Remove built-in margin and padding */
+  compact?: boolean;
 }
 
 /*───────────────────────────────────────────────────────────────*/
@@ -60,6 +62,7 @@ export const Box: React.FC<BoxProps> = ({
   background,
   textColor,
   centered,
+  compact,
   style,
   ...rest
 }) => {
@@ -79,7 +82,7 @@ export const Box: React.FC<BoxProps> = ({
         : undefined; // defer to cascade / presets
   }
 
-  const gap = theme.spacing(1);
+  const gap = compact ? '0' : theme.spacing(1);
 
   return (
     <Base

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -19,6 +19,8 @@ export interface PanelProps
   fullWidth?: boolean;
   /** Explicit background override */
   background?: string | undefined;
+  /** Remove built-in margin and padding */
+  compact?: boolean;
 }
 
 /*───────────────────────────────────────────────────────────*/
@@ -71,6 +73,7 @@ export const Panel: React.FC<PanelProps> = ({
   className,
   style,
   background,
+  compact,
   children,
   ...rest
 }) => {
@@ -103,7 +106,7 @@ export const Panel: React.FC<PanelProps> = ({
   }
 
   const presetClasses = p ? preset(p) : '';
-  const gap = theme.spacing(1);
+  const gap = compact ? '0' : theme.spacing(1);
 
   return (
     <Base

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -19,6 +19,8 @@ export interface StackProps
   /** If `true`, children wrap when they run out of space. Defaults to
    *  `true` for `row`, `false` for `column`. */
   wrap?: boolean;
+  /** Remove built-in margin and padding */
+  compact?: boolean;
 }
 
 /*───────────────────────────────────────────────────────────*/
@@ -45,6 +47,7 @@ export const Stack: React.FC<StackProps> = ({
   direction = 'column',
   spacing,
   wrap,
+  compact,
   preset: p,
   className,
   children,
@@ -67,7 +70,7 @@ export const Stack: React.FC<StackProps> = ({
   const shouldWrap = typeof wrap === 'boolean' ? wrap : direction === 'row';
 
   const presetClasses = p ? preset(p) : '';
-  const pad = theme.spacing(1);
+  const pad = compact ? '0' : theme.spacing(1);
 
   return (
     <StackContainer


### PR DESCRIPTION
## Summary
- allow Box, Panel, and Stack to zero out default margin/padding via new `compact` prop
- clean up docs MainPage to use the new prop instead of inline styles

## Testing
- `npm run build`
- `npm run build` in `docs`

------
https://chatgpt.com/codex/tasks/task_e_6865a3cc57208320a65c17eddf266574