### PR TITLE
Improve Tabs style alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Improved
 - Typography `autoSize` functionality
 - Stack default padding / margins
+- Tabs alignment and docs typography page now uses tabs for intro and reference
 ### Changed
 - `Table` now defaults to striped rows and column dividers
 

--- a/docs/src/pages/TypographyDemoPage.tsx
+++ b/docs/src/pages/TypographyDemoPage.tsx
@@ -7,6 +7,7 @@ import {
   Panel,
   Button,
   Table,
+  Tabs,
   useTheme,
 } from '@archway/valet';
 import type { TableColumn } from '@archway/valet';
@@ -105,77 +106,85 @@ export default function TypographyDemoPage() {
           Variants, font tweaks and theme coupling
         </Typography>
 
-        {/* 1. Variants ------------------------------------------------------ */}
-        <Typography variant="h3">1. Variants</Typography>
-        <Panel>
-          <Typography variant="h1">variant="h1"</Typography>
-          <Typography variant="h2">variant="h2"</Typography>
-          <Typography variant="h3">variant="h3"</Typography>
-          <Typography variant="h4">variant="h4"</Typography>
-          <Typography variant="h5">variant="h5"</Typography>
-          <Typography variant="h6">variant="h6"</Typography>
-          <Typography variant="subtitle">variant="subtitle"</Typography>
-          <Typography variant="body">variant="body"</Typography>
-          <Typography variant="button">variant="button"</Typography>
-        </Panel>
+        <Tabs>
+          <Tabs.Tab label="Introduction" />
+          <Tabs.Panel>
+            {/* 1. Variants -------------------------------------------------- */}
+            <Typography variant="h3">1. Variants</Typography>
+            <Panel>
+              <Typography variant="h1">variant="h1"</Typography>
+              <Typography variant="h2">variant="h2"</Typography>
+              <Typography variant="h3">variant="h3"</Typography>
+              <Typography variant="h4">variant="h4"</Typography>
+              <Typography variant="h5">variant="h5"</Typography>
+              <Typography variant="h6">variant="h6"</Typography>
+              <Typography variant="subtitle">variant="subtitle"</Typography>
+              <Typography variant="body">variant="body"</Typography>
+              <Typography variant="button">variant="button"</Typography>
+            </Panel>
 
-        {/* 2. Styling props ------------------------------------------------- */}
-        <Typography variant="h3">2. Styling props</Typography>
-        <Panel fullWidth>
-          <Typography variant="body">
-            (regular body text)
-          </Typography>
-          <Typography variant="body" bold>
-            bold
-          </Typography>
-          <Typography variant="body" italic>
-            italic
-          </Typography>
-          <Typography variant="body" bold italic>
-            bold italic
-          </Typography>
-          <Typography variant="body" centered>
-            centered text
-          </Typography>
-        </Panel>
+            {/* 2. Styling props ------------------------------------------- */}
+            <Typography variant="h3">2. Styling props</Typography>
+            <Panel fullWidth>
+              <Typography variant="body">
+                (regular body text)
+              </Typography>
+              <Typography variant="body" bold>
+                bold
+              </Typography>
+              <Typography variant="body" italic>
+                italic
+              </Typography>
+              <Typography variant="body" bold italic>
+                bold italic
+              </Typography>
+              <Typography variant="body" centered>
+                centered text
+              </Typography>
+            </Panel>
 
-        {/* 3. Font & size overrides ---------------------------------------- */}
-        <Typography variant="h3">3. Font &amp; size overrides</Typography>
-        <Panel>
-          <Typography fontFamily="Poppins">fontFamily="Poppins"</Typography>
-          <Typography fontSize="1.5rem">fontSize="1.5rem"</Typography>
-          <Typography scale={1.25}>scale=1.25</Typography>
-          <Typography autoSize scale={1.25}>
-            autoSize + scale (resize viewport)
-          </Typography>
-          <Typography variant="body" autoSize>
-            autoSize
-          </Typography>
-        </Panel>
+            {/* 3. Font & size overrides ---------------------------------- */}
+            <Typography variant="h3">3. Font &amp; size overrides</Typography>
+            <Panel>
+              <Typography fontFamily="Poppins">fontFamily="Poppins"</Typography>
+              <Typography fontSize="1.5rem">fontSize="1.5rem"</Typography>
+              <Typography scale={1.25}>scale=1.25</Typography>
+              <Typography autoSize scale={1.25}>
+                autoSize + scale (resize viewport)
+              </Typography>
+              <Typography variant="body" autoSize>
+                autoSize
+              </Typography>
+            </Panel>
 
-        {/* 4. Colour override & adaptation --------------------------------- */}
-        <Typography variant="h3">4. Colour override &amp; adaptation</Typography>
-        <Panel>
-          <Typography color="#e91e63">color="#e91e63"</Typography>
-          <Panel background={theme.colors['primary']}>
-            <Typography variant="h6">Inside Panel inherits text colour</Typography>
-          </Panel>
-          <Button>
-            <Typography variant="button" bold>
-              Typography inside Button
-            </Typography>
-          </Button>
-        </Panel>
+            {/* 4. Colour override & adaptation --------------------------- */}
+            <Typography variant="h3">4. Colour override &amp; adaptation</Typography>
+            <Panel>
+              <Typography color="#e91e63">color="#e91e63"</Typography>
+              <Panel background={theme.colors['primary']}>
+                <Typography variant="h6">Inside Panel inherits text colour</Typography>
+              </Panel>
+              <Button>
+                <Typography variant="button" bold>
+                  Typography inside Button
+                </Typography>
+              </Button>
+            </Panel>
 
-        {/* 5. Theme coupling ----------------------------------------------- */}
-        <Typography variant="h3">5. Theme coupling</Typography>
-        <Button variant="outlined" onClick={toggleMode}>
-          Toggle light / dark mode
-        </Button>
+            {/* 5. Theme coupling ----------------------------------------- */}
+            <Typography variant="h3">5. Theme coupling</Typography>
+            <Button variant="outlined" onClick={toggleMode}>
+              Toggle light / dark mode
+            </Button>
+          </Tabs.Panel>
 
-        {/* 6. Prop reference ---------------------------------------------- */}
-        <Typography variant="h3">6. Prop reference</Typography>
-        <Table data={data} columns={columns} />
+          <Tabs.Tab label="Reference" />
+          <Tabs.Panel>
+            {/* 6. Prop reference ------------------------------------------ */}
+            <Typography variant="h3">6. Prop reference</Typography>
+            <Table data={data} columns={columns} />
+          </Tabs.Panel>
+        </Tabs>
 
         {/* Back nav --------------------------------------------------------- */}
         <Button

--- a/docs/src/pages/TypographyDemoPage.tsx
+++ b/docs/src/pages/TypographyDemoPage.tsx
@@ -97,7 +97,7 @@ export default function TypographyDemoPage() {
 
   return (
     <Surface>
-      <Stack spacing={1} preset="showcaseStack">
+      <Stack compact>
         {/* Page header ----------------------------------------------------- */}
         <Typography variant="h2" bold>
           Typography Showcase
@@ -110,7 +110,7 @@ export default function TypographyDemoPage() {
           <Tabs.Tab label="Introduction" />
           <Tabs.Panel>
             {/* 1. Variants -------------------------------------------------- */}
-            <Typography variant="h3">1. Variants</Typography>
+            <Typography variant="h3">Variants</Typography>
             <Panel>
               <Typography variant="h1">variant="h1"</Typography>
               <Typography variant="h2">variant="h2"</Typography>
@@ -124,7 +124,7 @@ export default function TypographyDemoPage() {
             </Panel>
 
             {/* 2. Styling props ------------------------------------------- */}
-            <Typography variant="h3">2. Styling props</Typography>
+            <Typography variant="h3">Styling props</Typography>
             <Panel fullWidth>
               <Typography variant="body">
                 (regular body text)
@@ -144,7 +144,7 @@ export default function TypographyDemoPage() {
             </Panel>
 
             {/* 3. Font & size overrides ---------------------------------- */}
-            <Typography variant="h3">3. Font &amp; size overrides</Typography>
+            <Typography variant="h3">Font &amp; size overrides</Typography>
             <Panel>
               <Typography fontFamily="Poppins">fontFamily="Poppins"</Typography>
               <Typography fontSize="1.5rem">fontSize="1.5rem"</Typography>
@@ -158,7 +158,7 @@ export default function TypographyDemoPage() {
             </Panel>
 
             {/* 4. Colour override & adaptation --------------------------- */}
-            <Typography variant="h3">4. Colour override &amp; adaptation</Typography>
+            <Typography variant="h3">Color override &amp; adaptation</Typography>
             <Panel>
               <Typography color="#e91e63">color="#e91e63"</Typography>
               <Panel background={theme.colors['primary']}>
@@ -172,7 +172,7 @@ export default function TypographyDemoPage() {
             </Panel>
 
             {/* 5. Theme coupling ----------------------------------------- */}
-            <Typography variant="h3">5. Theme coupling</Typography>
+            <Typography variant="h3">Theme coupling</Typography>
             <Button variant="outlined" onClick={toggleMode}>
               Toggle light / dark mode
             </Button>
@@ -181,8 +181,8 @@ export default function TypographyDemoPage() {
           <Tabs.Tab label="Reference" />
           <Tabs.Panel>
             {/* 6. Prop reference ------------------------------------------ */}
-            <Typography variant="h3">6. Prop reference</Typography>
-            <Table data={data} columns={columns} />
+            <Typography variant="h3">Prop reference</Typography>
+            <Table data={data} columns={columns} constrainHeight={false}/>
           </Tabs.Panel>
         </Tabs>
 

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -45,9 +45,8 @@ const Root = styled('div')<{
   width: 100%;
   display: grid;
   margin: ${({ $gap }) => $gap};
-  & > * {
-    padding: ${({ $gap }) => $gap};
-  }
+  gap: ${({ $gap }) => $gap};
+  & > * { padding: 0; }
 
   ${({ $orientation, $placement }) =>
     $orientation === 'horizontal'
@@ -77,7 +76,9 @@ const TabList = styled('div')<{
   display: flex;
   flex-direction: ${({ $orientation }) =>
     $orientation === 'vertical' ? 'column' : 'row'};
-  gap: 0;
+  gap: ${({ $orientation }) =>
+    $orientation === 'vertical' ? '0.25rem' : '0'};
+  align-items: stretch;
 
   ${({ $orientation }) =>
     $orientation === 'vertical' && 'width: max-content;'}
@@ -90,11 +91,12 @@ const TabBtn = styled('button')<{
   $primary : string;
   $orient  : 'horizontal' | 'vertical';
 }>`
+  box-sizing: border-box;
   background: transparent;
   border: none;
   color: inherit;
   font: inherit;
-  padding: 0.75rem 1.25rem;
+  padding: 0.5rem 0.75rem;
   cursor: pointer;
   appearance: none;
 
@@ -102,9 +104,12 @@ const TabBtn = styled('button')<{
   touch-action: manipulation;
 
   ${({ $orient }) =>
-    $orient === 'vertical' ? 'width: 100%;' : 'min-width: 4rem;'}
+    $orient === 'vertical' ? 'width: 100%;' : 'min-width: 3rem;'}
 
   position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   text-align: center;
 
   &:focus-visible {
@@ -117,15 +122,15 @@ const TabBtn = styled('button')<{
     position: absolute;
     ${({ $orient }) =>
       $orient === 'horizontal'
-        ? `left: 0; right: 0; bottom: -1px; height: 2px;`
-        : `top: 0; bottom: 0; right: -1px; width: 2px;`}
+        ? `left: 0; right: 0; bottom: 0; height: 2px;`
+        : `top: 0; bottom: 0; right: 0; width: 2px;`}
     background: ${({ $primary, $active }) => ($active ? $primary : 'transparent')};
     transition: background 150ms ease;
   }
 `;
 
 const Panel = styled('div')`
-  padding: 1rem 0;
+  padding: 0.75rem 0;
   overflow: hidden;
 `;
 


### PR DESCRIPTION
## Summary
- compact the Tabs layout and tighten gaps
- center tab labels and tweak active indicator position

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6867549b39e48320954a8f4dd1822247