### PR TITLE
Remove top-level lines from TreeView list variant

### DIFF
--- a/src/components/TreeView.tsx
+++ b/src/components/TreeView.tsx
@@ -72,17 +72,21 @@ const Branch = styled('ul')<{ $line: string; $root?: boolean }>`
   ${({ $root, $line }) => !$root && `border-left: 1px solid ${$line};`}
 `;
 
-const BranchItem = styled('li')<{ $line: string }>`
+const BranchItem = styled('li')<{ $line: string; $root?: boolean }>`
   position: relative;
   margin: 0;
   padding: 0;
+  ${({ $line, $root }) =>
+    $root
+      ? ''
+      : `
   &::before {
     content: '';
     position: absolute;
     top: 0.875rem;
     left: -1rem;
     width: 1rem;
-    border-top: 1px solid ${({ $line }) => $line};
+    border-top: 1px solid ${$line};
   }
   &::after {
     content: '';
@@ -90,8 +94,9 @@ const BranchItem = styled('li')<{ $line: string }>`
     top: 0;
     bottom: 0;
     left: -1rem;
-    border-left: 1px solid ${({ $line }) => $line};
+    border-left: 1px solid ${$line};
   }
+  `}
 `;
 
 const ListRow = styled('div')<{
@@ -227,7 +232,7 @@ export function TreeView<T>({
   const renderBranch = (items: TreeNode<T>[], level: number): React.ReactNode => (
     <Branch role={level ? 'group' : undefined} $line={line} $root={level === 0}>
       {items.map((node) => (
-        <BranchItem key={node.id} $line={line} role="none">
+        <BranchItem key={node.id} $line={line} $root={level === 0} role="none">
           <ListRow
             ref={(el) => (refs.current[node.id] = el)}
             role="treeitem"


### PR DESCRIPTION
## Summary
- prevent `TreeView` list variant from drawing lines on the root level

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ec37a49c88320bf2f4a59acb0a57b