### PR TITLE
Docs drawer navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Unreleased
 ### Added
 - Tree component demonstrating nested navigation (renamed from TreeView)
+- Responsive drawer navigation with Getting Started pages
 ### Improved
 - List variant lines centered on expand boxes and omit root connector
 - Tree demo shows a third level with mixed collapsible nodes

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -49,6 +49,9 @@ const RadioGroupDemoPage    = page(() => import('./pages/RadioGroupDemo'));
 const VideoDemoPage         = page(() => import('./pages/VideoDemo'));
 const SnackbarDemoPage      = page(() => import('./pages/SnackbarDemo'));
 const TreeDemoPage          = page(() => import('./pages/TreeDemo'));
+const OverviewPage          = page(() => import('./pages/Overview'));
+const InstallationPage      = page(() => import('./pages/Installation'));
+const UsagePage             = page(() => import('./pages/Usage'));
 
 /*───────────────────────────────────────────────────────────*/
 export function App() {
@@ -71,6 +74,9 @@ export function App() {
     <Suspense fallback={Fallback}>
       <Routes>
         <Route path="/"                element={<MainPage />} />
+        <Route path="/overview"        element={<OverviewPage />} />
+        <Route path="/installation"    element={<InstallationPage />} />
+        <Route path="/usage"           element={<UsagePage />} />
         <Route path="/typography"      element={<TypographyDemoPage />} />
         <Route path="/presets"         element={<PresetDemoPage />} />
         <Route path="/form"            element={<FormDemoPage />} />

--- a/docs/src/pages/Installation.tsx
+++ b/docs/src/pages/Installation.tsx
@@ -1,0 +1,21 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/Installation.tsx  | valet
+// Getting started installation page
+// ─────────────────────────────────────────────────────────────
+import { Surface, Stack, Typography, Button } from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+
+export default function InstallationPage() {
+  const navigate = useNavigate();
+
+  return (
+    <Surface>
+      <Stack spacing={1} preset="showcaseStack">
+        <Typography variant="h2" bold>Installation</Typography>
+        <Typography>Install via npm:</Typography>
+        <Typography><code>npm install @archway/valet</code></Typography>
+        <Button onClick={() => navigate(-1)}>← Back</Button>
+      </Stack>
+    </Surface>
+  );
+}

--- a/docs/src/pages/MainPage.tsx
+++ b/docs/src/pages/MainPage.tsx
@@ -1,244 +1,108 @@
-// src/pages/MainPage.tsx
+// ─────────────────────────────────────────────────────────────
+// src/pages/MainPage.tsx  | valet
+// Doc home with responsive drawer navigation
+// ─────────────────────────────────────────────────────────────
 import { useNavigate } from 'react-router-dom';
-import { Surface, Button, Typography, Stack, useTheme, Box, Panel } from '@archway/valet';
+import {
+  Surface,
+  Drawer,
+  Stack,
+  Button,
+  Typography,
+  useTheme,
+} from '@archway/valet';
 
 export default function MainPage() {
   const navigate = useNavigate();
-  const { mode, toggleMode } = useTheme();
+  const { theme, mode, toggleMode } = useTheme();
+
+  const components: [string, string][] = [
+    ['Accordion', '/accordion-demo'],
+    ['Avatar', '/avatar-demo'],
+    ['Box', '/box-demo'],
+    ['Button', '/button-demo'],
+    ['Checkbox', '/checkbox-demo'],
+    ['Chat', '/chat-demo'],
+    ['Drawer', '/drawer-demo'],
+    ['FormControl + Textfield', '/text-form-demo'],
+    ['Grid', '/grid-demo'],
+    ['Icon', '/icon-demo'],
+    ['Icon Button', '/icon-button-demo'],
+    ['List', '/list-demo'],
+    ['Modal', '/modal-demo'],
+    ['Pagination', '/pagination-demo'],
+    ['Panel', '/panel-demo'],
+    ['Progress', '/progress-demo'],
+    ['Radio Group', '/radio-demo'],
+    ['Slider', '/slider-demo'],
+    ['Select', '/select-demo'],
+    ['Snackbar', '/snackbar-demo'],
+    ['Switch', '/switch-demo'],
+    ['Table', '/table-demo'],
+    ['Tabs', '/tabs-demo'],
+    ['Tooltip', '/tooltip-demo'],
+    ['Typography', '/typography'],
+    ['Video', '/video-demo'],
+    ['AppBar', '/appbar-demo'],
+    ['Speed Dial', '/speeddial-demo'],
+    ['Stepper', '/stepper-demo'],
+    ['Tree', '/tree-demo'],
+  ];
+
+  const demos: [string, string][] = [
+    ['Presets', '/presets'],
+    ['Form', '/form'],
+    ['Parallax', '/parallax'],
+    ['Radio Button', '/test'],
+  ];
 
   return (
     <Surface>
-      <Typography variant="h1" centered><b>zeroui</b> Docs</Typography>
+      <Drawer responsive anchor="left" size="16rem" persistent>
+        <Stack spacing={1} style={{ padding: theme.spacing(1) }}>
+          <Typography variant="h3" bold>Getting Started</Typography>
+          <Button onClick={() => navigate('/overview')}>Overview</Button>
+          <Button onClick={() => navigate('/installation')}>Installation</Button>
+          <Button onClick={() => navigate('/usage')}>Usage</Button>
 
-      <Box centered compact>
-        <Stack compact spacing={2}>
-          <Panel variant="alt">
-            <Typography variant="h2" centered>Components</Typography>
-
-            <Stack direction="row">
-              <Button
-                onClick={() => navigate('/accordion-demo')}
-              >
-                Accordion
-              </Button>
-
-              <Button
-                onClick={() => navigate('/avatar-demo')}
-              >
-                Avatar
-              </Button>
-
-              <Button
-                onClick={() => navigate('/box-demo')}
-              >
-                Box
-              </Button>
-
-              <Button
-                onClick={() => navigate('/button-demo')}
-              >
-                Button
-              </Button>
-
-              <Button
-                onClick={() => navigate('/checkbox-demo')}
-              >
-                Checkbox
-              </Button>
-
-              <Button
-                onClick={() => navigate('/chat-demo')}
-              >
-                Chat
-              </Button>
-
-              <Button
-                onClick={() => navigate('/drawer-demo')}
-              >
-                Drawer
-              </Button>
-
-              <Button
-                onClick={() => navigate('/text-form-demo')}
-              >
-                FormControl + Textfield
-              </Button>
-
-              <Button
-                onClick={() => navigate('/grid-demo')}
-              >
-                Grid
-              </Button>
-
-              <Button
-                onClick={() => navigate('/icon-demo')}
-              >
-                Icon
-              </Button>
-
-              <Button
-                onClick={() => navigate('/icon-button-demo')}
-              >
-                Icon Button
-              </Button>
-
-              <Button
-                onClick={() => navigate('/list-demo')}
-              >
-                List
-              </Button>
-
-              <Button
-                onClick={() => navigate('/modal-demo')}
-              >
-                Modal
-              </Button>
-
-              <Button
-                onClick={() => navigate('/pagination-demo')}
-              >
-                Pagination
-              </Button>
-
-              <Button
-                onClick={() => navigate('/panel-demo')}
-              >
-                Panel
-              </Button>
-
-              <Button
-                onClick={() => navigate('/progress-demo')}
-              >
-                Progress
-              </Button>
-
-              <Button
-                onClick={() => navigate('/radio-demo')}
-              >
-                Radio Group
-              </Button>
-
-              <Button
-                onClick={() => navigate('/slider-demo')}
-              >
-                Slider
-              </Button>
-
-              <Button
-                onClick={() => navigate('/select-demo')}
-              >
-                Select
-              </Button>
-
-              <Button
-                onClick={() => navigate('/snackbar-demo')}
-              >
-                Snackbar
-              </Button>
-
-              <Button
-                onClick={() => navigate('/switch-demo')}
-              >
-                Switch
-              </Button>
-
-              <Button
-                onClick={() => navigate('/table-demo')}
-              >
-                Table
-              </Button>
-
-              <Button
-                onClick={() => navigate('/tabs-demo')}
-              >
-                Tabs
-              </Button>
-
-              <Button
-                onClick={() => navigate('/tooltip-demo')}
-              >
-                Tooltip
-              </Button>
-
-              <Button
-                onClick={() => navigate('/typography')}
-              >
-                Typography
-              </Button>
-
-              <Button
-                onClick={() => navigate('/video-demo')}
-              >
-                Video
-              </Button>
-
-              <Button
-                onClick={() => navigate('/appbar-demo')}
-              >
-                AppBar
-              </Button>
-
-              <Button
-                onClick={() => navigate('/speeddial-demo')}
-              >
-                Speed Dial
-              </Button>
-
-              <Button
-                onClick={() => navigate('/stepper-demo')}
-              >
-                Stepper
-              </Button>
-
-              <Button
-                onClick={() => navigate('/tree-demo')}
-              >
-                Tree
-              </Button>
-            </Stack>
-          </Panel>
-
-          <Panel>
-            <Typography centered variant="h2">Demos</Typography>
-
-            <Stack direction="row">
-              <Button
-                onClick={() => navigate('/presets')}
-              >
-                Presets
-              </Button>
-
-              <Button
-                onClick={() => navigate('/form')}
-              >
-                Form
-              </Button>
-
-              <Button
-                onClick={() => navigate('/parallax')}
-              >
-                Parallax
-              </Button>
-
-              <Button
-                onClick={() => navigate('/test')}
-              >
-                Radio Button
-              </Button>
-            </Stack>
-          </Panel>
-
-          <Box>
-            <Button
-              size="lg"
-              variant='outlined'
-              onClick={toggleMode}
-            >
-              Switch to {mode === 'light' ? 'dark' : 'light'} mode
+          <Typography variant="h3" bold style={{ marginTop: theme.spacing(1) }}>
+            Components
+          </Typography>
+          {components.map(([label, path]) => (
+            <Button key={path} onClick={() => navigate(path)}>
+              {label}
             </Button>
-          </Box>
+          ))}
+
+          <Typography variant="h3" bold style={{ marginTop: theme.spacing(1) }}>
+            Demos
+          </Typography>
+          {demos.map(([label, path]) => (
+            <Button key={path} onClick={() => navigate(path)}>
+              {label}
+            </Button>
+          ))}
         </Stack>
-      </Box>
+      </Drawer>
+
+      <Stack
+        spacing={1}
+        style={{
+          padding: theme.spacing(1),
+          marginLeft: '16rem',
+          maxWidth: 980,
+        }}
+      >
+        <Typography variant="h1" bold>
+          valet
+        </Typography>
+        <Typography variant="subtitle">
+          A lightweight React component kit bridging AI and the web.
+        </Typography>
+        <Button variant="outlined" onClick={toggleMode}>
+          Switch to {mode === 'light' ? 'dark' : 'light'} mode
+        </Button>
+      </Stack>
     </Surface>
   );
 }

--- a/docs/src/pages/Overview.tsx
+++ b/docs/src/pages/Overview.tsx
@@ -1,0 +1,27 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/Overview.tsx  | valet
+// Getting started overview page
+// ─────────────────────────────────────────────────────────────
+import { Surface, Stack, Typography, Button, useTheme } from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+
+export default function OverviewPage() {
+  const navigate = useNavigate();
+  const { mode, toggleMode } = useTheme();
+
+  return (
+    <Surface>
+      <Stack spacing={1} preset="showcaseStack">
+        <Typography variant="h2" bold>Overview</Typography>
+        <Typography>
+          valet offers a focused collection of accessible UI components with
+          built-in theming. It bridges next-generation AI proxies with the web.
+        </Typography>
+        <Button variant="outlined" onClick={toggleMode}>
+          Switch to {mode === 'light' ? 'dark' : 'light'} mode
+        </Button>
+        <Button onClick={() => navigate(-1)}>← Back</Button>
+      </Stack>
+    </Surface>
+  );
+}

--- a/docs/src/pages/Usage.tsx
+++ b/docs/src/pages/Usage.tsx
@@ -1,0 +1,25 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/Usage.tsx  | valet
+// Getting started usage page
+// ─────────────────────────────────────────────────────────────
+import { Surface, Stack, Typography, Button } from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+
+export default function UsagePage() {
+  const navigate = useNavigate();
+
+  return (
+    <Surface>
+      <Stack spacing={1} preset="showcaseStack">
+        <Typography variant="h2" bold>Usage</Typography>
+        <Typography>
+          Import components as needed and wrap each route in a <code>{'<Surface>'}</code>.
+        </Typography>
+        <Typography>
+          Example: <code>{'<Button>Click me</Button>'}</code>
+        </Typography>
+        <Button onClick={() => navigate(-1)}>← Back</Button>
+      </Stack>
+    </Surface>
+  );
+}


### PR DESCRIPTION
## Summary
- overhaul docs main page to use a responsive drawer nav
- add simple overview, installation and usage pages
- route new pages via the app
- note new docs features in the changelog

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686f6afc70a88320be185439f3e8eb8c