### PR TITLE
Fix doc tab overflow

### DIFF
--- a/src/components/Surface.tsx
+++ b/src/components/Surface.tsx
@@ -59,7 +59,7 @@ export const Surface: React.FC<SurfaceProps> = ({
       useStore.setState((s) => ({
         ...s,
         width: rect.width,
-        height: Math.round(rect.height),
+        height: rect.height,
         hasScrollbar:
           node.scrollHeight > node.clientHeight ||
           node.scrollWidth > node.clientWidth,

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -127,6 +127,7 @@ const TabBtn = styled('button')<{
 const Panel = styled('div')`
   padding: 1rem 0;
   overflow: hidden;
+  min-height: 0; /* prevent rounding overflow in parent grid */
 `;
 
 /*───────────────────────────────────────────────────────────*/

--- a/src/system/surfaceStore.ts
+++ b/src/system/surfaceStore.ts
@@ -44,7 +44,7 @@ export const createSurfaceStore = () =>
             const rect = entry.target.getBoundingClientRect()
             const metrics = {
               width: rect.width,
-              height: Math.round(rect.height),
+              height: rect.height,
               top: rect.top - sRect.top + scrollTop,
               left: rect.left - sRect.left + scrollLeft,
             }
@@ -77,7 +77,7 @@ export const createSurfaceStore = () =>
         const rect = node.getBoundingClientRect()
         const metrics = {
           width: rect.width,
-          height: Math.round(rect.height),
+          height: rect.height,
           top: rect.top - sRect.top + scrollTop,
           left: rect.left - sRect.left + scrollLeft,
         }


### PR DESCRIPTION
## Summary
- prevent rounding overflow in `<Tabs.Panel>`
- report more accurate surface sizes

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868173934e883208884fa69a33add0a