### PR TITLE
Add reusable drawer for docs

### DIFF
--- a/docs/src/pages/DocsLayout.tsx
+++ b/docs/src/pages/DocsLayout.tsx
@@ -1,0 +1,127 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/DocsLayout.tsx | valet
+// Shared layout with responsive drawer navigation
+// ─────────────────────────────────────────────────────────────
+import type { ReactNode } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import {
+  Surface,
+  Drawer,
+  Tree,
+  type TreeNode,
+  useSurface,
+  useTheme,
+} from '@archway/valet';
+
+interface Item { label: string; path?: string }
+
+const components: [string, string][] = [
+  ['Accordion', '/accordion-demo'],
+  ['Avatar', '/avatar-demo'],
+  ['Box', '/box-demo'],
+  ['Button', '/button-demo'],
+  ['Checkbox', '/checkbox-demo'],
+  ['Chat', '/chat-demo'],
+  ['Drawer', '/drawer-demo'],
+  ['FormControl + Textfield', '/text-form-demo'],
+  ['Grid', '/grid-demo'],
+  ['Icon', '/icon-demo'],
+  ['Icon Button', '/icon-button-demo'],
+  ['List', '/list-demo'],
+  ['Modal', '/modal-demo'],
+  ['Pagination', '/pagination-demo'],
+  ['Panel', '/panel-demo'],
+  ['Progress', '/progress-demo'],
+  ['Radio Group', '/radio-demo'],
+  ['Slider', '/slider-demo'],
+  ['Select', '/select-demo'],
+  ['Snackbar', '/snackbar-demo'],
+  ['Switch', '/switch-demo'],
+  ['Table', '/table-demo'],
+  ['Tabs', '/tabs-demo'],
+  ['Tooltip', '/tooltip-demo'],
+  ['Typography', '/typography'],
+  ['Video', '/video-demo'],
+  ['AppBar', '/appbar-demo'],
+  ['Speed Dial', '/speeddial-demo'],
+  ['Stepper', '/stepper-demo'],
+  ['Tree', '/tree-demo'],
+];
+
+const demos: [string, string][] = [
+  ['Presets', '/presets'],
+  ['Form', '/form'],
+  ['Parallax', '/parallax'],
+  ['Radio Button', '/test'],
+];
+
+const treeData: TreeNode<Item>[] = [
+  {
+    id: 'getting-started',
+    data: { label: 'Getting Started' },
+    children: [
+      { id: '/overview', data: { label: 'Overview', path: '/overview' } },
+      { id: '/installation', data: { label: 'Installation', path: '/installation' } },
+      { id: '/usage', data: { label: 'Usage', path: '/usage' } },
+    ],
+  },
+  {
+    id: 'components',
+    data: { label: 'Components' },
+    children: components.map(([label, path]) => ({
+      id: path,
+      data: { label, path },
+    })),
+  },
+  {
+    id: 'demos',
+    data: { label: 'Demos' },
+    children: demos.map(([label, path]) => ({
+      id: path,
+      data: { label, path },
+    })),
+  },
+];
+
+function DocsDrawer() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { theme } = useTheme();
+
+  return (
+    <Drawer responsive anchor="left" size="16rem">
+      <Tree<Item>
+        nodes={treeData}
+        getLabel={(n) => n.label}
+        variant="list"
+        selected={location.pathname}
+        defaultExpanded={['getting-started', 'components', 'demos']}
+        onNodeSelect={(n) => n.path && navigate(n.path)}
+        style={{ padding: theme.spacing(1) }}
+      />
+    </Drawer>
+  );
+}
+
+export default function DocsLayout({ children }: { children: ReactNode }) {
+  const { width, height } = useSurface();
+  const { theme } = useTheme();
+  const landscape = width >= height;
+
+  return (
+    <Surface>
+      <DocsDrawer />
+      <div
+        style={{
+          padding: theme.spacing(1),
+          marginLeft: landscape ? '16rem' : 0,
+          maxWidth: 980,
+        }}
+      >
+        {children}
+      </div>
+    </Surface>
+  );
+}
+
+export { DocsDrawer };

--- a/docs/src/pages/Installation.tsx
+++ b/docs/src/pages/Installation.tsx
@@ -2,14 +2,15 @@
 // src/pages/Installation.tsx  | valet
 // Getting started installation page
 // ─────────────────────────────────────────────────────────────
