### PR TITLE
Accordion ignores hover after touch

### DIFF
--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -97,7 +97,7 @@ const HeaderBtn = styled('button')<{
 
   /* Hover tint – only on devices that actually support hover */
   @media (hover: hover) {
-    &:hover:not(:disabled) {
+    &:hover:not(:disabled,[data-touch='true']) {
       background: ${({ $primary }) => `${$primary}11`};
     }
   }
@@ -365,27 +365,31 @@ const AccordionItem: React.FC<AccordionItemProps> = ({
           }}
           onPointerDown={(e) => {
             if (e.pointerType === 'touch') {
+              e.currentTarget.dataset.touch = 'true';
               longPressTimer.current = setTimeout(() => {
                 wasLongPress.current = true;
                 if (!disabled) toggle(index);
               }, 500);
             }
           }}
-          onPointerUp={() => {
+          onPointerUp={(e) => {
+            delete e.currentTarget.dataset.touch;
             if (longPressTimer.current) {
               clearTimeout(longPressTimer.current);
               longPressTimer.current = null;
             }
             wasLongPress.current = false;
           }}
-          onPointerLeave={() => {
+          onPointerLeave={(e) => {
+            delete e.currentTarget.dataset.touch;
             if (longPressTimer.current) {
               clearTimeout(longPressTimer.current);
               longPressTimer.current = null;
             }
             wasLongPress.current = false;
           }}
-          onPointerCancel={() => {
+          onPointerCancel={(e) => {
+            delete e.currentTarget.dataset.touch;
             if (longPressTimer.current) {
               clearTimeout(longPressTimer.current);
               longPressTimer.current = null;


### PR DESCRIPTION
## Summary
- stop hover highlight when activated via touch

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c00d2c2d88320bd448f8d4782ac77