### PR TITLE
Stabilize Accordion height constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Unreleased
 ### Fixed
 - Accordion hover state now waits for pointer movement on Windows touchscreens
+- Accordion constrainHeight no longer flickers near the Surface's limits
 
 ## [v0.8.1]
 ### Improved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 - Accordion hover state now waits for pointer movement on Windows touchscreens
 - Accordion constrainHeight no longer flickers near the Surface's limits
+- Accordion now updates its available space when items open or close
 
 ## [v0.8.1]
 ### Improved

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -274,7 +274,7 @@ export const Accordion: React.FC<AccordionProps> & {
   useLayoutEffect(() => {
     if (!constrainHeight || !wrapRef.current || !surface.element) return;
     update();
-  }, [constrainHeight, surface.height, surface.element]);
+  }, [constrainHeight, open, surface.height, surface.element]);
 
   return (
     <AccordionCtx.Provider value={ctx}>

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -226,17 +226,13 @@ export const Accordion: React.FC<AccordionProps> & {
     const sRect = surfEl.getBoundingClientRect();
     const nRect = node.getBoundingClientRect();
     const top = Math.round(nRect.top - sRect.top + surfEl.scrollTop);
-    const hasAfterContent = surfEl.scrollHeight > surfEl.clientHeight;
-    const bottomSpace = hasAfterContent
-      ? Math.max(
-          0,
-          surfEl.scrollHeight - (nRect.bottom - sRect.top + surfEl.scrollTop),
-        )
-      : 0;
+    const bottomSpace = Math.round(
+      surfEl.scrollHeight - (nRect.bottom - sRect.top + surfEl.scrollTop),
+    );
     const available = Math.round(surface.height - top - bottomSpace);
     const cutoff = calcCutoff();
 
-    const shouldClamp = node.scrollHeight > available && available >= cutoff;
+    const shouldClamp = available >= cutoff;
     if (shouldClamp) {
       if (!constraintRef.current) {
         surfEl.scrollTop = 0;


### PR DESCRIPTION
## Summary
- stop Accordion resize loop by mirroring Table logic
- document fix in changelog

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686c0f72a9c483209e9f5a3a6bb8f3b9