### PR TITLE
Fix Valet casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Because valet is React-based, ensure your build process already handles
 
 ## Playground
 
-You can try every component in the [Valet Docs](https://github.com/off-court-creations/valet/tree/main/docs). ([Live Demo!](https://main.db2j7e5kim3gg.amplifyapp.com/)) Clone that repository and run:
+You can try every component in the [valet Docs](https://github.com/off-court-creations/valet/tree/main/docs). ([Live Demo!](https://main.db2j7e5kim3gg.amplifyapp.com/)) Clone that repository and run:
 
 ```shell
 npm install
@@ -83,7 +83,7 @@ npm run dev
 
 ## Components
 
-These have been mostly tested in the [Valet Docs](https://github.com/off-court-creations/valet/tree/main/docs). ([Live Demo!](https://main.db2j7e5kim3gg.amplifyapp.com/))
+These have been mostly tested in the [valet Docs](https://github.com/off-court-creations/valet/tree/main/docs). ([Live Demo!](https://main.db2j7e5kim3gg.amplifyapp.com/))
 
 | Component     | QC0 💻 | QC0 📱 | 1.0.0? 💻📱 | Style QC0 💻 | Style QC0 📱 | Comments                   |
 |---------------|:------:|:-------:|:------------:|:-------------|:-------------:|----------------------------|

--- a/docs/src/main.tsx
+++ b/docs/src/main.tsx
@@ -1,6 +1,6 @@
 // ─────────────────────────────────────────────────────────────
 // src/main.tsx
-// Bootstraps React + Valet, *plus* eagerly registers presets.
+// Bootstraps React + valet, *plus* eagerly registers presets.
 // ─────────────────────────────────────────────────────────────
 import React            from 'react';
 import ReactDOM         from 'react-dom/client';

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -1,6 +1,6 @@
 // ─────────────────────────────────────────────────────────────
 // src/components/Tabs.tsx | valet
-// Grid-based Valet <Tabs> — bullet-proof placement: top / bottom / left / right
+// Grid-based valet <Tabs> — bullet-proof placement: top / bottom / left / right
 // ─────────────────────────────────────────────────────────────
 import React, {
   createContext,

--- a/src/css/createStyled.ts
+++ b/src/css/createStyled.ts
@@ -1,6 +1,6 @@
 // ─────────────────────────────────────────────────────────────
 // src/css/createStyled.ts | valet
-// Tiny CSS-in-JS helper powering Valet primitives. Now exports `styled` +
+// Tiny CSS-in-JS helper powering valet primitives. Now exports `styled` +
 // `keyframes`, giving our components Emotion-style animation ergonomics.
 //
 // • Atomic – each unique rule hashed → single class / keyframes injection


### PR DESCRIPTION
## Summary
- fix incorrect brand casing in docs and comments

## Testing
- `npm run lint` *(fails: couldn't find an ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_686731dc77f08320986bfd2332ba1075