### PR TITLE
Add responsive drawer hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ These have been mostly tested in the [valet Docs](https://github.com/off-court-c
 | useGoogleFonts     | ✅        | ✅             |----------|
 | useTheme           | ✅        | ✅             |----------|
 | useInitialTheme    | ✅        | ✅             | applies theme and waits for fonts |
+| useResponsiveDrawer | ✅        | ✅             | toggles Drawer persistence |
+
+### Responsive drawers
+
+`useResponsiveDrawer(size, ratio)` returns `true` when a drawer of the
+given size should remain visible without a backdrop. Pass the returned
+boolean to the `<Drawer>` `persistent` prop. The optional `ratio`
+defaults to `0.4`.
 
 ## Utilities
 

--- a/docs/src/pages/DrawerDemo.tsx
+++ b/docs/src/pages/DrawerDemo.tsx
@@ -8,11 +8,15 @@ import {
   Button,
   Drawer,
   useTheme,
+  useResponsiveDrawer,
 } from '@archway/valet';
 
 export default function DrawerDemoPage() {
   const { theme, toggleMode } = useTheme();
   const navigate = useNavigate();
+
+  const drawerSize = '16rem';
+  const persistent = useResponsiveDrawer(drawerSize);
 
   const [overlayOpen, setOverlayOpen] = useState(false);
   const [rightOpen, setRightOpen] = useState(false);
@@ -20,7 +24,7 @@ export default function DrawerDemoPage() {
 
   return (
     <Surface>
-      <Drawer persistent anchor="left" size="16rem">
+      <Drawer persistent={persistent} anchor="left" size={drawerSize}>
         <Stack spacing={1} style={{ padding: theme.spacing(1) }}>
           <Typography variant="h4" bold>
             Persistent Drawer
@@ -30,7 +34,12 @@ export default function DrawerDemoPage() {
       </Drawer>
       <Stack
         spacing={1}
-        style={{ padding: theme.spacing(1), maxWidth: 980, margin: '0 auto', marginLeft: '16rem' }}
+        style={{
+          padding: theme.spacing(1),
+          maxWidth: 980,
+          margin: '0 auto',
+          marginLeft: persistent ? drawerSize : undefined,
+        }}
       >
         <Typography variant="h2" bold>
           Drawer Showcase

--- a/src/hooks/useResponsiveDrawer.ts
+++ b/src/hooks/useResponsiveDrawer.ts
@@ -1,0 +1,42 @@
+// ─────────────────────────────────────────────────────────────
+// src/hooks/useResponsiveDrawer.ts  | valet
+// persistent drawers when wide enough
+// ─────────────────────────────────────────────────────────────
+import { useMemo } from 'react';
+import { useSurface } from '../components/Surface';
+
+/**
+ * Determines if a Drawer should stay persistent based on
+ * current Surface width and desired ratio.
+ *
+ * @param size  Drawer size in px or any CSS length.
+ * @param ratio Portion of the Surface width required for persistence.
+ */
+export function useResponsiveDrawer(
+  size: number | string,
+  ratio = 0.4,
+): boolean {
+  const { width } = useSurface();
+
+  const toPx = (val: number | string): number => {
+    if (typeof val === 'number') return val;
+    const n = parseFloat(val);
+    if (val.endsWith('px')) return n;
+    if (val.endsWith('rem') || val.endsWith('em')) {
+      const base =
+        typeof window !== 'undefined'
+          ? parseFloat(getComputedStyle(document.documentElement).fontSize)
+          : 16;
+      return n * base;
+    }
+    if (val.endsWith('vw')) return (n / 100) * window.innerWidth;
+    if (val.endsWith('vh')) return (n / 100) * window.innerHeight;
+    return n;
+  };
+
+  const px = useMemo(() => toPx(size), [size]);
+
+  return px <= width * ratio;
+}
+
+export default useResponsiveDrawer;

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,3 +45,4 @@ export * from './system/themeStore';
 export * from './system/fontStore';
 export * from './system/createInitialTheme';
 export * from './hooks/useGoogleFonts';
+export * from './hooks/useResponsiveDrawer';


### PR DESCRIPTION
## Summary
- implement `useResponsiveDrawer` hook
- update Drawer docs page to use hook
- export hook from package
- document responsive drawers in README

## Testing
- `npm run build`
- `npm run build` in docs

------
https://chatgpt.com/codex/tasks/task_e_686f539ef1708320a44f207316fdc1cf