### PR TITLE
Add Avatar component

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -46,6 +46,7 @@ const StepperDemoPage       = page(() => import('./pages/StepperDemo'));
 const RadioGroupDemoPage    = page(() => import('./pages/RadioGroupDemo'));
 const VideoDemoPage         = page(() => import('./pages/VideoDemo'));
 const SnackbarDemoPage      = page(() => import('./pages/SnackbarDemo'));
+const AvatarDemoPage        = page(() => import('./pages/AvatarDemoPage'));
 
 /*───────────────────────────────────────────────────────────*/
 export function App() {
@@ -103,6 +104,7 @@ export function App() {
         <Route path="/radio-demo"      element={<RadioGroupDemoPage />} />
         <Route path="/video-demo"      element={<VideoDemoPage />} />
         <Route path="/snackbar-demo"   element={<SnackbarDemoPage />} />
+        <Route path="/avatar-demo"     element={<AvatarDemoPage />} />
       </Routes>
     </Suspense>
   );

--- a/docs/src/pages/AvatarDemoPage.tsx
+++ b/docs/src/pages/AvatarDemoPage.tsx
@@ -1,0 +1,43 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/AvatarDemoPage.tsx | valet
+// showcase of the Avatar component
+// ─────────────────────────────────────────────────────────────
+import { Surface, Stack, Typography, Button, Avatar, useTheme } from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+
+export default function AvatarDemoPage() {
+  const { theme, toggleMode } = useTheme();
+  const navigate = useNavigate();
+
+  return (
+    <Surface>
+      <Stack spacing={1} preset="showcaseStack">
+        <Typography variant="h2" bold>
+          Avatar Showcase
+        </Typography>
+        <Typography variant="subtitle">
+          Gravatar fallback with custom images
+        </Typography>
+
+        <Typography variant="h3">1. Gravatar by email</Typography>
+        <Avatar email="user@example.com" size={64} alt="gravatar" />
+
+        <Typography variant="h3">2. Custom image</Typography>
+        <Avatar src="https://placekitten.com/96/96" size={96} alt="kitten" />
+
+        <Typography variant="h3">3. Theme coupling</Typography>
+        <Button variant="outlined" onClick={toggleMode}>
+          Toggle light / dark mode
+        </Button>
+
+        <Button
+          size="lg"
+          onClick={() => navigate(-1)}
+          style={{ marginTop: theme.spacing(1) }}
+        >
+          ← Back
+        </Button>
+      </Stack>
+    </Surface>
+  );
+}

--- a/docs/src/pages/MainPage.tsx
+++ b/docs/src/pages/MainPage.tsx
@@ -177,6 +177,11 @@ export default function MainPage() {
               >
                 Stepper
               </Button>
+              <Button
+                onClick={() => navigate('/avatar-demo')}
+              >
+                Avatar
+              </Button>
             </Stack>
           </Panel>
 

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,0 +1,61 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/Avatar.tsx  | valet
+// simple user avatar with Gravatar fallback
+// ─────────────────────────────────────────────────────────────
+import React from 'react';
+import { styled } from '../css/createStyled';
+import { preset } from '../css/stylePresets';
+import type { Presettable } from '../types';
+import { md5 } from '../helpers/md5';
+
+export interface AvatarProps
+  extends React.ImgHTMLAttributes<HTMLImageElement>,
+    Presettable {
+  /** Email used for Gravatar lookup. */
+  email?: string;
+  /** Image source URL. Overrides Gravatar. */
+  src?: string;
+  /** Width/height in CSS units. Default 40. */
+  size?: number | string;
+  /** Round image with 50% border radius. */
+  round?: boolean;
+}
+
+const Img = styled('img')<{ $size: string; $round: boolean }>`
+  width: ${({ $size }) => $size};
+  height: ${({ $size }) => $size};
+  border-radius: ${({ $round }) => ($round ? '50%' : '4px')};
+  object-fit: cover;
+`;
+
+export const Avatar: React.FC<AvatarProps> = ({
+  email,
+  src,
+  size = 40,
+  round = true,
+  preset: p,
+  className,
+  style,
+  alt,
+  ...rest
+}) => {
+  const finalSize = typeof size === 'number' ? `${size}px` : size;
+  const sizePx = parseInt(finalSize, 10) || 80;
+  const gravatar = email
+    ? `https://www.gravatar.com/avatar/${md5(email.trim().toLowerCase())}?d=identicon&s=${sizePx}`
+    : undefined;
+  const presetCls = p ? preset(p) : '';
+  return (
+    <Img
+      src={src || gravatar}
+      alt={alt ?? ''}
+      $size={finalSize}
+      $round={round}
+      className={[presetCls, className].filter(Boolean).join(' ')}
+      style={style}
+      {...rest}
+    />
+  );
+};
+
+export default Avatar;

--- a/src/helpers/md5.ts
+++ b/src/helpers/md5.ts
@@ -1,0 +1,143 @@
+// ─────────────────────────────────────────────────────────────
+// src/helpers/md5.ts  | valet
+// minimal MD5 hash for gravatar
+// ─────────────────────────────────────────────────────────────
+
+export function md5(str: string): string {
+  const rotate = (x: number, c: number) => (x << c) | (x >>> (32 - c));
+  const add = (a: number, b: number) => (a + b) | 0;
+
+  const cmn = (q: number, a: number, b: number, x: number, s: number, t: number) =>
+    add(rotate(add(add(a, q), add(x, t)), s), b);
+
+  const ff = (a: number, b: number, c: number, d: number, x: number, s: number, t: number) =>
+    cmn((b & c) | (~b & d), a, b, x, s, t);
+  const gg = (a: number, b: number, c: number, d: number, x: number, s: number, t: number) =>
+    cmn((b & d) | (c & ~d), a, b, x, s, t);
+  const hh = (a: number, b: number, c: number, d: number, x: number, s: number, t: number) =>
+    cmn(b ^ c ^ d, a, b, x, s, t);
+  const ii = (a: number, b: number, c: number, d: number, x: number, s: number, t: number) =>
+    cmn(c ^ (b | ~d), a, b, x, s, t);
+
+  const md5cycle = (state: number[], k: number[]) => {
+    let [a, b, c, d] = state;
+
+    a = ff(a, b, c, d, k[0], 7, -680876936);
+    d = ff(d, a, b, c, k[1], 12, -389564586);
+    c = ff(c, d, a, b, k[2], 17, 606105819);
+    b = ff(b, c, d, a, k[3], 22, -1044525330);
+    a = ff(a, b, c, d, k[4], 7, -176418897);
+    d = ff(d, a, b, c, k[5], 12, 1200080426);
+    c = ff(c, d, a, b, k[6], 17, -1473231341);
+    b = ff(b, c, d, a, k[7], 22, -45705983);
+    a = ff(a, b, c, d, k[8], 7, 1770035416);
+    d = ff(d, a, b, c, k[9], 12, -1958414417);
+    c = ff(c, d, a, b, k[10], 17, -42063);
+    b = ff(b, c, d, a, k[11], 22, -1990404162);
+    a = ff(a, b, c, d, k[12], 7, 1804603682);
+    d = ff(d, a, b, c, k[13], 12, -40341101);
+    c = ff(c, d, a, b, k[14], 17, -1502002290);
+    b = ff(b, c, d, a, k[15], 22, 1236535329);
+
+    a = gg(a, b, c, d, k[1], 5, -165796510);
+    d = gg(d, a, b, c, k[6], 9, -1069501632);
+    c = gg(c, d, a, b, k[11], 14, 643717713);
+    b = gg(b, c, d, a, k[0], 20, -373897302);
+    a = gg(a, b, c, d, k[5], 5, -701558691);
+    d = gg(d, a, b, c, k[10], 9, 38016083);
+    c = gg(c, d, a, b, k[15], 14, -660478335);
+    b = gg(b, c, d, a, k[4], 20, -405537848);
+    a = gg(a, b, c, d, k[9], 5, 568446438);
+    d = gg(d, a, b, c, k[14], 9, -1019803690);
+    c = gg(c, d, a, b, k[3], 14, -187363961);
+    b = gg(b, c, d, a, k[8], 20, 1163531501);
+    a = gg(a, b, c, d, k[13], 5, -1444681467);
+    d = gg(d, a, b, c, k[2], 9, -51403784);
+    c = gg(c, d, a, b, k[7], 14, 1735328473);
+    b = gg(b, c, d, a, k[12], 20, -1926607734);
+
+    a = hh(a, b, c, d, k[5], 4, -378558);
+    d = hh(d, a, b, c, k[8], 11, -2022574463);
+    c = hh(c, d, a, b, k[11], 16, 1839030562);
+    b = hh(b, c, d, a, k[14], 23, -35309556);
+    a = hh(a, b, c, d, k[1], 4, -1530992060);
+    d = hh(d, a, b, c, k[4], 11, 1272893353);
+    c = hh(c, d, a, b, k[7], 16, -155497632);
+    b = hh(b, c, d, a, k[10], 23, -1094730640);
+    a = hh(a, b, c, d, k[13], 4, 681279174);
+    d = hh(d, a, b, c, k[0], 11, -358537222);
+    c = hh(c, d, a, b, k[3], 16, -722521979);
+    b = hh(b, c, d, a, k[6], 23, 76029189);
+    a = hh(a, b, c, d, k[9], 4, -640364487);
+    d = hh(d, a, b, c, k[12], 11, -421815835);
+    c = hh(c, d, a, b, k[15], 16, 530742520);
+    b = hh(b, c, d, a, k[2], 23, -995338651);
+
+    a = ii(a, b, c, d, k[0], 6, -198630844);
+    d = ii(d, a, b, c, k[7], 10, 1126891415);
+    c = ii(c, d, a, b, k[14], 15, -1416354905);
+    b = ii(b, c, d, a, k[5], 21, -57434055);
+    a = ii(a, b, c, d, k[12], 6, 1700485571);
+    d = ii(d, a, b, c, k[3], 10, -1894986606);
+    c = ii(c, d, a, b, k[10], 15, -1051523);
+    b = ii(b, c, d, a, k[1], 21, -2054922799);
+    a = ii(a, b, c, d, k[8], 6, 1873313359);
+    d = ii(d, a, b, c, k[15], 10, -30611744);
+    c = ii(c, d, a, b, k[6], 15, -1560198380);
+    b = ii(b, c, d, a, k[13], 21, 1309151649);
+    a = ii(a, b, c, d, k[4], 6, -145523070);
+    d = ii(d, a, b, c, k[11], 10, -1120210379);
+    c = ii(c, d, a, b, k[2], 15, 718787259);
+    b = ii(b, c, d, a, k[9], 21, -343485551);
+
+    state[0] = add(a, state[0]);
+    state[1] = add(b, state[1]);
+    state[2] = add(c, state[2]);
+    state[3] = add(d, state[3]);
+  };
+
+  const md5blk = (s: string): number[] => {
+    const md5blks = new Array(16);
+    for (let i = 0; i < 64; i += 4) {
+      md5blks[i >> 2] =
+        s.charCodeAt(i) |
+        (s.charCodeAt(i + 1) << 8) |
+        (s.charCodeAt(i + 2) << 16) |
+        (s.charCodeAt(i + 3) << 24);
+    }
+    return md5blks;
+  };
+
+  const md51 = (s: string): number[] => {
+    let n = s.length;
+    const state = [1732584193, -271733879, -1732584194, 271733878];
+    let i: number;
+    for (i = 64; i <= n; i += 64) {
+      md5cycle(state, md5blk(s.substring(i - 64, i)));
+    }
+    s = s.substring(i - 64);
+    const tail = new Array(16).fill(0);
+    for (i = 0; i < s.length; i++) {
+      tail[i >> 2] |= s.charCodeAt(i) << ((i % 4) << 3);
+    }
+    tail[i >> 2] |= 0x80 << ((i % 4) << 3);
+    if (i > 55) {
+      md5cycle(state, tail);
+      for (i = 0; i < 16; i++) tail[i] = 0;
+    }
+    const tmp = n * 8;
+    tail[14] = tmp & 0xffffffff;
+    tail[15] = Math.floor(tmp / 0x100000000);
+    md5cycle(state, tail);
+    return state;
+  };
+
+  const rhex = (n: number): string =>
+    ((n >>> 0).toString(16).padStart(8, '0'));
+
+  const hex = (x: number[]): string => x.map(rhex).join('');
+
+  return hex(md51(str));
+}
+
+export default md5;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export * from './components/RadioGroup';
 export * from './components/Slider';
 export * from './components/Snackbar';
 export * from './components/Stack';
+export * from './components/Avatar';
 export { default as Select } from './components/Select';  // ← gives you `Select`
 export type {
   SelectProps,


### PR DESCRIPTION
## Summary
- add `Avatar` component with gravatar support
- add internal md5 helper
- document the component in docs
- showcase Avatar in the demo site

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d8478d2b88329ad8bfa602ba05ab5