### PR TITLE
Add files variant to Tree

### DIFF
--- a/docs/src/pages/TreeDemo.tsx
+++ b/docs/src/pages/TreeDemo.tsx
@@ -40,6 +40,25 @@ const DATA: TreeNode<Item>[] = [
   },
 ];
 
+const FILES: TreeNode<Item>[] = [
+  {
+    id: 'src',
+    data: { label: 'src' },
+    children: [
+      {
+        id: 'components',
+        data: { label: 'components' },
+        children: [
+          { id: 'Button.tsx', data: { label: 'Button.tsx' } },
+          { id: 'Tree.tsx', data: { label: 'Tree.tsx' } },
+        ],
+      },
+      { id: 'index.ts', data: { label: 'index.ts' } },
+    ],
+  },
+  { id: 'package.json', data: { label: 'package.json' } },
+];
+
 export default function TreeDemoPage() {
   const { theme, toggleMode } = useTheme();
   const navigate = useNavigate();
@@ -69,6 +88,14 @@ export default function TreeDemoPage() {
           getLabel={(n) => n.label}
           defaultExpanded={['fruit', 'dairy']}
           variant="list"
+        />
+
+        <Typography variant="h3">3. Files variant</Typography>
+        <Tree<Item>
+          nodes={FILES}
+          getLabel={(n) => n.label}
+          defaultExpanded={['src', 'components']}
+          variant="files"
         />
 
         <Stack direction="row" spacing={1}>

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -3,6 +3,7 @@
 // Basic accessible tree view component
 // ─────────────────────────────────────────────────────────────
 import React, { useMemo, useState, useRef, KeyboardEvent } from 'react';
+import Icon from './Icon';
 import { styled } from '../css/createStyled';
 import { useTheme } from '../system/themeStore';
 import { preset } from '../css/stylePresets';
@@ -23,7 +24,7 @@ export interface TreeProps<T>
   getLabel: (node: T) => React.ReactNode;
   defaultExpanded?: string[];
   onNodeSelect?: (node: T) => void;
-  variant?: 'chevron' | 'list';
+  variant?: 'chevron' | 'list' | 'files';
 }
 
 /*───────────────────────────────────────────────────────────*/
@@ -250,7 +251,7 @@ export function Tree<T>({
             }}
             onDoubleClick={() => node.children && toggle(node.id)}
           >
-            {node.children && (
+            {variant === 'list' && node.children && (
               <BoxIcon
                 aria-hidden
                 $open={expanded.has(node.id)}
@@ -260,6 +261,15 @@ export function Tree<T>({
                   e.stopPropagation();
                   toggle(node.id);
                 }}
+              />
+            )}
+            {variant === 'files' && (
+              <Icon
+                icon={node.children ? (expanded.has(node.id) ? 'carbon:folder-open' : 'carbon:folder') : 'carbon:document'}
+                size={16}
+                style={{ marginRight: '0.25rem' }}
+                aria-hidden
+                onClick={node.children ? (e => { e.stopPropagation(); toggle(node.id); }) : undefined}
               />
             )}
             {getLabel(node.data)}


### PR DESCRIPTION
## Summary
- extend Tree with `files` variant using Carbon file/folder icons
- showcase file tree demo in docs

## Testing
- `npm run build`
- `cd docs && npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686f437779888320ab2cb98dcdf8e1a9