### PR TITLE
Center row children in Stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. The format 
 - Uniform highlight width on Accordion items
 ### Improved
 - Clearer hover contrast on Accordion headers
+- Stack rows now vertically center their children
 ### Added
 - Avatar component with Gravatar fallback
 - Avatar demo page now includes an interactive email form

--- a/src/components/Stack.tsx
+++ b/src/components/Stack.tsx
@@ -34,6 +34,7 @@ const StackContainer = styled('div')<{
 }>`
   display: flex;
   flex-direction: ${({ $dir }) => $dir};
+  align-items: ${({ $dir }) => ($dir === 'row' ? 'center' : 'stretch')};
   gap: ${({ $gap }) => $gap};
   ${({ $wrap }) => ($wrap ? 'flex-wrap: wrap;' : '')}
   margin: ${({ $margin }) => $margin};


### PR DESCRIPTION
## Summary
- center items in `Stack` when arranged in a row
- document the change

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686da7c7ab208320adeb5754c283729c