### PR TITLE
Add persistent drawer example

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -40,6 +40,7 @@ const SelectDemoPage        = page(() => import('./pages/SelectDemo'));
 const TablePlaygroundPage   = page(() => import('./pages/TableDemo'));
 const ListDemoPage          = page(() => import('./pages/ListDemoPage'));
 const DrawerDemoPage        = page(() => import('./pages/DrawerDemo'));
+const DrawerPersistentDemoPage = page(() => import('./pages/DrawerPersistentDemo'));
 const AppBarDemoPage        = page(() => import('./pages/AppBarDemo'));
 const GridDemoPage          = page(() => import('./pages/GridDemo'));
 const PaginationDemoPage    = page(() => import('./pages/PaginationDemo'));
@@ -98,6 +99,7 @@ export function App() {
         <Route path="/table-demo"      element={<TablePlaygroundPage />} />
         <Route path="/list-demo"       element={<ListDemoPage />} />
         <Route path="/drawer-demo"     element={<DrawerDemoPage />} />
+        <Route path="/drawer-persistent" element={<DrawerPersistentDemoPage />} />
         <Route path="/appbar-demo"     element={<AppBarDemoPage />} />
         <Route path="/grid-demo"       element={<GridDemoPage />} />
         <Route path="/pagination-demo" element={<PaginationDemoPage />} />

--- a/docs/src/pages/DrawerDemo.tsx
+++ b/docs/src/pages/DrawerDemo.tsx
@@ -1,4 +1,7 @@
-// src/pages/DrawerDemo.tsx
+// ─────────────────────────────────────────────────────────────
+// src/pages/DrawerDemo.tsx | valet
+// Usage showcase and prop reference for <Drawer/>
+// ─────────────────────────────────────────────────────────────
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -8,81 +11,161 @@ import {
   Button,
   Drawer,
   useTheme,
+  Tabs,
+  Table,
 } from '@archway/valet';
+import type { TableColumn } from '@archway/valet';
+import type { ReactNode } from 'react';
 
 export default function DrawerDemoPage() {
   const { theme, toggleMode } = useTheme();
   const navigate = useNavigate();
 
   const [leftOpen, setLeftOpen] = useState(false);
-  const [rightOpen, setRightOpen] = useState(false);
   const [stubbornOpen, setStubbornOpen] = useState(false);
+
+  interface Row {
+    prop: ReactNode;
+    type: ReactNode;
+    default: ReactNode;
+    description: ReactNode;
+  }
+
+  const columns: TableColumn<Row>[] = [
+    { header: 'Prop', accessor: 'prop' },
+    { header: 'Type', accessor: 'type' },
+    { header: 'Default', accessor: 'default' },
+    { header: 'Description', accessor: 'description' },
+  ];
+
+  const data: Row[] = [
+    {
+      prop: <code>open</code>,
+      type: <code>boolean</code>,
+      default: <code>false</code>,
+      description: 'Controlled visibility',
+    },
+    {
+      prop: <code>defaultOpen</code>,
+      type: <code>boolean</code>,
+      default: <code>false</code>,
+      description: 'Uncontrolled initial state',
+    },
+    {
+      prop: <code>anchor</code>,
+      type: <code>'left' | 'right' | 'top' | 'bottom'</code>,
+      default: <code>'left'</code>,
+      description: 'Drawer side',
+    },
+    {
+      prop: <code>onClose</code>,
+      type: <code>() =&gt; void</code>,
+      default: <code>-</code>,
+      description: 'Called when user requests close',
+    },
+    {
+      prop: <code>size</code>,
+      type: <code>number | string</code>,
+      default: <code>'16rem'</code>,
+      description: 'Width or height of drawer',
+    },
+    {
+      prop: <code>disableBackdropClick</code>,
+      type: <code>boolean</code>,
+      default: <code>false</code>,
+      description: 'Ignore backdrop clicks',
+    },
+    {
+      prop: <code>disableEscapeKeyDown</code>,
+      type: <code>boolean</code>,
+      default: <code>false</code>,
+      description: 'Ignore ESC key',
+    },
+    {
+      prop: <code>backdrop</code>,
+      type: <code>boolean</code>,
+      default: <code>true</code>,
+      description: 'Render translucent backdrop',
+    },
+    {
+      prop: <code>persistent</code>,
+      type: <code>boolean</code>,
+      default: <code>false</code>,
+      description: 'Render in place instead of portaling',
+    },
+    {
+      prop: <code>preset</code>,
+      type: <code>string | string[]</code>,
+      default: <code>-</code>,
+      description: 'Apply style presets',
+    },
+  ];
 
   return (
     <Surface>
-      <Stack
-        spacing={1}
-        style={{ padding: theme.spacing(1), maxWidth: 980, margin: '0 auto' }}
-      >
+      <Stack spacing={1} preset="showcaseStack">
         <Typography variant="h2" bold>
           Drawer Showcase
         </Typography>
-        <Typography variant="subtitle">
-          Minimal slide-in navigation panel
-        </Typography>
-
-        {/* 1. Basic uncontrolled drawer */}
-        <Typography variant="h3">1. Left drawer</Typography>
-        <Button onClick={() => setLeftOpen(true)}>Open left drawer</Button>
-        <Drawer open={leftOpen} onClose={() => setLeftOpen(false)}>
-          <Stack spacing={1} style={{ padding: theme.spacing(1) }}>
-            <Typography variant="h4" bold>
-              Left Drawer
+        <Tabs>
+          <Tabs.Tab label="Usage" />
+          <Tabs.Panel>
+            <Typography variant="subtitle">
+              Minimal slide-in navigation panel
             </Typography>
-            <Typography>Click outside or press ESC to close.</Typography>
-          </Stack>
-        </Drawer>
 
-        {/* 2. Controlled right drawer */}
-        <Typography variant="h3">2. Controlled right drawer</Typography>
-        <Stack direction="row" spacing={1}>
-          <Button onClick={() => setRightOpen(true)}>Open</Button>
-          <Button onClick={() => setRightOpen(false)}>Close</Button>
-        </Stack>
-        <Drawer anchor="right" open={rightOpen} onClose={() => setRightOpen(false)}>
-          <Stack spacing={1} style={{ padding: theme.spacing(1) }}>
-            <Typography variant="h4" bold>
-              Controlled Drawer
-            </Typography>
-            <Typography>State managed by external buttons.</Typography>
-          </Stack>
-        </Drawer>
+            {/* 1. Left drawer */}
+            <Typography variant="h3">1. Left drawer</Typography>
+            <Button onClick={() => setLeftOpen(true)}>Open left drawer</Button>
+            <Drawer open={leftOpen} onClose={() => setLeftOpen(false)}>
+              <Stack spacing={1} style={{ padding: theme.spacing(1) }}>
+                <Typography variant="h4" bold>
+                  Left Drawer
+                </Typography>
+                <Typography>Click outside or press ESC to close.</Typography>
+              </Stack>
+            </Drawer>
 
-        {/* 3. Non-dismissable bottom drawer */}
-        <Typography variant="h3">3. Disable backdrop & ESC</Typography>
-        <Button onClick={() => setStubbornOpen(true)}>Open stubborn drawer</Button>
-        <Drawer
-          anchor="bottom"
-          open={stubbornOpen}
-          onClose={() => setStubbornOpen(false)}
-          disableBackdropClick
-          disableEscapeKeyDown
-        >
-          <Stack spacing={1} style={{ padding: theme.spacing(1) }}>
-            <Typography variant="h4" bold>
-              Can't close via backdrop or ESC
-            </Typography>
-            <Button onClick={() => setStubbornOpen(false)}>Close</Button>
-          </Stack>
-        </Drawer>
+            {/* 2. Non-dismissable bottom drawer */}
+            <Typography variant="h3">2. Disable backdrop & ESC</Typography>
+            <Button onClick={() => setStubbornOpen(true)}>Open stubborn drawer</Button>
+            <Drawer
+              anchor="bottom"
+              open={stubbornOpen}
+              onClose={() => setStubbornOpen(false)}
+              disableBackdropClick
+              disableEscapeKeyDown
+            >
+              <Stack spacing={1} style={{ padding: theme.spacing(1) }}>
+                <Typography variant="h4" bold>
+                  Can't close via backdrop or ESC
+                </Typography>
+                <Button onClick={() => setStubbornOpen(false)}>Close</Button>
+              </Stack>
+            </Drawer>
 
-        {/* Theme toggle + back nav */}
-        <Stack direction="row" spacing={1}>
-          <Button variant="outlined" onClick={toggleMode}>
-            Toggle light / dark
-          </Button>
-          <Button onClick={() => navigate(-1)}>← Back</Button>
-        </Stack>
+            <Button
+              variant="outlined"
+              size="sm"
+              onClick={() => navigate('/drawer-persistent')}
+            >
+              Persistent drawer demo
+            </Button>
+
+            <Stack direction="row" spacing={1}>
+              <Button variant="outlined" onClick={toggleMode}>
+                Toggle light / dark
+              </Button>
+              <Button onClick={() => navigate(-1)}>← Back</Button>
+            </Stack>
+          </Tabs.Panel>
+
+          <Tabs.Tab label="Reference" />
+          <Tabs.Panel>
+            <Typography variant="h3">Prop reference</Typography>
+            <Table data={data} columns={columns} constrainHeight={false} />
+          </Tabs.Panel>
+        </Tabs>
       </Stack>
     </Surface>
   );

--- a/docs/src/pages/DrawerPersistentDemo.tsx
+++ b/docs/src/pages/DrawerPersistentDemo.tsx
@@ -1,0 +1,51 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/DrawerPersistentDemo.tsx | valet
+// Persistent drawer used as a simple sidebar
+// ─────────────────────────────────────────────────────────────
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Surface, Stack, Typography, Button, Drawer, useTheme } from '@archway/valet';
+
+export default function DrawerPersistentDemo() {
+  const { theme, toggleMode } = useTheme();
+  const navigate = useNavigate();
+
+  const [open, setOpen] = useState(true);
+
+  return (
+    <Surface>
+      <Stack spacing={1} preset="showcaseStack">
+        <Typography variant="h2" bold>
+          Persistent Drawer
+        </Typography>
+        <Typography variant="subtitle">
+          Acts like a sidebar without backdrop
+        </Typography>
+        <Button variant="outlined" onClick={() => setOpen((o) => !o)}>
+          Toggle drawer
+        </Button>
+        <div style={{ minHeight: 240 }}>
+          <Drawer
+            open={open}
+            onClose={() => setOpen(false)}
+            backdrop={false}
+            persistent
+          >
+            <Stack spacing={1} style={{ padding: theme.spacing(1) }}>
+              <Typography variant="h4" bold>
+                Sidebar content
+              </Typography>
+              <Button onClick={() => setOpen(false)}>Close</Button>
+            </Stack>
+          </Drawer>
+        </div>
+        <Stack direction="row" spacing={1}>
+          <Button variant="outlined" onClick={toggleMode}>
+            Toggle light / dark
+          </Button>
+          <Button onClick={() => navigate(-1)}>← Back</Button>
+        </Stack>
+      </Stack>
+    </Surface>
+  );
+}

--- a/docs/src/pages/MainPage.tsx
+++ b/docs/src/pages/MainPage.tsx
@@ -59,6 +59,12 @@ export default function MainPage() {
               </Button>
 
               <Button
+                onClick={() => navigate('/drawer-persistent')}
+              >
+                Persistent Drawer
+              </Button>
+
+              <Button
                 onClick={() => navigate('/text-form-demo')}
               >
                 FormControl + Textfield

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -29,6 +29,10 @@ export interface DrawerProps extends Presettable {
   disableBackdropClick?: boolean;
   /** Disable closing via ESC key */
   disableEscapeKeyDown?: boolean;
+  /** Show translucent backdrop */
+  backdrop?: boolean;
+  /** Render in place instead of portaling */
+  persistent?: boolean;
   /** Drawer contents */
   children?: React.ReactNode;
 }
@@ -94,6 +98,8 @@ export const Drawer: React.FC<DrawerProps> = ({
   size = '16rem',
   disableBackdropClick = false,
   disableEscapeKeyDown = false,
+  backdrop = true,
+  persistent = false,
   children,
   preset: presetKey,
 }) => {
@@ -132,25 +138,34 @@ export const Drawer: React.FC<DrawerProps> = ({
     if (e.target === e.currentTarget) requestClose();
   };
 
-  if (!open) return null;
+  if (!open && !persistent) return null;
 
-  const drawerElement = (
-    <>
+  const backdropNode =
+    backdrop && open && !persistent ? (
       <Backdrop $fade={fade} onClick={handleBackdropClick} />
-      <Panel
-        $anchor={anchor}
-        $fade={fade}
-        $size={typeof size === 'number' ? `${size}px` : size}
-        $bg={theme.colors.surface}
-        $text={theme.colors.text}
-        className={presetClasses}
-      >
-        {children}
-      </Panel>
+    ) : null;
+
+  const panel = (
+    <Panel
+      $anchor={anchor}
+      $fade={fade}
+      $size={typeof size === 'number' ? `${size}px` : size}
+      $bg={theme.colors.surface}
+      $text={theme.colors.text}
+      className={presetClasses}
+    >
+      {children}
+    </Panel>
+  );
+
+  const content = (
+    <>
+      {backdropNode}
+      {panel}
     </>
   );
 
-  return createPortal(drawerElement, document.body);
+  return persistent ? content : createPortal(content, document.body);
 };
 
 export default Drawer;


### PR DESCRIPTION
## Summary
- make Drawer backdrop optional and add persistent prop
- update drawer demo layout with tabs
- add new persistent drawer example page
- route to new page from main page and drawer demo

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686e98e0d1588320b9964d5ef77e158f