### PR TITLE
Update Avatar size tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file. The format 
 ### Added
 - Avatar component with Gravatar fallback
 - Avatar demo page now includes an interactive email form
+### Changed
+- Avatar size tokens now map to rem units
 
 ## [v0.8.2]
 ### Improved

--- a/docs/src/pages/AvatarDemo.tsx
+++ b/docs/src/pages/AvatarDemo.tsx
@@ -42,17 +42,17 @@ export default function AvatarDemoPage() {
           onSubmitValues={(vals) => setEmail(vals.email)}
         >
           <Stack direction="row" spacing={1}>
-            <Avatar email={email} size={64} />
+            <Avatar email={email} size="l" />
             <TextField name="email" type="email" placeholder="you@example.com" />
             <Button type="submit">Show</Button>
           </Stack>
         </FormControl>
         <Typography variant="h3">2. Default example</Typography>
-        <Avatar email="support@gravatar.com" size={64} />
+        <Avatar email="support@gravatar.com" size="l" />
         <Typography variant="h3">3. Custom src</Typography>
         <Avatar
           src="https://avatars.githubusercontent.com/u/9919?s=200&v=4"
-          size={64}
+          size="l"
           alt="GitHub"
         />
 

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -8,6 +8,8 @@ import { preset } from '../css/stylePresets';
 import type { Presettable } from '../types';
 import { md5 } from '../helpers/md5';
 
+export type AvatarSize = 'xs' | 's' | 'm' | 'l' | 'xl';
+
 export interface AvatarProps
   extends React.ImgHTMLAttributes<HTMLImageElement>,
     Presettable {
@@ -15,16 +17,24 @@ export interface AvatarProps
   src?: string;
   /** Email used for Gravatar lookup when src missing. */
   email?: string;
-  /** Square pixel size. Defaults to 48. */
-  size?: number;
+  /** Size token controlling relative dimensions. */
+  size?: AvatarSize;
   /** Fallback style when no avatar exists. */
   gravatarDefault?: string;
 }
 
-const Img = styled('img')<{ $size: number }>`
+const sizeMap: Record<AvatarSize, string> = {
+  xs: '1.5rem',
+  s : '2rem',
+  m : '3rem',
+  l : '4rem',
+  xl: '6rem',
+};
+
+const Img = styled('img')<{ $size: string }>`
   display: inline-block;
-  width: ${({ $size }) => `${$size}px`};
-  height: ${({ $size }) => `${$size}px`};
+  width: ${({ $size }) => $size};
+  height: ${({ $size }) => $size};
   border-radius: 50%;
   object-fit: cover;
 `;
@@ -32,23 +42,27 @@ const Img = styled('img')<{ $size: number }>`
 export const Avatar: React.FC<AvatarProps> = ({
   src,
   email,
-  size = 48,
+  size = 'm',
   gravatarDefault = 'identicon',
   preset: p,
   className,
   ...rest
 }) => {
+  const rem = sizeMap[size];
+  const px = Math.round(parseFloat(rem) * 16);
+
   let finalSrc = src;
   if (!finalSrc) {
     const hash = email ? md5(email.trim().toLowerCase()) : '';
-    finalSrc = `https://www.gravatar.com/avatar/${hash}?s=${size}&d=${encodeURIComponent(gravatarDefault)}`;
+    finalSrc = `https://www.gravatar.com/avatar/${hash}?s=${px}&d=${encodeURIComponent(gravatarDefault)}`;
   }
+
   const presetCls = p ? preset(p) : '';
   return (
     <Img
       {...rest}
       src={finalSrc}
-      $size={size}
+      $size={rem}
       className={[presetCls, className].filter(Boolean).join(' ')}
     />
   );


### PR DESCRIPTION
## Summary
- map Avatar size tokens to rem units
- update changelog

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686d9b9e7c4c83208929283c5eec6599