### PR TITLE
Add Chat component with demo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,7 @@ component rather than the page. Pass `constrainHeight={false}` to opt out.
 - **Box** – baseline container that handles background, text colour and centring.
 - **Button** – theme-aware button with variants and sizes.
 - **Checkbox** – controlled/uncontrolled checkbox adhering to accessibility.
+- **Chat** – conversation UI with OpenAI message format and optional height constraint.
 - **Drawer** – sliding overlay panel with escape handling and backdrop.
 - **FormControl** – context provider wiring labels, errors and disabled state.
 - **Grid** – CSS grid layout helper with gaps and spans.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 
 ## Unreleased
+### Added
+- Chat component with OpenAI-style messages and height constraint option
 
 ## [v0.8.3]
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ These have been mostly tested in the [valet Docs](https://github.com/off-court-c
 | Box           |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
 | Button        |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
 | Checkbox      |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
+| Chat          |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
 | Drawer        |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
 | FormControl   |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
 | Grid          |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
@@ -143,7 +144,7 @@ These have been mostly tested in the [valet Docs](https://github.com/off-court-c
 
 ## Intended Components
 
-- Chat
+<!-- None -->
 
 ## Contributing
 

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -25,6 +25,7 @@ const TextFieldDemoPage     = page(() => import('./pages/TextFormDemo'));
 const IconDemoPage          = page(() => import('./pages/IconDemoPage'));
 const IconButtonDemoPage    = page(() => import('./pages/IconButtonDemoPage'));
 const AvatarDemoPage        = page(() => import('./pages/AvatarDemo'));
+const ChatDemoPage          = page(() => import('./pages/ChatDemo'));
 const PanelDemoPage         = page(() => import('./pages/PanelDemo'));
 const CheckboxDemoPage      = page(() => import('./pages/CheckBoxDemo'));
 const TooltipDemoPage       = page(() => import('./pages/TooltipDemo'));
@@ -104,6 +105,7 @@ export function App() {
         <Route path="/stepper-demo"    element={<StepperDemoPage />} />
         <Route path="/radio-demo"      element={<RadioGroupDemoPage />} />
         <Route path="/video-demo"      element={<VideoDemoPage />} />
+        <Route path="/chat-demo"       element={<ChatDemoPage />} />
         <Route path="/snackbar-demo"   element={<SnackbarDemoPage />} />
       </Routes>
     </Suspense>

--- a/docs/src/pages/ChatDemo.tsx
+++ b/docs/src/pages/ChatDemo.tsx
@@ -1,0 +1,54 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// src/pages/ChatDemo.tsx
+// Simple showcase for <Chat /> component
+// ─────────────────────────────────────────────────────────────────────────────
+import { useState } from 'react';
+import {
+  Surface,
+  Stack,
+  Typography,
+  Button,
+  Chat,
+  useTheme,
+} from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+import type { ChatMessage } from '@archway/valet';
+
+export default function ChatDemoPage() {
+  const navigate = useNavigate();
+  const { theme, toggleMode } = useTheme();
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    { role: 'assistant', content: 'Hello! How can I help you?' },
+  ]);
+
+  const handleSend = (m: ChatMessage) => {
+    setMessages(prev => [...prev, m, { role: 'assistant', content: `Echo: ${m.content}` }]);
+  };
+
+  return (
+    <Surface>
+      <Stack spacing={1} preset="showcaseStack">
+        <Typography variant="h2" bold>
+          Chat Showcase
+        </Typography>
+        <Typography variant="subtitle">
+          Chat component with OpenAI style messages
+        </Typography>
+
+        <Chat messages={messages} onSend={handleSend} constrainHeight />
+
+        <Button variant="outlined" onClick={toggleMode}>
+          Toggle light / dark mode
+        </Button>
+
+        <Button
+          size="lg"
+          onClick={() => navigate(-1)}
+          style={{ marginTop: theme.spacing(1) }}
+        >
+          ← Back
+        </Button>
+      </Stack>
+    </Surface>
+  );
+}

--- a/docs/src/pages/MainPage.tsx
+++ b/docs/src/pages/MainPage.tsx
@@ -47,6 +47,12 @@ export default function MainPage() {
               </Button>
 
               <Button
+                onClick={() => navigate('/chat-demo')}
+              >
+                Chat
+              </Button>
+
+              <Button
                 onClick={() => navigate('/drawer-demo')}
               >
                 Drawer

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,0 +1,206 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/Chat.tsx  | valet
+// OpenAI style chat component with height constraint
+// ─────────────────────────────────────────────────────────────
+import React, {
+  useState,
+  useRef,
+  useId,
+  useEffect,
+  useLayoutEffect,
+} from 'react';
+import { styled }          from '../css/createStyled';
+import { useTheme }        from '../system/themeStore';
+import { useSurface }      from '../system/surfaceStore';
+import { preset }          from '../css/stylePresets';
+import IconButton          from './IconButton';
+import TextField           from './TextField';
+import Panel               from './Panel';
+import Typography          from './Typography';
+import type { Presettable } from '../types';
+
+/*───────────────────────────────────────────────────────────*/
+/* Types                                                      */
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant' | 'function' | 'tool';
+  content: string;
+  name?: string;
+}
+
+export interface ChatProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSubmit'>,
+    Presettable {
+  messages: ChatMessage[];
+  onSend?: (message: ChatMessage) => void;
+  placeholder?: string;
+  disableInput?: boolean;
+  constrainHeight?: boolean;
+}
+
+/*───────────────────────────────────────────────────────────*/
+/* Styled primitives                                         */
+const Wrapper = styled('div')<{ $gap: string }>`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ $gap }) => $gap};
+`;
+
+const Messages = styled('div')<{ $gap: string }>`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ $gap }) => $gap};
+`;
+
+const Row = styled('div')<{ $from: 'user' | 'assistant' | 'system' | 'function' | 'tool' }>`
+  display: flex;
+  justify-content: ${({ $from }) => ($from === 'user' ? 'flex-end' : 'flex-start')};
+`;
+
+const InputRow = styled('form')<{ $gap: string }>`
+  display: flex;
+  align-items: flex-end;
+  gap: ${({ $gap }) => $gap};
+`;
+
+/*───────────────────────────────────────────────────────────*/
+/* Component                                                  */
+export const Chat: React.FC<ChatProps> = ({
+  messages,
+  onSend,
+  placeholder = 'Message…',
+  disableInput = false,
+  constrainHeight = true,
+  preset: p,
+  className,
+  style,
+  ...rest
+}) => {
+  const { theme } = useTheme();
+  const surface = useSurface();
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const uniqueId = useId();
+  const [maxHeight, setMaxHeight] = useState<number>();
+  const [shouldConstrain, setShouldConstrain] = useState(false);
+  const constraintRef = useRef(false);
+
+  const [text, setText] = useState('');
+
+  const calcCutoff = () => {
+    if (typeof document === 'undefined') return 32;
+    const fs = parseFloat(
+      getComputedStyle(document.documentElement).fontSize,
+    );
+    return (isNaN(fs) ? 16 : fs) * 2;
+  };
+
+  const update = () => {
+    const node = wrapRef.current;
+    const surfEl = surface.element;
+    if (!node || !surfEl) return;
+    const sRect = surfEl.getBoundingClientRect();
+    const nRect = node.getBoundingClientRect();
+    const top = Math.round(nRect.top - sRect.top + surfEl.scrollTop);
+    const bottomSpace = Math.round(
+      surfEl.scrollHeight - (nRect.bottom - sRect.top + surfEl.scrollTop),
+    );
+    const available = Math.round(surface.height - top - bottomSpace);
+    const cutoff = calcCutoff();
+
+    const next = available >= cutoff;
+    if (next) {
+      if (!constraintRef.current) {
+        surfEl.scrollTop = 0;
+        surfEl.scrollLeft = 0;
+      }
+      constraintRef.current = true;
+      setShouldConstrain(true);
+      setMaxHeight(Math.max(0, available));
+    } else {
+      constraintRef.current = false;
+      setShouldConstrain(false);
+      setMaxHeight(undefined);
+    }
+  };
+
+  useEffect(() => {
+    if (!constrainHeight) {
+      constraintRef.current = false;
+      setShouldConstrain(false);
+      setMaxHeight(undefined);
+    } else {
+      constraintRef.current = false;
+    }
+  }, [constrainHeight]);
+
+  useLayoutEffect(() => {
+    if (!constrainHeight || !wrapRef.current || !surface.element) return;
+    const node = wrapRef.current;
+    surface.registerChild(uniqueId, node, update);
+    const ro = new ResizeObserver(update);
+    ro.observe(node);
+    update();
+    return () => {
+      surface.unregisterChild(uniqueId);
+      ro.disconnect();
+    };
+  }, [constrainHeight, surface.element]);
+
+  useLayoutEffect(() => {
+    if (!constrainHeight || !wrapRef.current || !surface.element) return;
+    update();
+  }, [constrainHeight, surface.height, surface.element]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!text.trim()) return;
+    const msg: ChatMessage = { role: 'user', content: text.trim() };
+    onSend?.(msg);
+    setText('');
+  };
+
+  const presetClasses = p ? preset(p) : '';
+
+  return (
+    <Wrapper
+      {...rest}
+      ref={wrapRef}
+      $gap={theme.spacing(1)}
+      style={{ ...style, overflow: 'hidden' }}
+      className={[presetClasses, className].filter(Boolean).join(' ')}
+    >
+      <Messages
+        $gap={theme.spacing(0.5)}
+        style={shouldConstrain ? { overflowY: 'auto', maxHeight } : undefined}
+      >
+        {messages.map((m, i) => (
+          <Row key={i} $from={m.role}>
+            <Panel fullWidth compact variant={m.role === 'user' ? 'alt' : 'main'}>
+              {m.name && (
+                <Typography variant="subtitle" bold>
+                  {m.name}
+                </Typography>
+              )}
+              <Typography>{m.content}</Typography>
+            </Panel>
+          </Row>
+        ))}
+      </Messages>
+      {!disableInput && (
+        <InputRow onSubmit={handleSubmit} $gap={theme.spacing(0.5)}>
+          <TextField
+            as="textarea"
+            name="chat-message"
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            rows={1}
+            placeholder={placeholder}
+            style={{ flex: 1 }}
+          />
+          <IconButton icon="mdi:send" type="submit" aria-label="Send" />
+        </InputRow>
+      )}
+    </Wrapper>
+  );
+};
+
+export default Chat;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from './components/Accordion';
 export * from './components/Box';
 export * from './components/Button';
 export * from './components/Checkbox';
+export * from './components/Chat';
 export * from './components/FormControl';
 export * from './components/Icon';
 export * from './components/IconButton';


### PR DESCRIPTION
## Summary
- introduce Chat component with OpenAI-style messages
- export Chat in library index
- document Chat in AGENTS, README and CHANGELOG
- showcase Chat on docs site with new route and navigation link

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686db645bdf8832093a8871a95a0335b