-import { Surface, Stack, Typography, Button, Panel } from '@archway/valet';
+import { Stack, Typography, Button, Panel } from '@archway/valet';
+import DocsLayout from './DocsLayout';
 import { useNavigate } from 'react-router-dom';
 
 export default function InstallationPage() {
   const navigate = useNavigate();
 
   return (
-    <Surface>
+    <DocsLayout>
       <Stack spacing={1} preset="showcaseStack">
         <Typography variant="h2" bold>Installation</Typography>
         <Typography>Install via npm:</Typography>
@@ -19,6 +20,6 @@ export default function InstallationPage() {
         <Typography>For now, valet works best with React 18</Typography>
         <Button onClick={() => navigate(-1)}>← Back</Button>
       </Stack>
-    </Surface>
+    </DocsLayout>
   );
 }

--- a/docs/src/pages/MainPage.tsx
+++ b/docs/src/pages/MainPage.tsx
@@ -2,93 +2,20 @@
 // src/pages/MainPage.tsx  | valet
 // Doc home with responsive drawer navigation
 // ─────────────────────────────────────────────────────────────
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import {
   Surface,
-  Drawer,
   Stack,
   Button,
   Typography,
-  Tree,
-  type TreeNode,
   useTheme,
   useSurface,
 } from '@archway/valet';
+import { DocsDrawer } from './DocsLayout';
 
 export default function MainPage() {
   const navigate = useNavigate();
-  const location = useLocation();
   const { theme, mode, toggleMode } = useTheme();
-
-  const components: [string, string][] = [
-    ['Accordion', '/accordion-demo'],
-    ['Avatar', '/avatar-demo'],
-    ['Box', '/box-demo'],
-    ['Button', '/button-demo'],
-    ['Checkbox', '/checkbox-demo'],
-    ['Chat', '/chat-demo'],
-    ['Drawer', '/drawer-demo'],
-    ['FormControl + Textfield', '/text-form-demo'],
-    ['Grid', '/grid-demo'],
-    ['Icon', '/icon-demo'],
-    ['Icon Button', '/icon-button-demo'],
-    ['List', '/list-demo'],
-    ['Modal', '/modal-demo'],
-    ['Pagination', '/pagination-demo'],
-    ['Panel', '/panel-demo'],
-    ['Progress', '/progress-demo'],
-    ['Radio Group', '/radio-demo'],
-    ['Slider', '/slider-demo'],
-    ['Select', '/select-demo'],
-    ['Snackbar', '/snackbar-demo'],
-    ['Switch', '/switch-demo'],
-    ['Table', '/table-demo'],
-    ['Tabs', '/tabs-demo'],
-    ['Tooltip', '/tooltip-demo'],
-    ['Typography', '/typography'],
-    ['Video', '/video-demo'],
-    ['AppBar', '/appbar-demo'],
-    ['Speed Dial', '/speeddial-demo'],
-    ['Stepper', '/stepper-demo'],
-    ['Tree', '/tree-demo'],
-  ];
-
-  const demos: [string, string][] = [
-    ['Presets', '/presets'],
-    ['Form', '/form'],
-    ['Parallax', '/parallax'],
-    ['Radio Button', '/test'],
-  ];
-
-  interface Item { label: string; path?: string }
-
-  const treeData: TreeNode<Item>[] = [
-    {
-      id: 'getting-started',
-      data: { label: 'Getting Started' },
-      children: [
-        { id: '/overview', data: { label: 'Overview', path: '/overview' } },
-        { id: '/installation', data: { label: 'Installation', path: '/installation' } },
-        { id: '/usage', data: { label: 'Usage', path: '/usage' } },
-      ],
-    },
-    {
-      id: 'components',
-      data: { label: 'Components' },
-      children: components.map(([label, path]) => ({
-        id: path,
-        data: { label, path },
-      })),
-    },
-    {
-      id: 'demos',
-      data: { label: 'Demos' },
-      children: demos.map(([label, path]) => ({
-        id: path,
-        data: { label, path },
-      })),
-    },
-  ];
 
   function Content() {
     const { width, height } = useSurface();
@@ -118,17 +45,7 @@ export default function MainPage() {
 
   return (
     <Surface>
-      <Drawer responsive anchor="left" size="16rem">
-        <Tree<Item>
-          nodes={treeData}
-          getLabel={(n) => n.label}
-          variant="list"
-          selected={location.pathname}
-          defaultExpanded={['getting-started', 'components', 'demos']}
-          onNodeSelect={(n) => n.path && navigate(n.path)}
-          style={{ padding: theme.spacing(1) }}
-        />
-      </Drawer>
+      <DocsDrawer />
       <Content />
     </Surface>
   );

--- a/docs/src/pages/Overview.tsx
+++ b/docs/src/pages/Overview.tsx
@@ -2,14 +2,15 @@
 // src/pages/Overview.tsx  | valet
 // Getting started overview page
 // ─────────────────────────────────────────────────────────────
-import { Surface, Stack, Typography, Button } from '@archway/valet';
+import { Stack, Typography, Button } from '@archway/valet';
+import DocsLayout from './DocsLayout';
 import { useNavigate } from 'react-router-dom';
 
 export default function OverviewPage() {
   const navigate = useNavigate();
 
   return (
-    <Surface>
+    <DocsLayout>
       <Stack preset="showcaseStack">
         <Typography variant="h2">Overview</Typography>
         <Typography>
@@ -19,6 +20,6 @@ export default function OverviewPage() {
         </Typography>
         <Button onClick={() => navigate(-1)}>← Back</Button>
       </Stack>
-    </Surface>
+    </DocsLayout>
   );
 }

--- a/docs/src/pages/Usage.tsx
+++ b/docs/src/pages/Usage.tsx
@@ -2,14 +2,15 @@
 // src/pages/Usage.tsx  | valet
 // Getting started usage page
 // ─────────────────────────────────────────────────────────────
-import { Surface, Stack, Typography, Button } from '@archway/valet';
+import { Stack, Typography, Button } from '@archway/valet';
+import DocsLayout from './DocsLayout';
 import { useNavigate } from 'react-router-dom';
 
 export default function UsagePage() {
   const navigate = useNavigate();
 
   return (
-    <Surface>
+    <DocsLayout>
       <Stack spacing={1} preset="showcaseStack">
         <Typography variant="h2" bold>Usage</Typography>
         <Typography>
@@ -20,6 +21,6 @@ export default function UsagePage() {
         </Typography>
         <Button onClick={() => navigate(-1)}>← Back</Button>
       </Stack>
-    </Surface>
+    </DocsLayout>
   );
 }


### PR DESCRIPTION
## Summary
- create a shared `DocsLayout` component that exposes a responsive drawer
- use the shared layout in Overview, Installation, and Usage pages
- update MainPage to reuse the drawer component

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68701ebbdc288320a01590b9f7478e1c