### PR TITLE
Fix accordion highlight width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 
 ## Unreleased
+### Fixed
+- Uniform highlight width on Accordion items
 
 ## [v0.8.2]
 ### Improved

--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -76,7 +76,7 @@ const HeaderBtn = styled('button')<{
   justify-content : space-between;
   align-items     : center;
   gap             : 1rem;
-  padding         : 1rem 0;
+  padding         : 1rem ${({ $shift }) => $shift};
   background      : transparent;
   border          : none;
   color           : inherit;
@@ -85,8 +85,8 @@ const HeaderBtn = styled('button')<{
   text-align      : left;
   appearance      : none;
   box-sizing      : border-box;
-  margin-inline-start : -${({ $shift }) => $shift};
-  padding-inline-start: ${({ $shift }) => $shift};
+  margin-inline-start: -${({ $shift }) => $shift};
+  margin-inline-end  : -${({ $shift }) => $shift};
 
   /* Disable blue tap-highlight & text selection on mobile */
   -webkit-tap-highlight-color: transparent;


### PR DESCRIPTION
## Summary
- adjust header margins to apply spacing on both ends
- note fix in changelog

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686d7d4f869c832985b62e95b9e59512