### PR TITLE
Add list variant to TreeView

### DIFF
--- a/docs/src/pages/TreeViewDemo.tsx
+++ b/docs/src/pages/TreeViewDemo.tsx
@@ -1,6 +1,6 @@
 // src/pages/TreeViewDemo.tsx
 import { useState } from 'react';
-import { Surface, Stack, Typography, Button, TreeView, type TreeNode, useTheme } from '@archway/valet';
+import { Surface, Stack, Typography, Button, TreeView, type TreeNode, type TreeViewVariant, useTheme } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
 
 interface Item {
@@ -30,6 +30,7 @@ export default function TreeViewDemoPage() {
   const { theme, toggleMode } = useTheme();
   const navigate = useNavigate();
   const [selected, setSelected] = useState('');
+  const [variant, setVariant] = useState<TreeViewVariant>('chevron');
 
   return (
     <Surface>
@@ -42,10 +43,26 @@ export default function TreeViewDemoPage() {
           getLabel={(n) => n.label}
           defaultExpanded={['fruit']}
           onNodeSelect={(n) => setSelected(String(n.label))}
+          variant={variant}
         />
         <Typography variant="body">
           Selected: <code>{selected}</code>
         </Typography>
+
+        <Stack direction="row" spacing={1}>
+          <Button
+            variant={variant === 'chevron' ? 'contained' : 'outlined'}
+            onClick={() => setVariant('chevron')}
+          >
+            Chevron
+          </Button>
+          <Button
+            variant={variant === 'list' ? 'contained' : 'outlined'}
+            onClick={() => setVariant('list')}
+          >
+            List
+          </Button>
+        </Stack>
 
         <Stack direction="row" spacing={1}>
           <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>


### PR DESCRIPTION
## Summary
- support TreeView variant prop
- add new `list` design with connector lines and square expanders
- showcase variants in docs demo

## Testing
- `npm run build`
- `npm run build` in docs

------
https://chatgpt.com/codex/tasks/task_e_686ebd6f06bc83209b6f0363dbd328b2