### PR TITLE
Add list variant to TreeView

### DIFF
--- a/docs/src/pages/TreeViewDemo.tsx
+++ b/docs/src/pages/TreeViewDemo.tsx
@@ -37,15 +37,25 @@ export default function TreeViewDemoPage() {
         <Typography variant="h2" bold>TreeView Showcase</Typography>
         <Typography variant="subtitle">Nested list with keyboard navigation</Typography>
 
+        <Typography variant="h3">1. Chevron variant</Typography>
         <TreeView<Item>
           nodes={DATA}
           getLabel={(n) => n.label}
           defaultExpanded={['fruit']}
           onNodeSelect={(n) => setSelected(String(n.label))}
+          variant="chevron"
         />
         <Typography variant="body">
           Selected: <code>{selected}</code>
         </Typography>
+
+        <Typography variant="h3">2. List variant</Typography>
+        <TreeView<Item>
+          nodes={DATA}
+          getLabel={(n) => n.label}
+          defaultExpanded={['fruit']}
+          variant="list"
+        />
 
         <Stack direction="row" spacing={1}>
           <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>


### PR DESCRIPTION
## Summary
- add `variant` prop to TreeView
- implement new `list` variant with connecting lines and box icons
- showcase both `chevron` and `list` variants in the docs
- align list connectors with expand boxes

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ebd6f06bc83209b6f0363dbd328b2