### PR TITLE
Add responsive drawer type

### DIFF
--- a/docs/src/pages/DrawerDemo.tsx
+++ b/docs/src/pages/DrawerDemo.tsx
@@ -84,6 +84,19 @@ export default function DrawerDemoPage() {
           </Stack>
         </Drawer>
 
+        {/* 4. Responsive drawer */}
+        <Typography variant="h3">4. Responsive drawer</Typography>
+        <Drawer responsive anchor="right" size="16rem">
+          <Stack spacing={1} style={{ padding: theme.spacing(1) }}>
+            <Typography variant="h4" bold>
+              Responsive Drawer
+            </Typography>
+            <Typography>
+              Persistent in landscape, icon in portrait.
+            </Typography>
+          </Stack>
+        </Drawer>
+
         {/* Theme toggle + back nav */}
         <Stack direction="row" spacing={1}>
           <Button variant="outlined" onClick={toggleMode}>


### PR DESCRIPTION
## Summary
- add responsive Drawer that switches between persistent and overlay based on orientation
- show responsive Drawer example in docs

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686f580168088320abde6156fbcd01c7