### PR TITLE
Improve TreeView list connector lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file. The format 
 ## Unreleased
 ### Added
 - TreeView component demonstrating nested navigation
+### Improved
+- List variant lines centered on expand boxes and omit root connector
 
 ## [v0.8.4]
 ### Added

--- a/src/components/TreeView.tsx
+++ b/src/components/TreeView.tsx
@@ -69,27 +69,30 @@ const Branch = styled('ul')<{ $line: string; $root?: boolean }>`
   margin: 0;
   padding-left: ${({ $root }) => ($root ? 0 : '1rem')};
   position: relative;
-  ${({ $root, $line }) => !$root && `border-left: 1px solid ${$line};`}
 `;
 
-const BranchItem = styled('li')<{ $line: string }>`
+const BranchItem = styled('li')<{ $line: string; $root?: boolean }>`
   position: relative;
   margin: 0;
   padding: 0;
-  &::before {
-    content: '';
-    position: absolute;
-    top: 0.875rem;
-    left: -1rem;
-    width: 1rem;
-    border-top: 1px solid ${({ $line }) => $line};
-  }
+  ${({ $root, $line }) =>
+    !$root &&
+    `
+      &::before {
+        content: '';
+        position: absolute;
+        top: 0.875rem;
+        left: calc(-1rem + 0.375em);
+        width: calc(1rem - 0.375em);
+        border-top: 1px solid ${$line};
+      }
+    `}
   &::after {
     content: '';
     position: absolute;
     top: 0;
     bottom: 0;
-    left: -1rem;
+    left: calc(-1rem + 0.375em);
     border-left: 1px solid ${({ $line }) => $line};
   }
 `;
@@ -227,7 +230,7 @@ export function TreeView<T>({
   const renderBranch = (items: TreeNode<T>[], level: number): React.ReactNode => (
     <Branch role={level ? 'group' : undefined} $line={line} $root={level === 0}>
       {items.map((node) => (
-        <BranchItem key={node.id} $line={line} role="none">
+        <BranchItem key={node.id} $line={line} $root={level === 0} role="none">
           <ListRow
             ref={(el) => (refs.current[node.id] = el)}
             role="treeitem"


### PR DESCRIPTION
## Summary
- refine TreeView list variant connectors to drop leftmost lines
- center connecting lines under expand boxes
- update changelog

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686ec8bac7cc8320a5595eb54506d24e