### PR TITLE
Fix hover suppression on Windows touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## Unreleased
+### Fixed
+- Accordion hover suppression persists until pointer moves on Windows touchscreens
+
 ## [v0.8.1]
 ### Improved
 - Accordion chevron orientation and animation performance


### PR DESCRIPTION
## Summary
- maintain skipHover until the pointer moves or leaves
- document fix in Unreleased changelog

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c081a4ea4832084e332260882cac3