### PR TITLE
Fix tab panel overflow side effects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. The format 
 - `Table` now defaults to striped rows and column dividers
 ### Fixed
 - Tab panels no longer create stray scrollbars when tables are constrained
+- Table inside tab panels no longer oscillates in height
 
 ## [v0.7.2]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file. The format 
 - Stack default padding / margins
 ### Changed
 - `Table` now defaults to striped rows and column dividers
+### Fixed
+- Tab panels no longer create stray scrollbars when tables are constrained
 
 ## [v0.7.2]
 ### Changed

--- a/docs/src/pages/TypographyDemoPage.tsx
+++ b/docs/src/pages/TypographyDemoPage.tsx
@@ -173,7 +173,7 @@ export default function TypographyDemoPage() {
           <Tabs.Tab label="Reference" />
           <Tabs.Panel>
             <Typography variant="h3">Prop reference</Typography>
-            <Table data={data} columns={columns} constrainHeight={false}/>
+            <Table data={data} columns={columns} />
           </Tabs.Panel>
         </Tabs>
 

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -150,14 +150,11 @@ export function Table<T extends object>({
     const node = wrapRef.current;
     const surfEl = surface.element;
     if (!node || !surfEl) return;
-    let other = surfEl.scrollHeight - node.offsetHeight;
-    const parent = node.parentElement;
-    if (parent && typeof window !== 'undefined') {
-      const cs = getComputedStyle(parent);
-      other +=
-        (parseFloat(cs.marginTop) || 0) + (parseFloat(cs.marginBottom) || 0);
-    }
-    const available = surface.height - other;
+    const rect = node.getBoundingClientRect();
+    const surfRect = surfEl.getBoundingClientRect();
+    const top = rect.top - surfRect.top + surfEl.scrollTop;
+    const mb = parseFloat(getComputedStyle(node).marginBottom) || 0;
+    const available = Math.floor(surface.height - top - mb);
     const cutoff = calcCutoff();
 
     const next = available >= cutoff;

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -126,7 +126,6 @@ const TabBtn = styled('button')<{
 
 const Panel = styled('div')`
   padding: 1rem 0;
-  overflow: hidden;
 `;
 
 /*───────────────────────────────────────────────────────────*/


### PR DESCRIPTION
## Summary
- remove overflow hidden from Tabs panel container
- show table reference with default height
- document stray scrollbar fix in CHANGELOG

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686771a5c210832086831325c9381d3d