### PR TITLE
Add list variant to TreeView

### DIFF
--- a/docs/src/pages/TreeViewDemo.tsx
+++ b/docs/src/pages/TreeViewDemo.tsx
@@ -37,15 +37,25 @@ export default function TreeViewDemoPage() {
         <Typography variant="h2" bold>TreeView Showcase</Typography>
         <Typography variant="subtitle">Nested list with keyboard navigation</Typography>
 
+        <Typography variant="h3">1. Chevron variant</Typography>
         <TreeView<Item>
           nodes={DATA}
           getLabel={(n) => n.label}
           defaultExpanded={['fruit']}
           onNodeSelect={(n) => setSelected(String(n.label))}
+          variant="chevron"
         />
         <Typography variant="body">
           Selected: <code>{selected}</code>
         </Typography>
+
+        <Typography variant="h3">2. List variant</Typography>
+        <TreeView<Item>
+          nodes={DATA}
+          getLabel={(n) => n.label}
+          defaultExpanded={['fruit']}
+          variant="list"
+        />
 
         <Stack direction="row" spacing={1}>
           <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>

--- a/src/components/TreeView.tsx
+++ b/src/components/TreeView.tsx
@@ -23,6 +23,7 @@ export interface TreeViewProps<T>
   getLabel: (node: T) => React.ReactNode;
   defaultExpanded?: string[];
   onNodeSelect?: (node: T) => void;
+  variant?: 'chevron' | 'list';
 }
 
 /*───────────────────────────────────────────────────────────*/
@@ -63,12 +64,74 @@ const ExpandIcon = styled('span')<{ $open: boolean }>`
   transition: transform 150ms ease;
 `;
 
+const Branch = styled('ul')<{ $line: string; $root?: boolean }>`
+  list-style: none;
+  margin: 0;
+  padding-left: ${({ $root }) => ($root ? 0 : '0.75rem')};
+  position: relative;
+  ${({ $root, $line }) =>
+    !$root &&
+    `&::before{content:'';position:absolute;top:0;bottom:0;left:0.375rem;border-left:1px solid ${$line};}`}
+`;
+
+const BranchItem = styled('li')<{ $line: string }>`
+  position: relative;
+  margin: 0;
+  padding: 0;
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0.875rem;
+    left: 0;
+    width: 0.375rem;
+    border-top: 1px solid ${({ $line }) => $line};
+  }
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0.375rem;
+    border-left: 1px solid ${({ $line }) => $line};
+  }
+`;
+
+const ListRow = styled('div')<{
+  $hoverBg: string;
+  $selectedBg: string;
+  $selected: boolean;
+}>`
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  user-select: none;
+  ${({ $hoverBg }) =>`@media(hover:hover){&:hover{background:${$hoverBg};}}`}
+  ${({ $selected, $selectedBg }) => $selected ? `background:${$selectedBg};` : ''}
+  &:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+  }
+`;
+
+const BoxIcon = styled('span')<{ $open: boolean; $line: string }>`
+  display: inline-block;
+  width: 0.75em;
+  height: 0.75em;
+  border: 1px solid ${({ $line }) => $line};
+  background: ${({ $open, $line }) => ($open ? $line : 'transparent')};
+  margin-right: 0.25rem;
+  box-sizing: border-box;
+`;
+
 /*───────────────────────────────────────────────────────────*/
 export function TreeView<T>({
   nodes,
   getLabel,
   defaultExpanded = [],
   onNodeSelect,
+  variant = 'chevron',
   preset: p,
   className,
   ...rest
@@ -113,6 +176,8 @@ export function TreeView<T>({
       return next;
     });
   };
+
+  const line = theme.colors.backgroundAlt;
 
   const visibleIds = flat.map((f) => f.node.id);
 
@@ -161,24 +226,16 @@ export function TreeView<T>({
     }
   };
 
-  return (
-    <Root
-      {...rest}
-      role="tree"
-      tabIndex={0}
-      onKeyDown={keyNav}
-      $border={theme.colors.backgroundAlt}
-      className={[p ? preset(p) : '', className].filter(Boolean).join(' ')}
-    >
-      {flat.map(({ node, level }) => (
-        <li key={node.id} role="none">
-          <ItemRow
+  const renderBranch = (items: TreeNode<T>[], level: number): React.ReactNode => (
+    <Branch role={level ? 'group' : undefined} $line={line} $root={level === 0}>
+      {items.map((node) => (
+        <BranchItem key={node.id} $line={line} role="none">
+          <ListRow
             ref={(el) => (refs.current[node.id] = el)}
             role="treeitem"
             aria-expanded={node.children ? expanded.has(node.id) : undefined}
             aria-selected={selected === node.id}
             tabIndex={focused === node.id ? 0 : -1}
-            $level={level}
             $hoverBg={hoverBg}
             $selectedBg={selectedBg}
             $selected={selected === node.id}
@@ -190,21 +247,71 @@ export function TreeView<T>({
             onDoubleClick={() => node.children && toggle(node.id)}
           >
             {node.children && (
-              <ExpandIcon
+              <BoxIcon
                 aria-hidden
                 $open={expanded.has(node.id)}
+                $line={line}
                 onClick={(e) => {
                   e.stopPropagation();
                   toggle(node.id);
                 }}
-              >
-                ▶
-              </ExpandIcon>
+              />
             )}
             {getLabel(node.data)}
-          </ItemRow>
-        </li>
+          </ListRow>
+          {node.children && expanded.has(node.id) &&
+            renderBranch(node.children, level + 1)}
+        </BranchItem>
       ))}
+    </Branch>
+  );
+
+  return (
+    <Root
+      {...rest}
+      role="tree"
+      tabIndex={0}
+      onKeyDown={keyNav}
+      $border={theme.colors.backgroundAlt}
+      className={[p ? preset(p) : '', className].filter(Boolean).join(' ')}
+    >
+      {variant === 'chevron'
+        ? flat.map(({ node, level }) => (
+            <li key={node.id} role="none">
+              <ItemRow
+                ref={(el) => (refs.current[node.id] = el)}
+                role="treeitem"
+                aria-expanded={node.children ? expanded.has(node.id) : undefined}
+                aria-selected={selected === node.id}
+                tabIndex={focused === node.id ? 0 : -1}
+                $level={level}
+                $hoverBg={hoverBg}
+                $selectedBg={selectedBg}
+                $selected={selected === node.id}
+                onClick={() => {
+                  focusItem(node.id);
+                  setSelected(node.id);
+                  onNodeSelect?.(node.data);
+                }}
+                onDoubleClick={() => node.children && toggle(node.id)}
+              >
+                {node.children && (
+                  <ExpandIcon
+                    aria-hidden
+                    $open={expanded.has(node.id)}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      toggle(node.id);
+                    }}
+                  >
+                    ▶
+                  </ExpandIcon>
+                )}
+                {getLabel(node.data)}
+              </ItemRow>
+            </li>
+          ))
+        : renderBranch(nodes, 0)}
     </Root>
   );
 }


### PR DESCRIPTION
## Summary
- add `variant` prop to TreeView
- implement new `list` variant with connecting lines and box icons
- showcase both `chevron` and `list` variants in the docs
- adjust line positioning so connectors pass through the center of the list boxes

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ebd6f06bc83209b6f0363dbd328b2