### PR TITLE
Drawer border width

### DIFF
--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -52,6 +52,7 @@ const Panel = styled('div')<{
   $size: string;
   $bg: string;
   $text: string;
+  $primary: string;
 }>`
   position: fixed;
   z-index: 9999;
@@ -60,6 +61,14 @@ const Panel = styled('div')<{
   background: ${({ $bg }) => $bg};
   color: ${({ $text }) => $text};
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  ${({ $anchor, $primary }) =>
+    $anchor === 'left'
+      ? `border-right:0.25rem solid ${$primary};`
+      : $anchor === 'right'
+      ? `border-left:0.25rem solid ${$primary};`
+      : $anchor === 'top'
+      ? `border-bottom:0.25rem solid ${$primary};`
+      : `border-top:0.25rem solid ${$primary};`}
   ${({ $anchor, $size }) =>
     $anchor === 'left' || $anchor === 'right'
       ? `width:${$size}; height:100%;`
@@ -141,8 +150,9 @@ export const Drawer: React.FC<DrawerProps> = ({
         $anchor={anchor}
         $fade={fade}
         $size={typeof size === 'number' ? `${size}px` : size}
-        $bg={theme.colors.surface}
+        $bg={theme.colors.background}
         $text={theme.colors.text}
+        $primary={theme.colors.primary}
         className={presetClasses}
       >
         {children}


### PR DESCRIPTION
## Summary
- use theme background for Drawer Panel
- add divider lines along the drawer's inner edge
- adjust divider line width to 0.25rem

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ea788303883209ff51754fd9d169b