### PR TITLE
Add list treeview style

### DIFF
--- a/docs/src/pages/TreeViewDemo.tsx
+++ b/docs/src/pages/TreeViewDemo.tsx
@@ -35,9 +35,19 @@ export default function TreeViewDemoPage() {
     <Surface>
       <Stack spacing={1} preset="showcaseStack">
         <Typography variant="h2" bold>TreeView Showcase</Typography>
-        <Typography variant="subtitle">Nested list with keyboard navigation</Typography>
+        <Typography variant="subtitle">Keyboard navigation with two visual styles</Typography>
 
+        <Typography variant="h3">1. Chevron Variant</Typography>
         <TreeView<Item>
+          nodes={DATA}
+          getLabel={(n) => n.label}
+          defaultExpanded={['fruit']}
+          onNodeSelect={(n) => setSelected(String(n.label))}
+        />
+
+        <Typography variant="h3">2. List Variant</Typography>
+        <TreeView<Item>
+          variant="list"
           nodes={DATA}
           getLabel={(n) => n.label}
           defaultExpanded={['fruit']}

--- a/src/components/TreeView.tsx
+++ b/src/components/TreeView.tsx
@@ -16,6 +16,8 @@ export interface TreeNode<T> {
   children?: TreeNode<T>[];
 }
 
+export type TreeViewVariant = 'chevron' | 'list';
+
 export interface TreeViewProps<T>
   extends Omit<React.HTMLAttributes<HTMLUListElement>, 'children'>,
     Presettable {
@@ -23,6 +25,7 @@ export interface TreeViewProps<T>
   getLabel: (node: T) => React.ReactNode;
   defaultExpanded?: string[];
   onNodeSelect?: (node: T) => void;
+  variant?: TreeViewVariant;
 }
 
 /*───────────────────────────────────────────────────────────*/
@@ -33,16 +36,59 @@ const Root = styled('ul')<{ $border: string }>`
   border: 1px solid ${({ $border }) => $border};
 `;
 
+const Branch = styled('ul')<{ $border: string }>`
+  list-style: none;
+  margin: 0;
+  margin-left: 1.25rem;
+  padding-left: 0.75rem;
+  position: relative;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    border-left: 1px solid ${({ $border }) => $border};
+  }
+`;
+
+const BranchItem = styled('li')<{ $last: boolean; $border: string }>`
+  position: relative;
+  padding-left: 0.75rem;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0.75rem;
+    left: 0;
+    width: 0.75rem;
+    border-top: 1px solid ${({ $border }) => $border};
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: ${({ $last }) => ($last ? '0.75rem' : '0')};
+    left: 0;
+    border-left: 1px solid ${({ $border }) => $border};
+  }
+`;
+
 const ItemRow = styled('div')<{
   $level: number;
   $hoverBg: string;
   $selectedBg: string;
   $selected: boolean;
+  $variant: TreeViewVariant;
+  $border: string;
 }>`
   display: flex;
   align-items: center;
   gap: 0.25rem;
-  padding: 0.25rem 0.5rem 0.25rem ${({ $level }) => $level * 1.25}rem;
+  padding: 0.25rem 0.5rem 0.25rem
+    ${({ $variant, $level }) => ($variant === 'chevron' ? $level * 1.25 : 0)}rem;
   cursor: pointer;
   user-select: none;
   ${({ $hoverBg }) =>
@@ -53,14 +99,45 @@ const ItemRow = styled('div')<{
     outline: 2px solid currentColor;
     outline-offset: 2px;
   }
+
+  ${({ $variant, $border }) =>
+    $variant === 'list'
+      ? `
+    position: relative;
+    padding-left: 0.25rem;
+
+    &::before {
+      content: '';
+      position: absolute;
+      top: 50%;
+      left: 0;
+      width: 0.75rem;
+      border-top: 1px solid ${$border};
+      transform: translateY(-50%);
+    }
+  `
+      : ''}
 `;
 
-const ExpandIcon = styled('span')<{ $open: boolean }>`
+const ExpandIcon = styled('span')<{
+  $open: boolean;
+  $variant: TreeViewVariant;
+  $border: string;
+}>`
   display: inline-block;
   width: 1em;
   height: 1em;
-  transform: rotate(${({ $open }) => ($open ? 90 : 0)}deg);
-  transition: transform 150ms ease;
+  ${({ $variant, $open, $border }) =>
+    $variant === 'chevron'
+      ? `
+          transform: rotate(${$open ? 90 : 0}deg);
+          transition: transform 150ms ease;
+        `
+      : `
+          box-sizing: border-box;
+          border: 1px solid ${$border};
+          background: ${$open ? $border : 'transparent'};
+        `}
 `;
 
 /*───────────────────────────────────────────────────────────*/
@@ -69,6 +146,7 @@ export function TreeView<T>({
   getLabel,
   defaultExpanded = [],
   onNodeSelect,
+  variant = 'chevron',
   preset: p,
   className,
   ...rest
@@ -99,6 +177,69 @@ export function TreeView<T>({
   }, [nodes, expanded]);
 
   const refs = useRef<Record<string, HTMLDivElement | null>>({});
+
+  const renderNodes = (items: TreeNode<T>[], level: number): React.ReactNode =>
+    items.map((node, idx) => {
+      const isOpen = expanded.has(node.id);
+      const hasChildren = !!node.children?.length;
+
+      const row = (
+        <ItemRow
+          ref={(el) => (refs.current[node.id] = el)}
+          role="treeitem"
+          aria-expanded={hasChildren ? isOpen : undefined}
+          aria-selected={selected === node.id}
+          tabIndex={focused === node.id ? 0 : -1}
+          $level={level}
+          $hoverBg={hoverBg}
+          $selectedBg={selectedBg}
+          $selected={selected === node.id}
+          $variant={variant}
+          $border={theme.colors.backgroundAlt}
+          onClick={() => {
+            focusItem(node.id);
+            setSelected(node.id);
+            onNodeSelect?.(node.data);
+          }}
+          onDoubleClick={() => hasChildren && toggle(node.id)}
+        >
+          {hasChildren && (
+            <ExpandIcon
+              aria-hidden
+              $open={isOpen}
+              $variant={variant}
+              $border={theme.colors.backgroundAlt}
+              onClick={(e) => {
+                e.stopPropagation();
+                toggle(node.id);
+              }}
+            >
+              {variant === 'chevron' ? '▶' : ''}
+            </ExpandIcon>
+          )}
+          {getLabel(node.data)}
+        </ItemRow>
+      );
+
+      if (variant === 'list') {
+        return (
+          <BranchItem key={node.id} $last={idx === items.length - 1} $border={theme.colors.backgroundAlt}>
+            {row}
+            {hasChildren && isOpen && (
+              <Branch $border={theme.colors.backgroundAlt}>
+                {renderNodes(node.children!, level + 1)}
+              </Branch>
+            )}
+          </BranchItem>
+        );
+      }
+
+      return (
+        <li key={node.id} role="none">
+          {row}
+        </li>
+      );
+    });
 
   const focusItem = (id: string) => {
     setFocused(id);
@@ -170,41 +311,46 @@ export function TreeView<T>({
       $border={theme.colors.backgroundAlt}
       className={[p ? preset(p) : '', className].filter(Boolean).join(' ')}
     >
-      {flat.map(({ node, level }) => (
-        <li key={node.id} role="none">
-          <ItemRow
-            ref={(el) => (refs.current[node.id] = el)}
-            role="treeitem"
-            aria-expanded={node.children ? expanded.has(node.id) : undefined}
-            aria-selected={selected === node.id}
-            tabIndex={focused === node.id ? 0 : -1}
-            $level={level}
-            $hoverBg={hoverBg}
-            $selectedBg={selectedBg}
-            $selected={selected === node.id}
-            onClick={() => {
-              focusItem(node.id);
-              setSelected(node.id);
-              onNodeSelect?.(node.data);
-            }}
-            onDoubleClick={() => node.children && toggle(node.id)}
-          >
-            {node.children && (
-              <ExpandIcon
-                aria-hidden
-                $open={expanded.has(node.id)}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  toggle(node.id);
-                }}
-              >
-                ▶
-              </ExpandIcon>
-            )}
-            {getLabel(node.data)}
-          </ItemRow>
-        </li>
-      ))}
+      {variant === 'list' ? renderNodes(nodes, 0) :
+        flat.map(({ node, level }) => (
+          <li key={node.id} role="none">
+            <ItemRow
+              ref={(el) => (refs.current[node.id] = el)}
+              role="treeitem"
+              aria-expanded={node.children ? expanded.has(node.id) : undefined}
+              aria-selected={selected === node.id}
+              tabIndex={focused === node.id ? 0 : -1}
+              $level={level}
+              $hoverBg={hoverBg}
+              $selectedBg={selectedBg}
+              $selected={selected === node.id}
+              $variant={variant}
+              $border={theme.colors.backgroundAlt}
+              onClick={() => {
+                focusItem(node.id);
+                setSelected(node.id);
+                onNodeSelect?.(node.data);
+              }}
+              onDoubleClick={() => node.children && toggle(node.id)}
+            >
+              {node.children && (
+                <ExpandIcon
+                  aria-hidden
+                  $open={expanded.has(node.id)}
+                  $variant={variant}
+                  $border={theme.colors.backgroundAlt}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    toggle(node.id);
+                  }}
+                >
+                  ▶
+                </ExpandIcon>
+              )}
+              {getLabel(node.data)}
+            </ItemRow>
+          </li>
+        ))}
     </Root>
   );
 }


### PR DESCRIPTION
## Summary
- add a `list` variant to TreeView alongside existing chevron style
- support recursive rendering with connecting lines and square expand icons
- demo both variants in docs

## Testing
- `npm run build`
- `(cd docs && npm run build)`


------
https://chatgpt.com/codex/tasks/task_e_686ebd6f06bc83209b6f0363dbd328b2