### PR TITLE
Add TreeView component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 
 ## Unreleased
+### Added
+- TreeView component demonstrating nested navigation
 
 ## [v0.8.4]
 ### Added

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -48,6 +48,7 @@ const StepperDemoPage       = page(() => import('./pages/StepperDemo'));
 const RadioGroupDemoPage    = page(() => import('./pages/RadioGroupDemo'));
 const VideoDemoPage         = page(() => import('./pages/VideoDemo'));
 const SnackbarDemoPage      = page(() => import('./pages/SnackbarDemo'));
+const TreeViewDemoPage      = page(() => import('./pages/TreeViewDemo'));
 
 /*───────────────────────────────────────────────────────────*/
 export function App() {
@@ -107,6 +108,7 @@ export function App() {
         <Route path="/video-demo"      element={<VideoDemoPage />} />
         <Route path="/chat-demo"       element={<ChatDemoPage />} />
         <Route path="/snackbar-demo"   element={<SnackbarDemoPage />} />
+        <Route path="/treeview-demo"   element={<TreeViewDemoPage />} />
       </Routes>
     </Suspense>
   );

--- a/docs/src/pages/MainPage.tsx
+++ b/docs/src/pages/MainPage.tsx
@@ -189,6 +189,12 @@ export default function MainPage() {
               >
                 Stepper
               </Button>
+
+              <Button
+                onClick={() => navigate('/treeview-demo')}
+              >
+                TreeView
+              </Button>
             </Stack>
           </Panel>
 

--- a/docs/src/pages/TreeViewDemo.tsx
+++ b/docs/src/pages/TreeViewDemo.tsx
@@ -1,0 +1,57 @@
+// src/pages/TreeViewDemo.tsx
+import { useState } from 'react';
+import { Surface, Stack, Typography, Button, TreeView, type TreeNode, useTheme } from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+
+interface Item {
+  label: React.ReactNode;
+}
+
+const DATA: TreeNode<Item>[] = [
+  {
+    id: 'fruit',
+    data: { label: '🍎 Fruit' },
+    children: [
+      { id: 'apple', data: { label: 'Green Apple 🍏' } },
+      { id: 'banana', data: { label: 'Banana 🍌' } },
+    ],
+  },
+  {
+    id: 'dairy',
+    data: { label: '🧀 Dairy' },
+    children: [
+      { id: 'milk', data: { label: 'Milk 🥛' } },
+      { id: 'cheese', data: { label: 'Cheese 🧀' } },
+    ],
+  },
+];
+
+export default function TreeViewDemoPage() {
+  const { theme, toggleMode } = useTheme();
+  const navigate = useNavigate();
+  const [selected, setSelected] = useState('');
+
+  return (
+    <Surface>
+      <Stack spacing={1} preset="showcaseStack">
+        <Typography variant="h2" bold>TreeView Showcase</Typography>
+        <Typography variant="subtitle">Nested list with keyboard navigation</Typography>
+
+        <TreeView<Item>
+          nodes={DATA}
+          getLabel={(n) => n.label}
+          defaultExpanded={['fruit']}
+          onNodeSelect={(n) => setSelected(String(n.label))}
+        />
+        <Typography variant="body">
+          Selected: <code>{selected}</code>
+        </Typography>
+
+        <Stack direction="row" spacing={1}>
+          <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
+          <Button onClick={() => navigate(-1)}>← Back</Button>
+        </Stack>
+      </Stack>
+    </Surface>
+  );
+}

--- a/src/components/TreeView.tsx
+++ b/src/components/TreeView.tsx
@@ -1,0 +1,207 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/TreeView.tsx | valet
+// Basic accessible tree view component
+// ─────────────────────────────────────────────────────────────
+import React, { useMemo, useState, useRef, KeyboardEvent } from 'react';
+import { styled } from '../css/createStyled';
+import { useTheme } from '../system/themeStore';
+import { preset } from '../css/stylePresets';
+import { toRgb, mix, toHex } from '../helpers/color';
+import type { Presettable } from '../types';
+
+/*───────────────────────────────────────────────────────────*/
+export interface TreeNode<T> {
+  id: string;
+  data: T;
+  children?: TreeNode<T>[];
+}
+
+export interface TreeViewProps<T>
+  extends Omit<React.HTMLAttributes<HTMLUListElement>, 'children'>,
+    Presettable {
+  nodes: TreeNode<T>[];
+  getLabel: (node: T) => React.ReactNode;
+  defaultExpanded?: string[];
+  onNodeSelect?: (node: T) => void;
+}
+
+/*───────────────────────────────────────────────────────────*/
+const Root = styled('ul')<{ $border: string }>`
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid ${({ $border }) => $border};
+`;
+
+const ItemRow = styled('div')<{
+  $level: number;
+  $hoverBg: string;
+  $selectedBg: string;
+  $selected: boolean;
+}>`
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem 0.25rem ${({ $level }) => $level * 1.25}rem;
+  cursor: pointer;
+  user-select: none;
+  ${({ $hoverBg }) =>
+    `@media(hover:hover){&:hover{background:${$hoverBg};}}`}
+  ${({ $selected, $selectedBg }) =>
+    $selected ? `background:${$selectedBg};` : ''}
+  &:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+  }
+`;
+
+const ExpandIcon = styled('span')<{ $open: boolean }>`
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  transform: rotate(${({ $open }) => ($open ? 90 : 0)}deg);
+  transition: transform 150ms ease;
+`;
+
+/*───────────────────────────────────────────────────────────*/
+export function TreeView<T>({
+  nodes,
+  getLabel,
+  defaultExpanded = [],
+  onNodeSelect,
+  preset: p,
+  className,
+  ...rest
+}: TreeViewProps<T>) {
+  const { theme } = useTheme();
+  const [expanded, setExpanded] = useState(() => new Set(defaultExpanded));
+  const [focused, setFocused] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string | null>(null);
+
+  const hoverBg = toHex(mix(toRgb(theme.colors.primary), toRgb(theme.colors.background), 0.2));
+  const selectedBg = toHex(mix(toRgb(theme.colors.primary), toRgb(theme.colors.background), 0.4));
+
+  const flat = useMemo(() => {
+    const res: { node: TreeNode<T>; level: number }[] = [];
+    const walk = (items: TreeNode<T>[], level: number) => {
+      for (const it of items) {
+        res.push({ node: it, level });
+        if (it.children && expanded.has(it.id)) walk(it.children, level + 1);
+      }
+    };
+    walk(nodes, 0);
+    return res;
+  }, [nodes, expanded]);
+
+  const refs = useRef<Record<string, HTMLDivElement | null>>({});
+
+  const focusItem = (id: string) => {
+    setFocused(id);
+    refs.current[id]?.focus();
+  };
+
+  const toggle = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const visibleIds = flat.map((f) => f.node.id);
+
+  const keyNav = (e: KeyboardEvent<HTMLUListElement>) => {
+    if (!focused) return;
+    const idx = visibleIds.indexOf(focused);
+    if (idx === -1) return;
+    const current = flat[idx];
+
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        if (idx < visibleIds.length - 1) focusItem(visibleIds[idx + 1]);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        if (idx > 0) focusItem(visibleIds[idx - 1]);
+        break;
+      case 'ArrowRight':
+        e.preventDefault();
+        if (current.node.children) {
+          if (!expanded.has(current.node.id)) toggle(current.node.id);
+          else if (current.node.children.length)
+            focusItem(current.node.children[0].id);
+        }
+        break;
+      case 'ArrowLeft':
+        e.preventDefault();
+        if (expanded.has(current.node.id)) toggle(current.node.id);
+        else {
+          for (let i = idx - 1; i >= 0; i--) {
+            const candidate = flat[i];
+            if (candidate.level < current.level) {
+              focusItem(candidate.node.id);
+              break;
+            }
+          }
+        }
+        break;
+      case 'Enter':
+      case ' ': // Space
+        e.preventDefault();
+        setSelected(current.node.id);
+        onNodeSelect?.(current.node.data);
+        break;
+    }
+  };
+
+  return (
+    <Root
+      {...rest}
+      role="tree"
+      tabIndex={0}
+      onKeyDown={keyNav}
+      $border={theme.colors.backgroundAlt}
+      className={[p ? preset(p) : '', className].filter(Boolean).join(' ')}
+    >
+      {flat.map(({ node, level }) => (
+        <li key={node.id} role="none">
+          <ItemRow
+            ref={(el) => (refs.current[node.id] = el)}
+            role="treeitem"
+            aria-expanded={node.children ? expanded.has(node.id) : undefined}
+            aria-selected={selected === node.id}
+            tabIndex={focused === node.id ? 0 : -1}
+            $level={level}
+            $hoverBg={hoverBg}
+            $selectedBg={selectedBg}
+            $selected={selected === node.id}
+            onClick={() => {
+              focusItem(node.id);
+              setSelected(node.id);
+              onNodeSelect?.(node.data);
+            }}
+            onDoubleClick={() => node.children && toggle(node.id)}
+          >
+            {node.children && (
+              <ExpandIcon
+                aria-hidden
+                $open={expanded.has(node.id)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toggle(node.id);
+                }}
+              >
+                ▶
+              </ExpandIcon>
+            )}
+            {getLabel(node.data)}
+          </ItemRow>
+        </li>
+      ))}
+    </Root>
+  );
+}
+
+export default TreeView;

