### PR TITLE
Remove responsive drawer shadow

### DIFF
--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -64,6 +64,7 @@ const Panel = styled('div')<{
   $text: string;
   $primary: string;
   $persistent: boolean;
+  $responsive: boolean;
 }>`
   position: fixed;
   z-index: ${({ $persistent }) => ($persistent ? 9998 : 9999)};
@@ -75,7 +76,8 @@ const Panel = styled('div')<{
     $anchor === 'top' || $anchor === 'bottom' ? 'auto' : 'visible'};
   background: ${({ $bg }) => $bg};
   color: ${({ $text }) => $text};
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+  box-shadow: ${({ $responsive }) =>
+    $responsive ? 'none' : '0 4px 16px rgba(0, 0, 0, 0.3)'};
   ${({ $anchor, $primary }) =>
     $anchor === 'left'
       ? `border-right:0.25rem solid ${$primary};`
@@ -211,6 +213,7 @@ export const Drawer: React.FC<DrawerProps> = ({
         $text={theme.colors.text}
         $primary={theme.colors.primary}
         $persistent={persistentEffective}
+        $responsive={responsiveMode}
         className={presetClasses}
       >
         {responsiveMode && portrait && (


### PR DESCRIPTION
## Summary
- avoid drop shadow for responsive drawers

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68700b0202e08320b32d6d1afb6b610e