### PR TITLE
Table auto-height patches

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -149,7 +149,7 @@ export function Table<T extends object>({
     const node = wrapRef.current;
     const surfEl = surface.element;
     if (!node || !surfEl) return;
-    const other = surfEl.scrollHeight - node.offsetHeight;
+    const other = surfEl.scrollHeight - node.scrollHeight;
     const available = surface.height - other;
     const cutoff = calcCutoff();
     if (available < cutoff) {


### PR DESCRIPTION
## Summary
- adapt Table height on resize
- cut off constrain mode below 2rem

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867023fd6b483208566ffa08f54e519