### PR TITLE
Avatar docs update

### DIFF
--- a/docs/src/pages/AvatarDemo.tsx
+++ b/docs/src/pages/AvatarDemo.tsx
@@ -9,7 +9,11 @@ import {
   FormControl,
   createFormStore,
   useTheme,
+  Tabs,
+  Table,
 } from '@archway/valet';
+import type { TableColumn } from '@archway/valet';
+import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 
@@ -26,43 +30,106 @@ export default function AvatarDemoPage() {
   const navigate = useNavigate();
   const [email, setEmail] = useState('support@gravatar.com');
 
+  interface Row {
+    prop: ReactNode;
+    type: ReactNode;
+    default: ReactNode;
+    description: ReactNode;
+  }
+
+  const columns: TableColumn<Row>[] = [
+    { header: 'Prop', accessor: 'prop' },
+    { header: 'Type', accessor: 'type' },
+    { header: 'Default', accessor: 'default' },
+    { header: 'Description', accessor: 'description' },
+  ];
+
+  const data: Row[] = [
+    {
+      prop: <code>src</code>,
+      type: <code>string</code>,
+      default: <code>-</code>,
+      description: 'Image URL override',
+    },
+    {
+      prop: <code>email</code>,
+      type: <code>string</code>,
+      default: <code>-</code>,
+      description: 'Email used for Gravatar lookup',
+    },
+    {
+      prop: <code>size</code>,
+      type: <code>'xs' | 's' | 'm' | 'l' | 'xl'</code>,
+      default: <code>'m'</code>,
+      description: 'Relative size token',
+    },
+    {
+      prop: <code>gravatarDefault</code>,
+      type: <code>string</code>,
+      default: <code>'identicon'</code>,
+      description: 'Fallback style when no avatar exists',
+    },
+    {
+      prop: <code>alt</code>,
+      type: <code>string</code>,
+      default: <code>-</code>,
+      description: 'Image alt text',
+    },
+    {
+      prop: <code>preset</code>,
+      type: <code>string | string[]</code>,
+      default: <code>-</code>,
+      description: 'Apply style presets',
+    },
+  ];
+
   return (
     <Surface>
       <Stack preset="showcaseStack">
-        <Typography variant="h2" bold>
-          Avatar Showcase
-        </Typography>
-        <Typography variant="subtitle">
-          Gravatar wrapper with custom photo support
-        </Typography>
+        <Typography variant="h2">Avatar</Typography>
 
-        <Typography variant="h3">1. Try your Gravatar</Typography>
-        <FormControl
-          useStore={useEmailForm}
-          onSubmitValues={(vals) => setEmail(vals.email)}
-        >
-          <Stack direction="row" spacing={1}>
-            <Avatar email={email}/>
-            <TextField name="email" type="email" placeholder="you@example.com" />
-            <Button type="submit">Show</Button>
-          </Stack>
-        </FormControl>
-        <Typography variant="h3">2. Default example</Typography>
-        <Avatar email="support@gravatar.com" size="l" />
-        <Typography variant="h3">3. Custom src</Typography>
-        <Avatar
-          src="https://avatars.githubusercontent.com/u/9919?s=200&v=4"
-          size="l"
-          alt="GitHub"
-        />
+        <Tabs>
+          <Tabs.Tab label="Usage" />
+          <Tabs.Panel>
+            <Typography variant="subtitle">
+              Gravatar wrapper with custom photo support
+            </Typography>
 
-        {/* 4. Sizes --------------------------------------------------------- */}
-        <Typography variant="h3">4. Sizes</Typography>
-        <Stack direction="row" spacing={1}>
-          {(['xl', 'l', 'm', 's', 'xs'] as const).map((s) => (
-            <Avatar key={s} email="support@gravatar.com" size={s} />
-          ))}
-        </Stack>
+            <Typography variant="h3">1. Try your Gravatar</Typography>
+            <FormControl
+              useStore={useEmailForm}
+              onSubmitValues={(vals) => setEmail(vals.email)}
+            >
+              <Stack direction="row" spacing={1}>
+                <Avatar email={email} />
+                <TextField name="email" type="email" placeholder="you@example.com" />
+                <Button type="submit">Show</Button>
+              </Stack>
+            </FormControl>
+            <Typography variant="h3">2. Default example</Typography>
+            <Avatar email="support@gravatar.com" size="l" />
+            <Typography variant="h3">3. Custom src</Typography>
+            <Avatar
+              src="https://avatars.githubusercontent.com/u/9919?s=200&v=4"
+              size="l"
+              alt="GitHub"
+            />
+
+            {/* 4. Sizes --------------------------------------------------------- */}
+            <Typography variant="h3">4. Sizes</Typography>
+            <Stack direction="row" spacing={1}>
+              {(['xl', 'l', 'm', 's', 'xs'] as const).map((s) => (
+                <Avatar key={s} email="support@gravatar.com" size={s} />
+              ))}
+            </Stack>
+          </Tabs.Panel>
+
+          <Tabs.Tab label="Reference" />
+          <Tabs.Panel>
+            <Typography variant="h3">Prop reference</Typography>
+            <Table data={data} columns={columns} constrainHeight={false} />
+          </Tabs.Panel>
+        </Tabs>
 
         <Button
           size="lg"


### PR DESCRIPTION
## Summary
- refactor Avatar demo page to use Usage/Reference tabs
- add prop reference table for Avatar

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e81743fa08320b86afa6eaa5db857