### PR TITLE
Fix table constrain height loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file. The format 
 ### Changed
 - `Table` now defaults to striped rows and column dividers
 
+### Fixed
+- `Surface` updates overflow state when DOM changes
+- `Table` constrainHeight no longer shrinks continuously
+
 ## [v0.7.2]
 ### Changed
 - Main page of docs - Main page spacing styling

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -50,6 +50,7 @@ export interface TableProps<T>
 const Wrapper = styled('div')`
   width:100%;
   display:block;
+  box-sizing:border-box;
 `;
 const Root = styled('table')<{
   $striped:boolean; $hover:boolean; $lines:boolean;
@@ -57,6 +58,7 @@ const Root = styled('table')<{
 }>`
   width:100%;
   border-collapse:collapse;
+  box-sizing:border-box;
   border:1px solid ${({$border})=>$border};
 
   th,td{
@@ -150,7 +152,7 @@ export function Table<T extends object>({
     const node = wrapRef.current;
     const surfEl = surface.element;
     if (!node || !surfEl) return;
-    let other = surfEl.scrollHeight - node.offsetHeight;
+    let other = surfEl.scrollHeight - node.scrollHeight;
     const parent = node.parentElement;
     if (parent && typeof window !== 'undefined') {
       const cs = getComputedStyle(parent);

--- a/src/components/Tabs.tsx
+++ b/src/components/Tabs.tsx
@@ -126,7 +126,9 @@ const TabBtn = styled('button')<{
 
 const Panel = styled('div')`
   padding: 1rem 0;
-  overflow: hidden;
+  overflow: visible;
+  box-sizing: border-box;
+  min-height: 0;
 `;
 
 /*───────────────────────────────────────────────────────────*/
@@ -195,9 +197,13 @@ export const Tabs: React.FC<TabsProps> & {
     if (!React.isValidElement(child)) return;
     const name = (child.type as any).displayName;
     if (name === 'Tabs.Tab')
-      tabs.push(React.cloneElement(child, { index: tabs.length } as any));
+      tabs.push(
+        React.cloneElement(child, { index: tabs.length, key: tabs.length } as any),
+      );
     if (name === 'Tabs.Panel')
-      panels.push(React.cloneElement(child, { index: panels.length } as any));
+      panels.push(
+        React.cloneElement(child, { index: panels.length, key: panels.length } as any),
+      );
   });
 
   const ctx = useMemo<Ctx>(


### PR DESCRIPTION
## Summary
- stabilize Table constrainHeight by measuring other content against table scroll height
- document the fix in the changelog

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868173934e883208884fa69a33add0a