### PR TITLE
Update radio gap

### DIFF
--- a/src/components/RadioGroup.tsx
+++ b/src/components/RadioGroup.tsx
@@ -44,8 +44,8 @@ const useRadioGroup = () => {
 /*───────────────────────────────────────────────────────────*/
 /* Size map helper                                           */
 const createSizeMap = (t: Theme) => ({
-  sm: { indicator: '16px', dot: '8px',  gapInner: t.spacing(0.5) },
-  md: { indicator: '20px', dot: '10px', gapInner: t.spacing(0.5) },
+  sm: { indicator: '16px', dot: '8px',  gapInner: t.spacing(0.75) },
+  md: { indicator: '20px', dot: '10px', gapInner: t.spacing(0.75) },
   lg: { indicator: '24px', dot: '12px', gapInner: t.spacing(1) },
 });
 


### PR DESCRIPTION
## Summary
- widen the spacing between radio indicator and text

## Testing
- `npm run build`
- `npm run build` in docs

------
https://chatgpt.com/codex/tasks/task_e_686c3975304c8320880100c5d7f22184