### PR TITLE
Add avatar props to chat

### DIFF
--- a/docs/src/pages/ChatDemo.tsx
+++ b/docs/src/pages/ChatDemo.tsx
@@ -13,6 +13,7 @@ import {
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
 import type { ChatMessage } from '@archway/valet';
+import monkey from '../assets/monkey.jpg';
 
 export default function ChatDemoPage() {
   const navigate = useNavigate();
@@ -39,7 +40,13 @@ export default function ChatDemoPage() {
           Chat component with OpenAI style messages
         </Typography>
 
-        <Chat messages={messages} onSend={handleSend} constrainHeight />
+        <Chat
+          messages={messages}
+          onSend={handleSend}
+          constrainHeight
+          userAvatar="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+          systemAvatar={monkey}
+        />
 
         <Button variant="outlined" onClick={toggleMode}>
           Toggle light / dark mode

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -17,6 +17,7 @@ import IconButton          from './IconButton';
 import TextField           from './TextField';
 import Panel               from './Panel';
 import Typography          from './Typography';
+import Avatar              from './Avatar';
 import type { Presettable } from '../types';
 
 /*───────────────────────────────────────────────────────────*/
@@ -32,6 +33,10 @@ export interface ChatProps
     Presettable {
   messages: ChatMessage[];
   onSend?: (message: ChatMessage) => void;
+  /** Avatar image for user messages */
+  userAvatar?: string;
+  /** Avatar image for system / assistant messages */
+  systemAvatar?: string;
   placeholder?: string;
   disableInput?: boolean;
   constrainHeight?: boolean;
@@ -73,6 +78,8 @@ const InputRow = styled('form')<{ $gap: string }>`
 export const Chat: React.FC<ChatProps> = ({
   messages,
   onSend,
+  userAvatar,
+  systemAvatar,
   placeholder = 'Message…',
   disableInput = false,
   constrainHeight = true,
@@ -189,6 +196,9 @@ export const Chat: React.FC<ChatProps> = ({
             $left={m.role === 'user' ? theme.spacing(24) : theme.spacing(3)}
             $right={m.role === 'user' ? theme.spacing(3) : theme.spacing(24)}
           >
+            {m.role !== 'user' && systemAvatar && (
+              <Avatar src={systemAvatar} size="s" style={{ marginRight: theme.spacing(1) }} />
+            )}
             <Panel
               fullWidth
               compact
@@ -202,6 +212,9 @@ export const Chat: React.FC<ChatProps> = ({
               )}
               <Typography>{m.content}</Typography>
             </Panel>
+            {m.role === 'user' && userAvatar && (
+              <Avatar src={userAvatar} size="s" style={{ marginLeft: theme.spacing(1) }} />
+            )}
           </Row>
         ))}
       </Messages>


### PR DESCRIPTION
## Summary
- add `userAvatar` and `systemAvatar` props to Chat component
- show avatars in Chat rows
- demo Chat avatars using docs monkey asset and GitHub icon

## Testing
- `npm run build`
- `cd docs && npm run build`
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_686de524a6988320a0c726f941f212de