### PR TITLE
Add shared docs nav drawer

### DIFF
--- a/docs/src/layout/NavDrawer.tsx
+++ b/docs/src/layout/NavDrawer.tsx
@@ -1,0 +1,98 @@
+// ─────────────────────────────────────────────────────────────
+// src/layout/NavDrawer.tsx | valet
+// Reusable docs navigation drawer
+// ─────────────────────────────────────────────────────────────
+import { useNavigate, useLocation } from 'react-router-dom';
+import {
+  Drawer,
+  Tree,
+  type TreeNode,
+  useTheme,
+} from '@archway/valet';
+
+interface Item {
+  label: string;
+  path?: string;
+}
+
+export default function NavDrawer() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { theme } = useTheme();
+
+  const components: [string, string][] = [
+    ['Accordion', '/accordion-demo'],
+    ['Avatar', '/avatar-demo'],
+    ['Box', '/box-demo'],
+    ['Button', '/button-demo'],
+    ['Checkbox', '/checkbox-demo'],
+    ['Chat', '/chat-demo'],
+    ['Drawer', '/drawer-demo'],
+    ['FormControl + Textfield', '/text-form-demo'],
+    ['Grid', '/grid-demo'],
+    ['Icon', '/icon-demo'],
+    ['Icon Button', '/icon-button-demo'],
+    ['List', '/list-demo'],
+    ['Modal', '/modal-demo'],
+    ['Pagination', '/pagination-demo'],
+    ['Panel', '/panel-demo'],
+    ['Progress', '/progress-demo'],
+    ['Radio Group', '/radio-demo'],
+    ['Slider', '/slider-demo'],
+    ['Select', '/select-demo'],
+    ['Snackbar', '/snackbar-demo'],
+    ['Switch', '/switch-demo'],
+    ['Table', '/table-demo'],
+    ['Tabs', '/tabs-demo'],
+    ['Tooltip', '/tooltip-demo'],
+    ['Typography', '/typography'],
+    ['Video', '/video-demo'],
+    ['AppBar', '/appbar-demo'],
+    ['Speed Dial', '/speeddial-demo'],
+    ['Stepper', '/stepper-demo'],
+    ['Tree', '/tree-demo'],
+  ];
+
+  const demos: [string, string][] = [
+    ['Presets', '/presets'],
+    ['Form', '/form'],
+    ['Parallax', '/parallax'],
+    ['Radio Button', '/test'],
+  ];
+
+  const treeData: TreeNode<Item>[] = [
+    {
+      id: 'getting-started',
+      data: { label: 'Getting Started' },
+      children: [
+        { id: '/overview', data: { label: 'Overview', path: '/overview' } },
+        { id: '/installation', data: { label: 'Installation', path: '/installation' } },
+        { id: '/usage', data: { label: 'Usage', path: '/usage' } },
+      ],
+    },
+    {
+      id: 'components',
+      data: { label: 'Components' },
+      children: components.map(([label, path]) => ({ id: path, data: { label, path } })),
+    },
+    {
+      id: 'demos',
+      data: { label: 'Demos' },
+      children: demos.map(([label, path]) => ({ id: path, data: { label, path } })),
+    },
+  ];
+
+  return (
+    <Drawer responsive anchor="left" size="16rem">
+      <Tree<Item>
+        nodes={treeData}
+        getLabel={(n) => n.label}
+        variant="list"
+        selected={location.pathname}
+        defaultExpanded={['getting-started', 'components', 'demos']}
+        onNodeSelect={(n) => n.path && navigate(n.path)}
+        style={{ padding: theme.spacing(1) }}
+      />
+    </Drawer>
+  );
+}

--- a/docs/src/pages/Installation.tsx
+++ b/docs/src/pages/Installation.tsx
@@ -2,15 +2,19 @@
 // src/pages/Installation.tsx  | valet
 // Getting started installation page
 // ─────────────────────────────────────────────────────────────
