### PR TITLE
Add avatars to Chat component

### DIFF
--- a/docs/src/pages/ChatDemo.tsx
+++ b/docs/src/pages/ChatDemo.tsx
@@ -13,6 +13,7 @@ import {
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
 import type { ChatMessage } from '@archway/valet';
+import monkey from '../assets/monkey.jpg';
 
 export default function ChatDemoPage() {
   const navigate = useNavigate();
@@ -39,7 +40,13 @@ export default function ChatDemoPage() {
           Chat component with OpenAI style messages
         </Typography>
 
-        <Chat messages={messages} onSend={handleSend} constrainHeight />
+        <Chat
+          messages={messages}
+          onSend={handleSend}
+          constrainHeight
+          userAvatar="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          systemAvatar={monkey}
+        />
 
         <Button variant="outlined" onClick={toggleMode}>
           Toggle light / dark mode

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -17,6 +17,7 @@ import IconButton          from './IconButton';
 import TextField           from './TextField';
 import Panel               from './Panel';
 import Typography          from './Typography';
+import Avatar              from './Avatar';
 import type { Presettable } from '../types';
 
 /*───────────────────────────────────────────────────────────*/
@@ -35,6 +36,8 @@ export interface ChatProps
   placeholder?: string;
   disableInput?: boolean;
   constrainHeight?: boolean;
+  userAvatar?: string;
+  systemAvatar?: string;
 }
 
 /*───────────────────────────────────────────────────────────*/
@@ -60,6 +63,13 @@ const Row = styled('div')<{
   justify-content: ${({ $from }) => ($from === 'user' ? 'flex-end' : 'flex-start')};
   padding-left: ${({ $left }) => $left};
   padding-right: ${({ $right }) => $right};
+  position: relative;
+`;
+
+const AvatarSlot = styled('div')<{ $from: 'user' | 'assistant' | 'system' | 'function' | 'tool' }>`
+  position: absolute;
+  bottom: 0;
+  ${({ $from }) => ($from === 'user' ? 'right: 0;' : 'left: 0;')}
 `;
 
 const InputRow = styled('form')<{ $gap: string }>`
@@ -76,6 +86,8 @@ export const Chat: React.FC<ChatProps> = ({
   placeholder = 'Message…',
   disableInput = false,
   constrainHeight = true,
+  userAvatar,
+  systemAvatar,
   preset: p,
   className,
   style,
@@ -189,6 +201,11 @@ export const Chat: React.FC<ChatProps> = ({
             $left={m.role === 'user' ? theme.spacing(24) : theme.spacing(3)}
             $right={m.role === 'user' ? theme.spacing(3) : theme.spacing(24)}
           >
+            {((m.role === 'user' ? userAvatar : systemAvatar)) && (
+              <AvatarSlot $from={m.role}>
+                <Avatar src={m.role === 'user' ? userAvatar : systemAvatar} size="m" />
+              </AvatarSlot>
+            )}
             <Panel
               fullWidth
               compact


### PR DESCRIPTION
## Summary
- support `userAvatar` and `systemAvatar` in the Chat component
- showcase avatars in the Chat docs demo using the monkey asset

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686de524a6988320a0c726f941f212de