### PR TITLE
Stabilize Accordion resizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file. The format 
 ## Unreleased
 ### Fixed
 - Accordion hover state now waits for pointer movement on Windows touchscreens
+- Accordion constrainHeight no longer flickers near the Surface's limits
+- Accordion expands fully when enough height is available
 
 ## [v0.8.1]
 ### Improved

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -226,17 +226,14 @@ export const Accordion: React.FC<AccordionProps> & {
     const sRect = surfEl.getBoundingClientRect();
     const nRect = node.getBoundingClientRect();
     const top = Math.round(nRect.top - sRect.top + surfEl.scrollTop);
-    const hasAfterContent = surfEl.scrollHeight > surfEl.clientHeight;
-    const bottomSpace = hasAfterContent
-      ? Math.max(
-          0,
-          surfEl.scrollHeight - (nRect.bottom - sRect.top + surfEl.scrollTop),
-        )
-      : 0;
+    const bottomSpace = Math.round(
+      surfEl.scrollHeight - (nRect.bottom - sRect.top + surfEl.scrollTop),
+    );
     const available = Math.round(surface.height - top - bottomSpace);
     const cutoff = calcCutoff();
 
-    const shouldClamp = node.scrollHeight > available && available >= cutoff;
+    const shouldClamp =
+      node.scrollHeight - available > 1 && available >= cutoff;
     if (shouldClamp) {
       if (!constraintRef.current) {
         surfEl.scrollTop = 0;


### PR DESCRIPTION
## Summary
- stop constraining Accordion when content fits within available space
- document dynamic resizing fix

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c0f72a9c483209e9f5a3a6bb8f3b9