### PR TITLE
Update compact spacing behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file. The format 
 ### Improved
 - Typography `autoSize` functionality
 - Stack default padding / margins
+- compact prop for Stack, Box, Panel
+
 ### Changed
 - `Table` now defaults to striped rows and column dividers
 

--- a/docs/src/pages/TableDemo.tsx
+++ b/docs/src/pages/TableDemo.tsx
@@ -211,7 +211,7 @@ export default function TableDemoPage() {
             dividers={dividers}
             selectable={selectable}
             initialSort={{ index: 0 }}
-            style={{ minWidth: 640 }}
+            constrainHeight
           />
         </Panel>
 

--- a/docs/src/pages/TypographyDemoPage.tsx
+++ b/docs/src/pages/TypographyDemoPage.tsx
@@ -106,7 +106,7 @@ export default function TypographyDemoPage() {
           <Tabs.Tab label="Usage" />
           <Tabs.Panel>
             <Typography variant="h3">Variants</Typography>
-            <Panel>
+            <Panel compact>
               <Typography variant="h1">variant="h1"</Typography>
               <Typography variant="h2">variant="h2"</Typography>
               <Typography variant="h3">variant="h3"</Typography>
@@ -119,7 +119,7 @@ export default function TypographyDemoPage() {
             </Panel>
 
             <Typography variant="h3">Styling props</Typography>
-            <Panel fullWidth>
+            <Panel fullWidth compact>
               <Typography variant="body">
                 (regular body text)
               </Typography>
@@ -139,7 +139,7 @@ export default function TypographyDemoPage() {
 
             {/* 3. Font & size overrides ---------------------------------------- */}
             <Typography variant="h3">Font &amp; size overrides</Typography>
-            <Panel>
+            <Panel compact>
               <Typography fontFamily="Poppins">fontFamily="Poppins"</Typography>
               <Typography fontSize="1.5rem">fontSize="1.5rem"</Typography>
               <Typography scale={1.25}>scale=1.25</Typography>
@@ -152,7 +152,7 @@ export default function TypographyDemoPage() {
             </Panel>
 
             <Typography variant="h3">Colour override &amp; adaptation</Typography>
-            <Panel>
+            <Panel compact>
               <Typography color="#e91e63">color="#e91e63"</Typography>
               <Panel background={theme.colors['primary']}>
                 <Typography variant="h6">Inside Panel inherits text colour</Typography>

--- a/src/components/Box.tsx
+++ b/src/components/Box.tsx
@@ -82,7 +82,8 @@ export const Box: React.FC<BoxProps> = ({
         : undefined; // defer to cascade / presets
   }
 
-  const gap = compact ? '0' : theme.spacing(1);
+  const pad = theme.spacing(1);
+  const margin = compact ? '0' : pad;
 
   return (
     <Base
@@ -90,8 +91,8 @@ export const Box: React.FC<BoxProps> = ({
       $bg={background}
       $text={resolvedText}
       $center={centered}
-      $margin={gap}
-      $pad={gap}
+      $margin={margin}
+      $pad={pad}
       style={style}
       className={[presetClass, className].filter(Boolean).join(' ')}
     />

--- a/src/components/Panel.tsx
+++ b/src/components/Panel.tsx
@@ -31,7 +31,8 @@ const Base = styled('div')<{
   $outline?: string;
   $bg?: string;
   $text?: string;
-  $gap: string;
+  $margin: string;
+  $pad: string;
 }>`
   box-sizing: border-box;
   vertical-align: top;
@@ -39,9 +40,9 @@ const Base = styled('div')<{
   display      : ${({ $full }) => ($full ? 'block' : 'inline-block')};
   width        : ${({ $full }) => ($full ? '100%'  : 'auto')};
   align-self   : ${({ $full }) => ($full ? 'stretch' : 'flex-start')};
-  margin       : ${({ $gap }) => $gap};
+  margin       : ${({ $margin }) => $margin};
   & > * {
-    padding: ${({ $gap }) => $gap};
+    padding: ${({ $pad }) => $pad};
   }
 
   /* Only emit a background when we’ve actually been given one */
@@ -106,7 +107,8 @@ export const Panel: React.FC<PanelProps> = ({
   }
 
   const presetClasses = p ? preset(p) : '';
-  const gap = compact ? '0' : theme.spacing(1);
+  const pad = theme.spacing(1);
+  const margin = compact ? '0' : pad;
 
   return (
     <Base
@@ -116,7 +118,8 @@ export const Panel: React.FC<PanelProps> = ({
       $outline={theme.colors.backgroundAlt}
       $bg={bg}
       $text={textColour}
-      $gap={gap}
+      $margin={margin}
+      $pad={pad}
       style={style}
       className={[presetClasses, className].filter(Boolean).join(' ')}
     >

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -29,13 +29,14 @@ const StackContainer = styled('div')<{
   $dir: 'row' | 'column';
   $gap: string;
   $wrap: boolean;
+  $margin: string;
   $pad: string;
 }>`
   display: flex;
   flex-direction: ${({ $dir }) => $dir};
   gap: ${({ $gap }) => $gap};
   ${({ $wrap }) => ($wrap ? 'flex-wrap: wrap;' : '')}
-  margin: ${({ $pad }) => $pad};
+  margin: ${({ $margin }) => $margin};
   & > * {
     margin: ${({ $pad }) => $pad};
   }
@@ -70,7 +71,8 @@ export const Stack: React.FC<StackProps> = ({
   const shouldWrap = typeof wrap === 'boolean' ? wrap : direction === 'row';
 
   const presetClasses = p ? preset(p) : '';
-  const pad = compact ? '0' : theme.spacing(1);
+  const pad = theme.spacing(1);
+  const margin = compact ? '0' : pad;
 
   return (
     <StackContainer
@@ -78,6 +80,7 @@ export const Stack: React.FC<StackProps> = ({
       $dir={direction}
       $gap={gap}
       $wrap={shouldWrap}
+      $margin={margin}
       $pad={pad}
       className={[presetClasses, className].filter(Boolean).join(' ')}
       style={style}


### PR DESCRIPTION
## Summary
- remove the child spacing reduction when `compact` is set
- update Box, Panel and Stack components

## Testing
- `npm run build`
- `npm run build` in docs

------
https://chatgpt.com/codex/tasks/task_e_68677d4b073c832087f89888c0cb05f3