### PR TITLE
Table auto-height patches

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -2,10 +2,17 @@
 // src/components/Table.tsx  | valet
 // Row-hover highlight fixed and now more saturated hover colour.
 // ─────────────────────────────────────────────────────────────
-import React, { useMemo, useState, useEffect, useLayoutEffect, useRef, useId } from 'react';
+import React, {
+  useMemo,
+  useState,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useId,
+} from 'react';
 import { styled }                 from '../css/createStyled';
 import { useTheme }               from '../system/themeStore';
-import { useSurface }             from '../system/surfaceStore';
+import { SurfaceCtx } from '../system/surfaceStore';
 import { preset }                 from '../css/stylePresets';
 import { Checkbox }               from './Checkbox';
 import { stripe, toRgb, mix, toHex } from '../helpers/color';
@@ -124,36 +131,83 @@ export function Table<T extends object>({
   ...rest
 }:TableProps<T>) {
   const { theme } = useTheme();
-  const surface = useSurface();
+  const surfaceStore = React.useContext(SurfaceCtx);
+  if (!surfaceStore)
+    throw new Error('Table must be used within a <Surface> component');
+  const surface = surfaceStore();
   const wrapRef = useRef<HTMLDivElement>(null);
   const uniqueId = useId();
-  const [maxHeight,setMaxHeight] = useState<number>();
+  const [maxHeight, setMaxHeight] = useState<number>();
+  const [shouldConstrain, setShouldConstrain] = useState(constrainHeight);
+  const constraintRef = useRef(constrainHeight);
 
-  useLayoutEffect(() => {
-    if (!constrainHeight || !wrapRef.current) return;
+  const calcCutoff = () => {
+    if (typeof document === 'undefined') return 32;
+    const fs = parseFloat(
+      getComputedStyle(document.documentElement).fontSize,
+    );
+    return (isNaN(fs) ? 16 : fs) * 2;
+  };
+
+  const update = () => {
     const node = wrapRef.current;
-    const update = () => {
-      const surfEl = surface.element;
-      if (!surfEl) return;
-      const other = surfEl.scrollHeight - node.offsetHeight;
-      const available = surface.height - other;
+    const surfEl = surface.element;
+    if (!node || !surfEl) return;
+    const other = surfEl.scrollHeight - node.offsetHeight;
+    const available = surface.height - other;
+    const cutoff = calcCutoff();
+
+    const next = available >= cutoff;
+    if (next) {
+      if (!constraintRef.current) {
+        surfEl.scrollTop = 0;
+        surfEl.scrollLeft = 0;
+      }
+      constraintRef.current = true;
+      setShouldConstrain(true);
       setMaxHeight(Math.max(0, available));
-    };
-    surface.registerChild(uniqueId, node, update);
-    update();
-    return () => {
-      surface.unregisterChild(uniqueId);
-    };
+    } else {
+      constraintRef.current = false;
+      setShouldConstrain(false);
+      setMaxHeight(undefined);
+    }
+  };
+
+  useEffect(() => {
+    if (!constrainHeight) {
+      constraintRef.current = false;
+      setShouldConstrain(false);
+      setMaxHeight(undefined);
+    } else {
+      constraintRef.current = true;
+    }
   }, [constrainHeight]);
 
   useLayoutEffect(() => {
     if (!constrainHeight || !wrapRef.current) return;
     const node = wrapRef.current;
-    const surfEl = surface.element;
-    if (!surfEl) return;
-    const other = surfEl.scrollHeight - node.offsetHeight;
-    const available = surface.height - other;
-    setMaxHeight(Math.max(0, available));
+    surface.registerChild(uniqueId, node, update);
+    const ro = new ResizeObserver(update);
+    ro.observe(node);
+    update();
+    return () => {
+      surface.unregisterChild(uniqueId);
+      ro.disconnect();
+    };
+  }, [constrainHeight]);
+
+  // When other children within the surface change size, recalc our height
+  useLayoutEffect(() => {
+    if (!constrainHeight) return;
+    const unsub = surfaceStore.subscribe((s, p) => {
+      if (s.children !== p.children) update();
+    });
+    return () => unsub();
+  }, [constrainHeight, surfaceStore]);
+
+  useLayoutEffect(() => {
+    if (!constrainHeight || !wrapRef.current) return;
+    update();
   }, [constrainHeight, surface.height]);
 
   /* sort state */
@@ -230,7 +284,7 @@ export function Table<T extends object>({
     <Wrapper
       ref={wrapRef}
       style={
-        constrainHeight
+        shouldConstrain
           ? { overflow: 'auto', maxHeight }
           : undefined
       }


### PR DESCRIPTION
## Summary
- adapt Table height on resize
- cut off constrain mode below 2rem
- reset page scroll when table reconstrains
- recalc table height when sibling elements resize

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6867023fd6b483208566ffa08f54e519