### PR TITLE
Update typography demo to use Table component

### DIFF
--- a/docs/src/pages/TypographyDemoPage.tsx
+++ b/docs/src/pages/TypographyDemoPage.tsx
@@ -6,12 +6,93 @@ import {
   Typography,
   Panel,
   Button,
+  Table,
   useTheme,
 } from '@archway/valet';
+import type { TableColumn } from '@archway/valet';
+import type { ReactNode } from 'react';
 
 export default function TypographyDemoPage() {
   const { theme, toggleMode } = useTheme();
   const navigate = useNavigate();
+
+  interface Row {
+    prop: ReactNode;
+    type: ReactNode;
+    default: ReactNode;
+    description: ReactNode;
+  }
+
+  const columns: TableColumn<Row>[] = [
+    { header: 'Prop', accessor: 'prop' },
+    { header: 'Type', accessor: 'type' },
+    { header: 'Default', accessor: 'default' },
+    { header: 'Description', accessor: 'description' },
+  ];
+
+  const data: Row[] = [
+    {
+      prop: <code>variant</code>,
+      type: <code>'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'body' | 'subtitle' | 'button'</code>,
+      default: <code>'body'</code>,
+      description: 'Typography style preset',
+    },
+    {
+      prop: <code>bold</code>,
+      type: <code>boolean</code>,
+      default: <code>false</code>,
+      description: 'Use font-weight\u00A0700',
+    },
+    {
+      prop: <code>italic</code>,
+      type: <code>boolean</code>,
+      default: <code>false</code>,
+      description: 'Use italic font style',
+    },
+    {
+      prop: <code>centered</code>,
+      type: <code>boolean</code>,
+      default: <code>false</code>,
+      description:
+        'Center-align text and element within flex/grid parents',
+    },
+    {
+      prop: <code>fontFamily</code>,
+      type: <code>string</code>,
+      default: '-',
+      description: 'Override theme font family',
+    },
+    {
+      prop: <code>fontSize</code>,
+      type: <code>string</code>,
+      default: '-',
+      description: 'Explicit CSS font-size',
+    },
+    {
+      prop: <code>scale</code>,
+      type: <code>number</code>,
+      default: '-',
+      description: 'Multiply the final size (autoSize aware)',
+    },
+    {
+      prop: <code>autoSize</code>,
+      type: <code>boolean</code>,
+      default: <code>false</code>,
+      description: 'Resize to the current breakpoint',
+    },
+    {
+      prop: <code>color</code>,
+      type: <code>string</code>,
+      default: '-',
+      description: 'Override text colour',
+    },
+    {
+      prop: <code>preset</code>,
+      type: <code>string | string[]</code>,
+      default: '-',
+      description: 'Apply style presets',
+    },
+  ];
 
   return (
     <Surface>
@@ -92,78 +173,7 @@ export default function TypographyDemoPage() {
         {/* 6. Prop reference ---------------------------------------------- */}
         <Typography variant="h3">6. Prop reference</Typography>
         <Panel style={{ padding: theme.spacing(1), overflowX: 'auto' }}>
-          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
-            <thead>
-              <tr>
-                <th align="left">Prop</th>
-                <th align="left">Type</th>
-                <th align="left">Default</th>
-                <th align="left">Description</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td><code>variant</code></td>
-                <td><code>'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'body' | 'subtitle' | 'button'</code></td>
-                <td><code>'body'</code></td>
-                <td>Typography style preset</td>
-              </tr>
-              <tr>
-                <td><code>bold</code></td>
-                <td><code>boolean</code></td>
-                <td><code>false</code></td>
-                <td>Use font-weight&nbsp;700</td>
-              </tr>
-              <tr>
-                <td><code>italic</code></td>
-                <td><code>boolean</code></td>
-                <td><code>false</code></td>
-                <td>Use italic font style</td>
-              </tr>
-              <tr>
-                <td><code>centered</code></td>
-                <td><code>boolean</code></td>
-                <td><code>false</code></td>
-                <td>Center-align text and element within flex/grid parents</td>
-              </tr>
-              <tr>
-                <td><code>fontFamily</code></td>
-                <td><code>string</code></td>
-                <td>-</td>
-                <td>Override theme font family</td>
-              </tr>
-              <tr>
-                <td><code>fontSize</code></td>
-                <td><code>string</code></td>
-                <td>-</td>
-                <td>Explicit CSS font-size</td>
-              </tr>
-              <tr>
-                <td><code>scale</code></td>
-                <td><code>number</code></td>
-                <td>-</td>
-                <td>Multiply the final size (autoSize aware)</td>
-              </tr>
-              <tr>
-                <td><code>autoSize</code></td>
-                <td><code>boolean</code></td>
-                <td><code>false</code></td>
-                <td>Resize to the current breakpoint</td>
-              </tr>
-              <tr>
-                <td><code>color</code></td>
-                <td><code>string</code></td>
-                <td>-</td>
-                <td>Override text colour</td>
-              </tr>
-              <tr>
-                <td><code>preset</code></td>
-                <td><code>string | string[]</code></td>
-                <td>-</td>
-                <td>Apply style presets</td>
-              </tr>
-            </tbody>
-          </table>
+          <Table data={data} columns={columns} style={{ minWidth: 640 }} />
         </Panel>
 
         {/* Back nav --------------------------------------------------------- */}

--- a/docs/src/pages/TypographyDemoPage.tsx
+++ b/docs/src/pages/TypographyDemoPage.tsx
@@ -107,7 +107,7 @@ export default function TypographyDemoPage() {
 
         {/* 1. Variants ------------------------------------------------------ */}
         <Typography variant="h3">1. Variants</Typography>
-        <Panel style={{ padding: theme.spacing(1) }}>
+        <Panel>
           <Typography variant="h1">variant="h1"</Typography>
           <Typography variant="h2">variant="h2"</Typography>
           <Typography variant="h3">variant="h3"</Typography>
@@ -121,7 +121,10 @@ export default function TypographyDemoPage() {
 
         {/* 2. Styling props ------------------------------------------------- */}
         <Typography variant="h3">2. Styling props</Typography>
-        <Panel style={{ padding: theme.spacing(1) }}>
+        <Panel fullWidth>
+          <Typography variant="body">
+            (regular body text)
+          </Typography>
           <Typography variant="body" bold>
             bold
           </Typography>
@@ -138,7 +141,7 @@ export default function TypographyDemoPage() {
 
         {/* 3. Font & size overrides ---------------------------------------- */}
         <Typography variant="h3">3. Font &amp; size overrides</Typography>
-        <Panel style={{ padding: theme.spacing(1) }}>
+        <Panel>
           <Typography fontFamily="Poppins">fontFamily="Poppins"</Typography>
           <Typography fontSize="1.5rem">fontSize="1.5rem"</Typography>
           <Typography scale={1.25}>scale=1.25</Typography>
@@ -152,12 +155,12 @@ export default function TypographyDemoPage() {
 
         {/* 4. Colour override & adaptation --------------------------------- */}
         <Typography variant="h3">4. Colour override &amp; adaptation</Typography>
-        <Panel style={{ padding: theme.spacing(1) }}>
+        <Panel>
           <Typography color="#e91e63">color="#e91e63"</Typography>
-          <Panel background={theme.colors['primary']} style={{ padding: theme.spacing(1) }}>
+          <Panel background={theme.colors['primary']}>
             <Typography variant="h6">Inside Panel inherits text colour</Typography>
           </Panel>
-          <Button style={{ marginTop: theme.spacing(1) }}>
+          <Button>
             <Typography variant="button" bold>
               Typography inside Button
             </Typography>
@@ -172,9 +175,7 @@ export default function TypographyDemoPage() {
 
         {/* 6. Prop reference ---------------------------------------------- */}
         <Typography variant="h3">6. Prop reference</Typography>
-        <Panel style={{ padding: theme.spacing(1), overflowX: 'auto' }}>
-          <Table data={data} columns={columns} style={{ minWidth: 640 }} />
-        </Panel>
+        <Table data={data} columns={columns} dividers striped />
 
         {/* Back nav --------------------------------------------------------- */}
         <Button


### PR DESCRIPTION
## Summary
- use valet Table on the Typography demo page

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68671c9265148320857c8f1672cebf79