--- a/src/components/TreeView.tsx
+++ b/src/components/TreeView.tsx
@@ -78,8 +78,13 @@ export function TreeView<T>({
   const [focused, setFocused] = useState<string | null>(null);
   const [selected, setSelected] = useState<string | null>(null);
 
-  const hoverBg = toHex(mix(toRgb(theme.colors.primary), toRgb(theme.colors.background), 0.2));
-  const selectedBg = toHex(mix(toRgb(theme.colors.primary), toRgb(theme.colors.background), 0.4));
+  // Swap hover and active intensity per design feedback
+  const hoverBg = toHex(
+    mix(toRgb(theme.colors.primary), toRgb(theme.colors.background), 0.4)
+  );
+  const selectedBg = toHex(
+    mix(toRgb(theme.colors.primary), toRgb(theme.colors.background), 0.2)
+  );
 
   const flat = useMemo(() => {
     const res: { node: TreeNode<T>; level: number }[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ export * from './components/Stepper';
 export * from './components/SpeedDial';
 export * from './components/Grid';
 export * from './components/List';
+export * from './components/TreeView';
 export * from './components/Parallax';
 export * from './components/Progress';
 export * from './components/RadioGroup';


### PR DESCRIPTION
## Summary
- create `TreeView` component for nested lists and keyboard navigation
- export component from library
- add demo page for TreeView
- expose demo route in docs
- link demo from main page

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686eb47500e48320a12709afa266fe27