### PR TITLE
Default Table stripes and dividers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file. The format 
 ### Improved
 - Typography `autoSize` functionality
 - Stack default padding / margins
+### Changed
+- `Table` now defaults to striped rows and column dividers
 
 ## [v0.7.2]
 ### Changed

--- a/docs/src/pages/TableDemo.tsx
+++ b/docs/src/pages/TableDemo.tsx
@@ -71,7 +71,7 @@ export default function TableDemoPage() {
   const [rows,        setRows]        = useState(30);
   const [striped,     setStriped]     = useState(true);
   const [hoverable,   setHoverable]   = useState(true);
-  const [dividers,    setDividers]    = useState(false);
+  const [dividers,    setDividers]    = useState(true);
   const [selEnabled,  setSelEnabled]  = useState(false);
   const [multiSelect, setMultiSelect] = useState(false);
 

--- a/docs/src/pages/TypographyDemoPage.tsx
+++ b/docs/src/pages/TypographyDemoPage.tsx
@@ -175,7 +175,7 @@ export default function TypographyDemoPage() {
 
         {/* 6. Prop reference ---------------------------------------------- */}
         <Typography variant="h3">6. Prop reference</Typography>
-        <Table data={data} columns={columns} dividers striped />
+        <Table data={data} columns={columns} />
 
         {/* Back nav --------------------------------------------------------- */}
         <Button

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -117,9 +117,9 @@ const Td = styled('td')<{ $align:'left'|'center'|'right' }>`
 export function Table<T extends object>({
   data,
   columns,
-  striped=false,
+  striped=true,
   hoverable=false,
-  dividers=false,
+  dividers=true,
   selectable,
   initialSort,
   onSortChange,


### PR DESCRIPTION
## Summary
- switch Table defaults for `striped` and `dividers` to true
- update Table demo to reflect defaults
- note change in changelog

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686738d86c5483209d580a80a827e6f9