### PR TITLE
Fix tab panel table resize loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ All notable changes to this project will be documented in this file. The format 
 - Stack default padding / margins
 ### Changed
 - `Table` now defaults to striped rows and column dividers
+### Fixed
+- Tab panels no longer create stray scrollbars when tables are constrained
+- Table inside tab panels no longer oscillates in height
+- Full width panels inside tabs no longer overflow horizontally
+- Switching tabs with short content no longer leaves 1px scroll gaps
 
 ## [v0.7.2]
 ### Changed

--- a/docs/src/pages/TypographyDemoPage.tsx
+++ b/docs/src/pages/TypographyDemoPage.tsx
@@ -173,7 +173,7 @@ export default function TypographyDemoPage() {
           <Tabs.Tab label="Reference" />
           <Tabs.Panel>
             <Typography variant="h3">Prop reference</Typography>
-            <Table data={data} columns={columns} constrainHeight={false}/>
+            <Table data={data} columns={columns} />
           </Tabs.Panel>
         </Tabs>
 

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -39,7 +39,7 @@ const Base = styled('div')<{
   display      : ${({ $full }) => ($full ? 'block' : 'inline-block')};
   width        : ${({ $full }) => ($full ? '100%'  : 'auto')};
   align-self   : ${({ $full }) => ($full ? 'stretch' : 'flex-start')};
-  margin       : ${({ $gap }) => $gap};
+  margin       : ${({ $gap, $full }) => ($full ? `${$gap} 0` : $gap)};
   & > * {
     padding: ${({ $gap }) => $gap};
   }

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -150,14 +150,11 @@ export function Table<T extends object>({
     const node = wrapRef.current;
     const surfEl = surface.element;
     if (!node || !surfEl) return;
-    let other = surfEl.scrollHeight - node.offsetHeight;
-    const parent = node.parentElement;
-    if (parent && typeof window !== 'undefined') {
-      const cs = getComputedStyle(parent);
-      other +=
-        (parseFloat(cs.marginTop) || 0) + (parseFloat(cs.marginBottom) || 0);
-    }
-    const available = surface.height - other;
+    const rect = node.getBoundingClientRect();
+    const surfRect = surfEl.getBoundingClientRect();
+    const top = rect.top - surfRect.top + surfEl.scrollTop;
+    const mb = parseFloat(getComputedStyle(node).marginBottom) || 0;
+    const available = Math.floor(surface.height - top - mb);
     const cutoff = calcCutoff();
 
     const next = available >= cutoff;

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -42,6 +42,7 @@ const Root = styled('div')<{
   $placement : 'top' | 'bottom' | 'left' | 'right';
   $gap: string;
 }>`
+  box-sizing: border-box;
   width: 100%;
   display: grid;
   margin: ${({ $gap }) => $gap};
@@ -125,8 +126,9 @@ const TabBtn = styled('button')<{
 `;
 
 const Panel = styled('div')`
+  box-sizing: border-box;
+  overflow-x: hidden;
   padding: 1rem 0;
-  overflow: hidden;
 `;
 
 /*───────────────────────────────────────────────────────────*/


### PR DESCRIPTION
## Summary
- compute table space based on top offset instead of total scroll height
- remove overflow from tab panels and fix full width layout
- document stable table height and tab layout fixes in changelog

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686771a5c210832086831325c9381d3d