### PR TITLE
Drawer border width

### DIFF
--- a/docs/src/pages/DrawerDemo.tsx
+++ b/docs/src/pages/DrawerDemo.tsx
@@ -19,11 +19,20 @@ export default function DrawerDemoPage() {
   const [stubbornOpen, setStubbornOpen] = useState(false);
 
   return (
-    <Surface>
-      <Stack
-        spacing={1}
-        style={{ padding: theme.spacing(1), maxWidth: 980, margin: '0 auto' }}
-      >
+    <>
+      <Drawer persistent size="12rem">
+        <Stack spacing={1} style={{ padding: theme.spacing(1) }}>
+          <Typography variant="h4" bold>
+            Persistent Drawer
+          </Typography>
+          <Typography>Always visible on the left.</Typography>
+        </Stack>
+      </Drawer>
+      <Surface>
+        <Stack
+          spacing={1}
+          style={{ padding: theme.spacing(1), maxWidth: 980, margin: '0 auto' }}
+        >
         <Typography variant="h2" bold>
           Drawer Showcase
         </Typography>
@@ -85,5 +94,6 @@ export default function DrawerDemoPage() {
         </Stack>
       </Stack>
     </Surface>
+    </>
   );
 }

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -29,6 +29,8 @@ export interface DrawerProps extends Presettable {
   disableBackdropClick?: boolean;
   /** Disable closing via ESC key */
   disableEscapeKeyDown?: boolean;
+  /** Keep drawer open without backdrop */
+  persistent?: boolean;
   /** Drawer contents */
   children?: React.ReactNode;
 }
@@ -52,14 +54,24 @@ const Panel = styled('div')<{
   $size: string;
   $bg: string;
   $text: string;
+  $primary: string;
+  $persistent: boolean;
 }>`
   position: fixed;
-  z-index: 9999;
+  z-index: ${({ $persistent }) => ($persistent ? 9997 : 9999)};
   display: flex;
   flex-direction: column;
   background: ${({ $bg }) => $bg};
   color: ${({ $text }) => $text};
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  ${({ $anchor, $primary }) =>
+    $anchor === 'left'
+      ? `border-right:0.25rem solid ${$primary};`
+      : $anchor === 'right'
+      ? `border-left:0.25rem solid ${$primary};`
+      : $anchor === 'top'
+      ? `border-bottom:0.25rem solid ${$primary};`
+      : `border-top:0.25rem solid ${$primary};`}
   ${({ $anchor, $size }) =>
     $anchor === 'left' || $anchor === 'right'
       ? `width:${$size}; height:100%;`
@@ -72,15 +84,18 @@ const Panel = styled('div')<{
       : $anchor === 'top'
       ? 'top:0; left:0;'
       : 'bottom:0; left:0;'}
-  transform: ${({ $anchor, $fade }) =>
-    $anchor === 'left'
+  transform: ${({ $anchor, $fade, $persistent }) =>
+    $persistent
+      ? 'none'
+      : $anchor === 'left'
       ? `translateX(${$fade ? '-100%' : '0'})`
       : $anchor === 'right'
       ? `translateX(${$fade ? '100%' : '0'})`
       : $anchor === 'top'
       ? `translateY(${$fade ? '-100%' : '0'})`
       : `translateY(${$fade ? '100%' : '0'})`};
-  transition: transform 200ms ease;
+  transition: ${({ $persistent }) =>
+    $persistent ? 'none' : 'transform 200ms ease'};
 `;
 
 /*───────────────────────────────────────────────────────────*/
@@ -94,6 +109,7 @@ export const Drawer: React.FC<DrawerProps> = ({
   size = '16rem',
   disableBackdropClick = false,
   disableEscapeKeyDown = false,
+  persistent = false,
   children,
   preset: presetKey,
 }) => {
@@ -102,17 +118,18 @@ export const Drawer: React.FC<DrawerProps> = ({
 
   const uncontrolled = controlledOpen === undefined;
   const [openState, setOpenState] = useState(defaultOpen);
-  const open = uncontrolled ? openState : controlledOpen!;
-  const [fade, setFade] = useState(true);
+  const open = persistent ? true : uncontrolled ? openState : controlledOpen!;
+  const [fade, setFade] = useState(persistent ? false : true);
 
   const requestClose = useCallback(() => {
+    if (persistent) return;
     if (uncontrolled) setOpenState(false);
     onClose?.();
-  }, [uncontrolled, onClose]);
+  }, [persistent, uncontrolled, onClose]);
 
   /* Mount / unmount side-effects */
   useLayoutEffect(() => {
-    if (!open) return;
+    if (!open || persistent) return;
     setFade(false);
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape' && !disableEscapeKeyDown) {
@@ -125,10 +142,10 @@ export const Drawer: React.FC<DrawerProps> = ({
       document.removeEventListener('keydown', handleKeyDown, true);
       setFade(true);
     };
-  }, [open, disableEscapeKeyDown, requestClose]);
+  }, [open, persistent, disableEscapeKeyDown, requestClose]);
 
   const handleBackdropClick = (e: React.MouseEvent) => {
-    if (disableBackdropClick) return;
+    if (persistent || disableBackdropClick) return;
     if (e.target === e.currentTarget) requestClose();
   };
 
@@ -136,13 +153,15 @@ export const Drawer: React.FC<DrawerProps> = ({
 
   const drawerElement = (
     <>
-      <Backdrop $fade={fade} onClick={handleBackdropClick} />
+      {!persistent && <Backdrop $fade={fade} onClick={handleBackdropClick} />}
       <Panel
         $anchor={anchor}
         $fade={fade}
         $size={typeof size === 'number' ? `${size}px` : size}
-        $bg={theme.colors.surface}
+        $bg={theme.colors.background}
         $text={theme.colors.text}
+        $primary={theme.colors.primary}
+        $persistent={persistent}
         className={presetClasses}
       >
         {children}


### PR DESCRIPTION
## Summary
- use theme background for Drawer Panel
- add divider lines along the drawer's inner edge
- adjust divider line width to 0.25rem
- add persistent Drawer option with demo

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ea788303883209ff51754fd9d169b