### PR TITLE
Add avatars to Chat demo

### DIFF
--- a/docs/src/pages/ChatDemo.tsx
+++ b/docs/src/pages/ChatDemo.tsx
@@ -9,10 +9,13 @@ import {
   Typography,
   Button,
   Chat,
+  Avatar,
+  Icon,
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
 import type { ChatMessage } from '@archway/valet';
+import monkey from '../assets/monkey.jpg';
 
 export default function ChatDemoPage() {
   const navigate = useNavigate();
@@ -29,6 +32,9 @@ export default function ChatDemoPage() {
     setMessages(prev => [...prev, m, { role: 'assistant', content: `Echo: ${m.content}` }]);
   };
 
+  const systemAvatarEl = <Avatar src={monkey} size="m" alt="System" />;
+  const userAvatarEl = <Icon icon="mdi:github" size="2rem" aria-label="GitHub" />;
+
   return (
     <Surface>
       <Stack spacing={1} preset="showcaseStack">
@@ -39,7 +45,13 @@ export default function ChatDemoPage() {
           Chat component with OpenAI style messages
         </Typography>
 
-        <Chat messages={messages} onSend={handleSend} constrainHeight />
+        <Chat
+          messages={messages}
+          onSend={handleSend}
+          constrainHeight
+          systemAvatar={systemAvatarEl}
+          userAvatar={userAvatarEl}
+        />
 
         <Button variant="outlined" onClick={toggleMode}>
           Toggle light / dark mode

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -17,6 +17,7 @@ import IconButton          from './IconButton';
 import TextField           from './TextField';
 import Panel               from './Panel';
 import Typography          from './Typography';
+import Avatar              from './Avatar';
 import type { Presettable } from '../types';
 
 /*───────────────────────────────────────────────────────────*/
@@ -35,6 +36,8 @@ export interface ChatProps
   placeholder?: string;
   disableInput?: boolean;
   constrainHeight?: boolean;
+  userAvatar?: React.ReactNode;
+  systemAvatar?: React.ReactNode;
 }
 
 /*───────────────────────────────────────────────────────────*/
@@ -60,6 +63,18 @@ const Row = styled('div')<{
   justify-content: ${({ $from }) => ($from === 'user' ? 'flex-end' : 'flex-start')};
   padding-left: ${({ $left }) => $left};
   padding-right: ${({ $right }) => $right};
+  position: relative;
+  `;
+
+const AvatarSlot = styled('div')<{ $side: 'left' | 'right'; $padTop: string; $width: string }>`
+  position: absolute;
+  top: 0;
+  ${({ $side }) => ($side === 'left' ? 'left:0;' : 'right:0;')}
+  display: flex;
+  align-items: flex-start;
+  padding-top: ${({ $padTop }) => $padTop};
+  width: ${({ $width }) => $width};
+  justify-content: center;
 `;
 
 const InputRow = styled('form')<{ $gap: string }>`
@@ -76,6 +91,8 @@ export const Chat: React.FC<ChatProps> = ({
   placeholder = 'Message…',
   disableInput = false,
   constrainHeight = true,
+  userAvatar,
+  systemAvatar,
   preset: p,
   className,
   style,
@@ -189,6 +206,25 @@ export const Chat: React.FC<ChatProps> = ({
             $left={m.role === 'user' ? theme.spacing(24) : theme.spacing(3)}
             $right={m.role === 'user' ? theme.spacing(3) : theme.spacing(24)}
           >
+            {m.role === 'user'
+              ? userAvatar && (
+                  <AvatarSlot
+                    $side="right"
+                    $padTop={theme.spacing(0.5)}
+                    $width={theme.spacing(24)}
+                  >
+                    {userAvatar}
+                  </AvatarSlot>
+                )
+              : systemAvatar && (
+                  <AvatarSlot
+                    $side="left"
+                    $padTop={theme.spacing(0.5)}
+                    $width={theme.spacing(24)}
+                  >
+                    {systemAvatar}
+                  </AvatarSlot>
+                )}
             <Panel
               fullWidth
               compact


### PR DESCRIPTION
## Summary
- allow Chat component to specify user and system avatars
- demo Chat avatars in docs

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686de524a6988320a0c726f941f212de