### PR TITLE
Adjust Tree list box color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Improved
 - List variant lines centered on expand boxes and omit root connector
 - Tree demo shows a third level with mixed collapsible nodes
+- List variant boxes now use the secondary theme color when expanded
 
 ## [v0.8.4]
 ### Added

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -115,12 +115,16 @@ const ListRow = styled('div')<{
   }
 `;
 
-const BoxIcon = styled('span')<{ $open: boolean; $line: string }>`
+const BoxIcon = styled('span')<{
+  $open: boolean;
+  $line: string;
+  $fill: string;
+}>`
   display: inline-block;
   width: 0.75em;
   height: 0.75em;
   border: 1px solid ${({ $line }) => $line};
-  background: ${({ $open, $line }) => ($open ? $line : 'transparent')};
+  background: ${({ $open, $fill }) => ($open ? $fill : 'transparent')};
   margin-right: 0.25rem;
   box-sizing: border-box;
 `;
@@ -251,6 +255,7 @@ export function Tree<T>({
                 aria-hidden
                 $open={expanded.has(node.id)}
                 $line={line}
+                $fill={theme.colors.secondary}
                 onClick={(e) => {
                   e.stopPropagation();
                   toggle(node.id);


### PR DESCRIPTION
## Summary
- tint list variant box icons with theme secondary color
- note the change in the changelog

## Testing
- `npm run build`
- `(cd docs && npm run build)`

------
https://chatgpt.com/codex/tasks/task_e_686f10967d7483209424c50352d3264a