### PR TITLE
Remove root lines from TreeView list variant

### DIFF
--- a/src/components/TreeView.tsx
+++ b/src/components/TreeView.tsx
@@ -72,26 +72,16 @@ const Branch = styled('ul')<{ $line: string; $root?: boolean }>`
   ${({ $root, $line }) => !$root && `border-left: 1px solid ${$line};`}
 `;
 
-const BranchItem = styled('li')<{ $line: string }>`
+const BranchItem = styled('li')<{ $line: string; $root?: boolean }>`
   position: relative;
   margin: 0;
   padding: 0;
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0.875rem;
-    left: -1rem;
-    width: 1rem;
-    border-top: 1px solid ${({ $line }) => $line};
-  }
-  &::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: -1rem;
-    border-left: 1px solid ${({ $line }) => $line};
-  }
+  ${({ $line, $root }) =>
+    !$root &&
+    `&::before{content:'';position:absolute;top:0.875rem;left:-1rem;width:1rem;border-top:1px solid ${$line};}`}
+  ${({ $line, $root }) =>
+    !$root &&
+    `&::after{content:'';position:absolute;top:0;bottom:0;left:-1rem;border-left:1px solid ${$line};}`}
 `;
 
 const ListRow = styled('div')<{
@@ -227,7 +217,7 @@ export function TreeView<T>({
   const renderBranch = (items: TreeNode<T>[], level: number): React.ReactNode => (
     <Branch role={level ? 'group' : undefined} $line={line} $root={level === 0}>
       {items.map((node) => (
-        <BranchItem key={node.id} $line={line} role="none">
+        <BranchItem key={node.id} $line={line} role="none" $root={level === 0}>
           <ListRow
             ref={(el) => (refs.current[node.id] = el)}
             role="treeitem"


### PR DESCRIPTION
## Summary
- adjust styling so the highest level of the TreeView `list` variant has no vertical or horizontal lines

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686ec37a49c88320bf2f4a59acb0a57b