### PR TITLE
Fix scroll on Typography reference panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file. The format 
 ### Improved
 - Typography `autoSize` functionality
 - Stack default padding / margins
+- Tabs alignment and docs typography page now uses tabs for intro and reference
+### Fixed
+- Reference tab on Typography demo no longer shows a tiny scrollbar
+- Tab panels scale to content height so switching tabs doesn't scroll
+- Tabs no longer add a bottom margin, preventing stray scrollbars
 ### Changed
 - `Table` now defaults to striped rows and column dividers
 

--- a/docs/src/pages/TypographyDemoPage.tsx
+++ b/docs/src/pages/TypographyDemoPage.tsx
@@ -7,6 +7,7 @@ import {
   Panel,
   Button,
   Table,
+  Tabs,
   useTheme,
 } from '@archway/valet';
 import type { TableColumn } from '@archway/valet';
@@ -105,77 +106,85 @@ export default function TypographyDemoPage() {
           Variants, font tweaks and theme coupling
         </Typography>
 
-        {/* 1. Variants ------------------------------------------------------ */}
-        <Typography variant="h3">1. Variants</Typography>
-        <Panel>
-          <Typography variant="h1">variant="h1"</Typography>
-          <Typography variant="h2">variant="h2"</Typography>
-          <Typography variant="h3">variant="h3"</Typography>
-          <Typography variant="h4">variant="h4"</Typography>
-          <Typography variant="h5">variant="h5"</Typography>
-          <Typography variant="h6">variant="h6"</Typography>
-          <Typography variant="subtitle">variant="subtitle"</Typography>
-          <Typography variant="body">variant="body"</Typography>
-          <Typography variant="button">variant="button"</Typography>
-        </Panel>
+        <Tabs style={{ marginBottom: theme.spacing(1) }}>
+          <Tabs.Tab label="Introduction" />
+          <Tabs.Panel>
+            {/* 1. Variants -------------------------------------------------- */}
+            <Typography variant="h3">1. Variants</Typography>
+            <Panel>
+              <Typography variant="h1">variant="h1"</Typography>
+              <Typography variant="h2">variant="h2"</Typography>
+              <Typography variant="h3">variant="h3"</Typography>
+              <Typography variant="h4">variant="h4"</Typography>
+              <Typography variant="h5">variant="h5"</Typography>
+              <Typography variant="h6">variant="h6"</Typography>
+              <Typography variant="subtitle">variant="subtitle"</Typography>
+              <Typography variant="body">variant="body"</Typography>
+              <Typography variant="button">variant="button"</Typography>
+            </Panel>
 
-        {/* 2. Styling props ------------------------------------------------- */}
-        <Typography variant="h3">2. Styling props</Typography>
-        <Panel fullWidth>
-          <Typography variant="body">
-            (regular body text)
-          </Typography>
-          <Typography variant="body" bold>
-            bold
-          </Typography>
-          <Typography variant="body" italic>
-            italic
-          </Typography>
-          <Typography variant="body" bold italic>
-            bold italic
-          </Typography>
-          <Typography variant="body" centered>
-            centered text
-          </Typography>
-        </Panel>
+            {/* 2. Styling props ------------------------------------------- */}
+            <Typography variant="h3">2. Styling props</Typography>
+            <Panel fullWidth>
+              <Typography variant="body">
+                (regular body text)
+              </Typography>
+              <Typography variant="body" bold>
+                bold
+              </Typography>
+              <Typography variant="body" italic>
+                italic
+              </Typography>
+              <Typography variant="body" bold italic>
+                bold italic
+              </Typography>
+              <Typography variant="body" centered>
+                centered text
+              </Typography>
+            </Panel>
 
-        {/* 3. Font & size overrides ---------------------------------------- */}
-        <Typography variant="h3">3. Font &amp; size overrides</Typography>
-        <Panel>
-          <Typography fontFamily="Poppins">fontFamily="Poppins"</Typography>
-          <Typography fontSize="1.5rem">fontSize="1.5rem"</Typography>
-          <Typography scale={1.25}>scale=1.25</Typography>
-          <Typography autoSize scale={1.25}>
-            autoSize + scale (resize viewport)
-          </Typography>
-          <Typography variant="body" autoSize>
-            autoSize
-          </Typography>
-        </Panel>
+            {/* 3. Font & size overrides ---------------------------------- */}
+            <Typography variant="h3">3. Font &amp; size overrides</Typography>
+            <Panel>
+              <Typography fontFamily="Poppins">fontFamily="Poppins"</Typography>
+              <Typography fontSize="1.5rem">fontSize="1.5rem"</Typography>
+              <Typography scale={1.25}>scale=1.25</Typography>
+              <Typography autoSize scale={1.25}>
+                autoSize + scale (resize viewport)
+              </Typography>
+              <Typography variant="body" autoSize>
+                autoSize
+              </Typography>
+            </Panel>
 
-        {/* 4. Colour override & adaptation --------------------------------- */}
-        <Typography variant="h3">4. Colour override &amp; adaptation</Typography>
-        <Panel>
-          <Typography color="#e91e63">color="#e91e63"</Typography>
-          <Panel background={theme.colors['primary']}>
-            <Typography variant="h6">Inside Panel inherits text colour</Typography>
-          </Panel>
-          <Button>
-            <Typography variant="button" bold>
-              Typography inside Button
-            </Typography>
-          </Button>
-        </Panel>
+            {/* 4. Colour override & adaptation --------------------------- */}
+            <Typography variant="h3">4. Colour override &amp; adaptation</Typography>
+            <Panel>
+              <Typography color="#e91e63">color="#e91e63"</Typography>
+              <Panel background={theme.colors['primary']}>
+                <Typography variant="h6">Inside Panel inherits text colour</Typography>
+              </Panel>
+              <Button>
+                <Typography variant="button" bold>
+                  Typography inside Button
+                </Typography>
+              </Button>
+            </Panel>
 
-        {/* 5. Theme coupling ----------------------------------------------- */}
-        <Typography variant="h3">5. Theme coupling</Typography>
-        <Button variant="outlined" onClick={toggleMode}>
-          Toggle light / dark mode
-        </Button>
+            {/* 5. Theme coupling ----------------------------------------- */}
+            <Typography variant="h3">5. Theme coupling</Typography>
+            <Button variant="outlined" onClick={toggleMode}>
+              Toggle light / dark mode
+            </Button>
+          </Tabs.Panel>
 
-        {/* 6. Prop reference ---------------------------------------------- */}
-        <Typography variant="h3">6. Prop reference</Typography>
-        <Table data={data} columns={columns} />
+          <Tabs.Tab label="Reference" />
+          <Tabs.Panel>
+            {/* 6. Prop reference ------------------------------------------ */}
+            <Typography variant="h3">6. Prop reference</Typography>
+            <Table data={data} columns={columns} constrainHeight={false} />
+          </Tabs.Panel>
+        </Tabs>
 
         {/* Back nav --------------------------------------------------------- */}
         <Button

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -44,21 +44,20 @@ const Root = styled('div')<{
 }>`
   width: 100%;
   display: grid;
-  margin: ${({ $gap }) => $gap};
-  & > * {
-    padding: ${({ $gap }) => $gap};
-  }
+  margin: ${({ $gap }) => `${$gap} 0 0`};
+  gap: ${({ $gap }) => $gap};
+  & > * { padding: 0; }
 
   ${({ $orientation, $placement }) =>
     $orientation === 'horizontal'
       ? `
     /* rows: tab-strip + panel */
-    grid-template-rows: ${$placement === 'top' ? 'auto 1fr' : '1fr auto'};
+    grid-template-rows: ${$placement === 'top' ? 'auto auto' : 'auto auto'};
   `
       : `
     /* cols: tab-strip + panel */
     grid-template-columns: ${
-      $placement === 'left' ? 'max-content 1fr' : '1fr max-content'
+      $placement === 'left' ? 'max-content auto' : 'auto max-content'
     };
     align-items: start; /* keep panel aligned to top of tabs */
   `}
@@ -77,7 +76,9 @@ const TabList = styled('div')<{
   display: flex;
   flex-direction: ${({ $orientation }) =>
     $orientation === 'vertical' ? 'column' : 'row'};
-  gap: 0;
+  gap: ${({ $orientation }) =>
+    $orientation === 'vertical' ? '0.25rem' : '0'};
+  align-items: stretch;
 
   ${({ $orientation }) =>
     $orientation === 'vertical' && 'width: max-content;'}
@@ -90,11 +91,12 @@ const TabBtn = styled('button')<{
   $primary : string;
   $orient  : 'horizontal' | 'vertical';
 }>`
+  box-sizing: border-box;
   background: transparent;
   border: none;
   color: inherit;
   font: inherit;
-  padding: 0.75rem 1.25rem;
+  padding: 0.5rem 0.75rem;
   cursor: pointer;
   appearance: none;
 
@@ -102,9 +104,12 @@ const TabBtn = styled('button')<{
   touch-action: manipulation;
 
   ${({ $orient }) =>
-    $orient === 'vertical' ? 'width: 100%;' : 'min-width: 4rem;'}
+    $orient === 'vertical' ? 'width: 100%;' : 'min-width: 3rem;'}
 
   position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   text-align: center;
 
   &:focus-visible {
@@ -117,15 +122,15 @@ const TabBtn = styled('button')<{
     position: absolute;
     ${({ $orient }) =>
       $orient === 'horizontal'
-        ? `left: 0; right: 0; bottom: -1px; height: 2px;`
-        : `top: 0; bottom: 0; right: -1px; width: 2px;`}
+        ? `left: 0; right: 0; bottom: 0; height: 2px;`
+        : `top: 0; bottom: 0; right: 0; width: 2px;`}
     background: ${({ $primary, $active }) => ($active ? $primary : 'transparent')};
     transition: background 150ms ease;
   }
 `;
 
 const Panel = styled('div')`
-  padding: 1rem 0;
+  padding: 0.75rem 0;
   overflow: hidden;
 `;
 


### PR DESCRIPTION
## Summary
- drop bottom margin from Tabs container
- keep margin on Typography tabs via inline style
- document margin fix in changelog

## Testing
- `npm run build`
- `(cd docs && npm run build)`


------
https://chatgpt.com/codex/tasks/task_e_6867549b39e48320954a8f4dd1822247