### PR TITLE
Fix tiny scroll in Typography reference tab

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -50,6 +50,7 @@ export interface TableProps<T>
 const Wrapper = styled('div')`
   width:100%;
   display:block;
+  box-sizing:border-box;
 `;
 const Root = styled('table')<{
   $striped:boolean; $hover:boolean; $lines:boolean;
@@ -57,6 +58,7 @@ const Root = styled('table')<{
 }>`
   width:100%;
   border-collapse:collapse;
+  box-sizing:border-box;
   border:1px solid ${({$border})=>$border};
 
   th,td{

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -126,7 +126,8 @@ const TabBtn = styled('button')<{
 
 const Panel = styled('div')`
   padding: 1rem 0;
-  overflow: hidden;
+  overflow: visible;
+  box-sizing: border-box;
 `;
 
 /*───────────────────────────────────────────────────────────*/


### PR DESCRIPTION
## Summary
- adjust Table wrapper and table boxes to use border-box sizing
- relax Tabs panel overflow rules so height matches content

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6868173934e883208884fa69a33add0a