### PR TITLE
Table auto-height patches

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -135,8 +135,8 @@ export function Table<T extends object>({
   const wrapRef = useRef<HTMLDivElement>(null);
   const uniqueId = useId();
   const [maxHeight, setMaxHeight] = useState<number>();
-  const [shouldConstrain, setShouldConstrain] = useState(constrainHeight);
-  const constraintRef = useRef(constrainHeight);
+  const [shouldConstrain, setShouldConstrain] = useState(false);
+  const constraintRef = useRef(false);
 
   const calcCutoff = () => {
     if (typeof document === 'undefined') return 32;
@@ -176,12 +176,13 @@ export function Table<T extends object>({
       setShouldConstrain(false);
       setMaxHeight(undefined);
     } else {
-      constraintRef.current = true;
+      // fresh measurement will determine constraint state
+      constraintRef.current = false;
     }
   }, [constrainHeight]);
 
   useLayoutEffect(() => {
-    if (!constrainHeight || !wrapRef.current) return;
+    if (!constrainHeight || !wrapRef.current || !surface.element) return;
     const node = wrapRef.current;
     surface.registerChild(uniqueId, node, update);
     const ro = new ResizeObserver(update);
@@ -191,12 +192,12 @@ export function Table<T extends object>({
       surface.unregisterChild(uniqueId);
       ro.disconnect();
     };
-  }, [constrainHeight]);
+  }, [constrainHeight, surface.element]);
 
   useLayoutEffect(() => {
-    if (!constrainHeight || !wrapRef.current) return;
+    if (!constrainHeight || !wrapRef.current || !surface.element) return;
     update();
-  }, [constrainHeight, surface.height]);
+  }, [constrainHeight, surface.height, surface.element]);
 
   /* sort state */
   const [sort,setSort] =

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -2,7 +2,14 @@
 // src/components/Table.tsx  | valet
 // Row-hover highlight fixed and now more saturated hover colour.
 // ─────────────────────────────────────────────────────────────
-import React, { useMemo, useState, useEffect, useLayoutEffect, useRef, useId } from 'react';
+import React, {
+  useMemo,
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useId,
+} from 'react';
 import { styled }                 from '../css/createStyled';
 import { useTheme }               from '../system/themeStore';
 import { useSurface }             from '../system/surfaceStore';
@@ -127,33 +134,68 @@ export function Table<T extends object>({
   const surface = useSurface();
   const wrapRef = useRef<HTMLDivElement>(null);
   const uniqueId = useId();
-  const [maxHeight,setMaxHeight] = useState<number>();
+  const [maxHeight, setMaxHeight] = useState<number>();
+  const [shouldConstrain, setShouldConstrain] = useState(constrainHeight);
+  const constraintRef = useRef(constrainHeight);
 
-  useLayoutEffect(() => {
-    if (!constrainHeight || !wrapRef.current) return;
+  const calcCutoff = () => {
+    if (typeof document === 'undefined') return 32;
+    const fs = parseFloat(
+      getComputedStyle(document.documentElement).fontSize,
+    );
+    return (isNaN(fs) ? 16 : fs) * 2;
+  };
+
+  const update = () => {
     const node = wrapRef.current;
-    const update = () => {
-      const surfEl = surface.element;
-      if (!surfEl) return;
-      const other = surfEl.scrollHeight - node.offsetHeight;
-      const available = surface.height - other;
+    const surfEl = surface.element;
+    if (!node || !surfEl) return;
+    const other = surfEl.scrollHeight - node.offsetHeight;
+    const available = surface.height - other;
+    const cutoff = calcCutoff();
+
+    const next = available >= cutoff;
+    if (next) {
+      if (!constraintRef.current) {
+        surfEl.scrollTop = 0;
+        surfEl.scrollLeft = 0;
+      }
+      constraintRef.current = true;
+      setShouldConstrain(true);
       setMaxHeight(Math.max(0, available));
-    };
-    surface.registerChild(uniqueId, node, update);
-    update();
-    return () => {
-      surface.unregisterChild(uniqueId);
-    };
+    } else {
+      constraintRef.current = false;
+      setShouldConstrain(false);
+      setMaxHeight(undefined);
+    }
+  };
+
+  useEffect(() => {
+    if (!constrainHeight) {
+      constraintRef.current = false;
+      setShouldConstrain(false);
+      setMaxHeight(undefined);
+    } else {
+      constraintRef.current = true;
+    }
   }, [constrainHeight]);
 
   useLayoutEffect(() => {
     if (!constrainHeight || !wrapRef.current) return;
     const node = wrapRef.current;
-    const surfEl = surface.element;
-    if (!surfEl) return;
-    const other = surfEl.scrollHeight - node.offsetHeight;
-    const available = surface.height - other;
-    setMaxHeight(Math.max(0, available));
+    surface.registerChild(uniqueId, node, update);
+    const ro = new ResizeObserver(update);
+    ro.observe(node);
+    update();
+    return () => {
+      surface.unregisterChild(uniqueId);
+      ro.disconnect();
+    };
+  }, [constrainHeight]);
+
+  useLayoutEffect(() => {
+    if (!constrainHeight || !wrapRef.current) return;
+    update();
   }, [constrainHeight, surface.height]);
 
   /* sort state */
@@ -230,7 +272,7 @@ export function Table<T extends object>({
     <Wrapper
       ref={wrapRef}
       style={
-        constrainHeight
+        shouldConstrain
           ? { overflow: 'auto', maxHeight }
           : undefined
       }


### PR DESCRIPTION
## Summary
- adapt Table height on resize
- cut off constrain mode below 2rem
- reset page scroll when table reconstrains

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6867023fd6b483208566ffa08f54e519