-import { Surface, Stack, Typography, Button, Panel } from '@archway/valet';
+import { Surface, Stack, Typography, Button, Panel, useSurface } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../layout/NavDrawer';
 
 export default function InstallationPage() {
   const navigate = useNavigate();
+  const { width, height } = useSurface();
+  const landscape = width >= height;
 
   return (
     <Surface>
-      <Stack spacing={1} preset="showcaseStack">
+      <NavDrawer />
+      <Stack spacing={1} preset="showcaseStack" style={{ marginLeft: landscape ? '16rem' : 0 }}>
         <Typography variant="h2" bold>Installation</Typography>
         <Typography>Install via npm:</Typography>
         <Panel>

--- a/docs/src/pages/MainPage.tsx
+++ b/docs/src/pages/MainPage.tsx
@@ -2,93 +2,18 @@
 // src/pages/MainPage.tsx  | valet
 // Doc home with responsive drawer navigation
 // ─────────────────────────────────────────────────────────────
-import { useNavigate, useLocation } from 'react-router-dom';
 import {
   Surface,
-  Drawer,
   Stack,
   Button,
   Typography,
-  Tree,
-  type TreeNode,
   useTheme,
   useSurface,
 } from '@archway/valet';
+import NavDrawer from '../layout/NavDrawer';
 
 export default function MainPage() {
-  const navigate = useNavigate();
-  const location = useLocation();
   const { theme, mode, toggleMode } = useTheme();
-
-  const components: [string, string][] = [
-    ['Accordion', '/accordion-demo'],
-    ['Avatar', '/avatar-demo'],
-    ['Box', '/box-demo'],
-    ['Button', '/button-demo'],
-    ['Checkbox', '/checkbox-demo'],
-    ['Chat', '/chat-demo'],
-    ['Drawer', '/drawer-demo'],
-    ['FormControl + Textfield', '/text-form-demo'],
-    ['Grid', '/grid-demo'],
-    ['Icon', '/icon-demo'],
-    ['Icon Button', '/icon-button-demo'],
-    ['List', '/list-demo'],
-    ['Modal', '/modal-demo'],
-    ['Pagination', '/pagination-demo'],
-    ['Panel', '/panel-demo'],
-    ['Progress', '/progress-demo'],
-    ['Radio Group', '/radio-demo'],
-    ['Slider', '/slider-demo'],
-    ['Select', '/select-demo'],
-    ['Snackbar', '/snackbar-demo'],
-    ['Switch', '/switch-demo'],
-    ['Table', '/table-demo'],
-    ['Tabs', '/tabs-demo'],
-    ['Tooltip', '/tooltip-demo'],
-    ['Typography', '/typography'],
-    ['Video', '/video-demo'],
-    ['AppBar', '/appbar-demo'],
-    ['Speed Dial', '/speeddial-demo'],
-    ['Stepper', '/stepper-demo'],
-    ['Tree', '/tree-demo'],
-  ];
-
-  const demos: [string, string][] = [
-    ['Presets', '/presets'],
-    ['Form', '/form'],
-    ['Parallax', '/parallax'],
-    ['Radio Button', '/test'],
-  ];
-
-  interface Item { label: string; path?: string }
-
-  const treeData: TreeNode<Item>[] = [
-    {
-      id: 'getting-started',
-      data: { label: 'Getting Started' },
-      children: [
-        { id: '/overview', data: { label: 'Overview', path: '/overview' } },
-        { id: '/installation', data: { label: 'Installation', path: '/installation' } },
-        { id: '/usage', data: { label: 'Usage', path: '/usage' } },
-      ],
-    },
-    {
-      id: 'components',
-      data: { label: 'Components' },
-      children: components.map(([label, path]) => ({
-        id: path,
-        data: { label, path },
-      })),
-    },
-    {
-      id: 'demos',
-      data: { label: 'Demos' },
-      children: demos.map(([label, path]) => ({
-        id: path,
-        data: { label, path },
-      })),
-    },
-  ];
 
   function Content() {
     const { width, height } = useSurface();
@@ -118,17 +43,7 @@ export default function MainPage() {
 
   return (
     <Surface>
-      <Drawer responsive anchor="left" size="16rem">
-        <Tree<Item>
-          nodes={treeData}
-          getLabel={(n) => n.label}
-          variant="list"
-          selected={location.pathname}
-          defaultExpanded={['getting-started', 'components', 'demos']}
-          onNodeSelect={(n) => n.path && navigate(n.path)}
-          style={{ padding: theme.spacing(1) }}
-        />
-      </Drawer>
+      <NavDrawer />
       <Content />
     </Surface>
   );

--- a/docs/src/pages/Overview.tsx
+++ b/docs/src/pages/Overview.tsx
@@ -2,15 +2,19 @@
 // src/pages/Overview.tsx  | valet
 // Getting started overview page
 // ─────────────────────────────────────────────────────────────
-import { Surface, Stack, Typography, Button } from '@archway/valet';
+import { Surface, Stack, Typography, Button, useSurface } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../layout/NavDrawer';
 
 export default function OverviewPage() {
   const navigate = useNavigate();
+  const { width, height } = useSurface();
+  const landscape = width >= height;
 
   return (
     <Surface>
-      <Stack preset="showcaseStack">
+      <NavDrawer />
+      <Stack preset="showcaseStack" style={{ marginLeft: landscape ? '16rem' : 0 }}>
         <Typography variant="h2">Overview</Typography>
         <Typography>
           valet offers an opinionated collection of accessible UI components with

--- a/docs/src/pages/Usage.tsx
+++ b/docs/src/pages/Usage.tsx
@@ -2,15 +2,19 @@
 // src/pages/Usage.tsx  | valet
 // Getting started usage page
 // ─────────────────────────────────────────────────────────────
-import { Surface, Stack, Typography, Button } from '@archway/valet';
+import { Surface, Stack, Typography, Button, useSurface } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../layout/NavDrawer';
 
 export default function UsagePage() {
   const navigate = useNavigate();
+  const { width, height } = useSurface();
+  const landscape = width >= height;
 
   return (
     <Surface>
-      <Stack spacing={1} preset="showcaseStack">
+      <NavDrawer />
+      <Stack spacing={1} preset="showcaseStack" style={{ marginLeft: landscape ? '16rem' : 0 }}>
         <Typography variant="h2" bold>Usage</Typography>
         <Typography>
           Import components as needed and wrap each route in a <code>{'<Surface>'}</code>.


### PR DESCRIPTION
## Summary
- add reusable `NavDrawer` to docs
- use it on the main landing page
- use it on Overview, Installation and Usage pages

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68701ebbdc288320a01590b9f7478e1c