### PR TITLE
Add constrainHeight to accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Improved
 - Accordion chevron orientation and animation performance
+- Accordion can now constrain height with Surface
+
+### Fixed
+- Accordion constrained height now fills the available space within a Surface
+- Accordion no longer locks to collapsed height before expanding
 
 ## [v0.8.0]
 ### Improved

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -30,6 +30,7 @@ const TooltipDemoPage       = page(() => import('./pages/TooltipDemo'));
 const ModalDemoPage         = page(() => import('./pages/ModalDemo'));
 const SwitchDemoPage        = page(() => import('./pages/SwitchDemo'));
 const AccordionDemoPage     = page(() => import('./pages/AccordionDemo'));
+const AccordionConstrainedDemoPage = page(() => import('./pages/AccordionConstrainedDemo'));
 const TabsDemoPage          = page(() => import('./pages/TabsDemo'));
 const SliderDemoPage        = page(() => import('./pages/SliderDemo'));
 const ProgressDemoPage      = page(() => import('./pages/ProgressDemo'));
@@ -83,6 +84,10 @@ export function App() {
         <Route path="/modal-demo"      element={<ModalDemoPage />} />
         <Route path="/switch-demo"     element={<SwitchDemoPage />} />
         <Route path="/accordion-demo"  element={<AccordionDemoPage />} />
+        <Route
+          path="/accordion-constrained"
+          element={<AccordionConstrainedDemoPage />}
+        />
         <Route path="/tabs-demo"       element={<TabsDemoPage />} />
         <Route path="/slider-demo"     element={<SliderDemoPage />} />
         <Route path="/progress-demo"   element={<ProgressDemoPage />} />

--- a/docs/src/pages/AccordionConstrainedDemo.tsx
+++ b/docs/src/pages/AccordionConstrainedDemo.tsx
@@ -1,0 +1,45 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// src/pages/AccordionConstrainedDemo.tsx | valet
+// Demo for <Accordion> with constrainHeight enabled
+// ─────────────────────────────────────────────────────────────────────────────
+import {
+  Surface,
+  Stack,
+  Typography,
+  Accordion,
+  Button,
+  Panel,
+} from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+
+const LOREM =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse porta, nunc at egestas mattis, mauris risus iaculis mi, at cursus metus justo quis quam.';
+
+export default function AccordionConstrainedDemo() {
+  const navigate = useNavigate();
+
+  return (
+    <Surface>
+      <Stack spacing={1} preset="showcaseStack">
+        <Typography variant="h2" bold>
+          Constrained Accordion
+        </Typography>
+        <Typography>
+          Uses Surface child registration for automatic height
+        </Typography>
+        <Panel fullWidth>
+          <Accordion constrainHeight>
+            {Array.from({ length: 8 }, (_, i) => (
+              <Accordion.Item key={i} header={`Item ${i + 1}`}>
+                <Typography>{LOREM}</Typography>
+              </Accordion.Item>
+            ))}
+          </Accordion>
+        </Panel>
+        <Button size="lg" onClick={() => navigate('/accordion-demo')}>
+          ← Back
+        </Button>
+      </Stack>
+    </Surface>
+  );
+}

--- a/docs/src/pages/AccordionDemo.tsx
+++ b/docs/src/pages/AccordionDemo.tsx
@@ -45,6 +45,13 @@ export default function AccordionDemoPage() {
         <Typography>
           Smooth animations and unified chevron icons
         </Typography>
+        <Button
+          variant="outlined"
+          size="sm"
+          onClick={() => navigate('/accordion-constrained')}
+        >
+          Constrained height demo
+        </Button>
 
         {/* 1. Uncontrolled disclosure list (single item) ------------------ */}
         <Typography variant="h3">1. Uncontrolled (single-expand)</Typography>

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -15,11 +15,14 @@ import React, {
   useMemo,
   useLayoutEffect,
   useState,
+  useId,
+  useEffect,
 } from 'react';
 import { styled }               from '../css/createStyled';
 import { useTheme }             from '../system/themeStore';
 import { preset }               from '../css/stylePresets';
 import { toRgb, mix, toHex }    from '../helpers/color';
+import { useSurface }           from '../system/surfaceStore';
 import type { Presettable }     from '../types';
 
 /*───────────────────────────────────────────────────────────*/
@@ -47,6 +50,13 @@ const Root = styled('div')<{ $gap: string }>`
   & > * {
     padding: ${({ $gap }) => $gap};
   }
+`;
+
+const Wrapper = styled('div')`
+  width:100%;
+  display:block;
+  box-sizing:border-box;
+  min-height:0;
 `;
 
 const ItemWrapper = styled('div')`
@@ -122,6 +132,7 @@ export interface AccordionProps
   multiple?: boolean;
   onOpenChange?: (open: number[]) => void;
   headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+  constrainHeight?: boolean;
 }
 
 export interface AccordionItemProps
@@ -143,12 +154,19 @@ export const Accordion: React.FC<AccordionProps> & {
   multiple = false,
   onOpenChange,
   headingLevel = 3,
+  constrainHeight = true,
   preset: p,
   className,
   children,
   ...divProps
 }) => {
   const { theme } = useTheme();
+  const surface = useSurface();
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const uniqueId = useId();
+  const [maxHeight, setMaxHeight] = useState<number>();
+  const [shouldConstrain, setShouldConstrain] = useState(false);
+  const constraintRef = useRef(false);
   const controlled = openProp !== undefined;
   const toArray = (v?: number | number[]) =>
     v === undefined ? [] : Array.isArray(v) ? v : [v];
@@ -183,19 +201,91 @@ export const Accordion: React.FC<AccordionProps> & {
 
   const presetClasses = p ? preset(p) : '';
 
+  const calcCutoff = () => {
+    if (typeof document === 'undefined') return 32;
+    const fs = parseFloat(
+      getComputedStyle(document.documentElement).fontSize,
+    );
+    return (isNaN(fs) ? 16 : fs) * 2;
+  };
+
+  const update = () => {
+    const node = wrapRef.current;
+    const surfEl = surface.element;
+    if (!node || !surfEl) return;
+    const sRect = surfEl.getBoundingClientRect();
+    const nRect = node.getBoundingClientRect();
+    const top = Math.round(nRect.top - sRect.top + surfEl.scrollTop);
+    const bottomSpace = Math.round(
+      surfEl.scrollHeight - (nRect.bottom - sRect.top + surfEl.scrollTop),
+    );
+    const available = Math.round(surface.height - top - bottomSpace);
+    const cutoff = calcCutoff();
+
+    const needed = available >= cutoff && node.scrollHeight > available;
+    if (needed) {
+      if (!constraintRef.current) {
+        surfEl.scrollTop = 0;
+        surfEl.scrollLeft = 0;
+      }
+      constraintRef.current = true;
+      setShouldConstrain(true);
+      setMaxHeight(Math.max(0, available));
+    } else {
+      constraintRef.current = false;
+      setShouldConstrain(false);
+      setMaxHeight(undefined);
+    }
+  };
+
+  useEffect(() => {
+    if (!constrainHeight) {
+      constraintRef.current = false;
+      setShouldConstrain(false);
+      setMaxHeight(undefined);
+    } else {
+      constraintRef.current = false;
+    }
+  }, [constrainHeight]);
+
+  useLayoutEffect(() => {
+    if (!constrainHeight || !wrapRef.current || !surface.element) return;
+    const node = wrapRef.current;
+    surface.registerChild(uniqueId, node, update);
+    const ro = new ResizeObserver(update);
+    ro.observe(node);
+    update();
+    return () => {
+      surface.unregisterChild(uniqueId);
+      ro.disconnect();
+    };
+  }, [constrainHeight, surface.element]);
+
+  useLayoutEffect(() => {
+    if (!constrainHeight || !wrapRef.current || !surface.element) return;
+    update();
+  }, [constrainHeight, surface.height, surface.element]);
+
   return (
     <AccordionCtx.Provider value={ctx}>
-      <Root
-        {...divProps}
-        $gap={theme.spacing(1)}
-        className={[presetClasses, className].filter(Boolean).join(' ')}
+      <Wrapper
+        ref={wrapRef}
+        style={
+          shouldConstrain ? { overflow: 'auto', maxHeight } : undefined
+        }
       >
-        {React.Children.map(children, (child, idx) =>
-          React.isValidElement(child)
-            ? React.cloneElement(child as React.ReactElement<any>, { index: idx })
-            : child,
-        )}
-      </Root>
+        <Root
+          {...divProps}
+          $gap={theme.spacing(1)}
+          className={[presetClasses, className].filter(Boolean).join(' ')}
+        >
+          {React.Children.map(children, (child, idx) =>
+            React.isValidElement(child)
+              ? React.cloneElement(child as React.ReactElement<any>, { index: idx })
+              : child,
+          )}
+        </Root>
+      </Wrapper>
     </AccordionCtx.Provider>
   );
 };


### PR DESCRIPTION
## Summary
- allow Accordion to auto-constrain height within Surface like Table
- add constrained height demo page linking from the main Accordion demo
- fix constrained Accordion height by allowing flex shrink and wrapping it in Panel
- adjust Accordion constraint logic so it expands until space runs out

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b00a5d44c83209499cd97540bc4fe