### PR TITLE
Configure Amplify for docs build

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,18 @@
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - cd docs
+        - npm ci
+    build:
+      commands:
+        - cd docs
+        - npm run build
+  artifacts:
+    baseDirectory: docs/dist
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - docs/node_modules/**/*


### PR DESCRIPTION
## Summary
- add `amplify.yml` so AWS Amplify builds the `docs` directory

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865d66d1c1483208d223f303ae7560e