### PR TITLE
Fix Chat avatar alignment

### DIFF
--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -63,6 +63,7 @@ const Row = styled('div') <{
   $right: string;
 }>`
   display: flex;
+  align-items: center;
   justify-content: ${({ $from }) => ($from === 'user' ? 'flex-end' : 'flex-start')};
   padding-left: ${({ $left }) => $left};
   padding-right: ${({ $right }) => $right};


### PR DESCRIPTION
## Summary
- vertically center avatars relative to message bubbles in `<Chat>`

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686e0c26fa948320878f1e589f09199c