### PR TITLE
Add reusable docs drawer

### DIFF
--- a/docs/src/components/DocsDrawer.tsx
+++ b/docs/src/components/DocsDrawer.tsx
@@ -1,0 +1,101 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/DocsDrawer.tsx | valet
+// Reusable responsive navigation drawer for docs
+// ─────────────────────────────────────────────────────────────
+import { useNavigate, useLocation } from 'react-router-dom';
+import {
+  Drawer,
+  Tree,
+  type TreeNode,
+  useTheme,
+} from '@archway/valet';
+
+export default function DocsDrawer() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { theme } = useTheme();
+
+  const components: [string, string][] = [
+    ['Accordion', '/accordion-demo'],
+    ['Avatar', '/avatar-demo'],
+    ['Box', '/box-demo'],
+    ['Button', '/button-demo'],
+    ['Checkbox', '/checkbox-demo'],
+    ['Chat', '/chat-demo'],
+    ['Drawer', '/drawer-demo'],
+    ['FormControl + Textfield', '/text-form-demo'],
+    ['Grid', '/grid-demo'],
+    ['Icon', '/icon-demo'],
+    ['Icon Button', '/icon-button-demo'],
+    ['List', '/list-demo'],
+    ['Modal', '/modal-demo'],
+    ['Pagination', '/pagination-demo'],
+    ['Panel', '/panel-demo'],
+    ['Progress', '/progress-demo'],
+    ['Radio Group', '/radio-demo'],
+    ['Slider', '/slider-demo'],
+    ['Select', '/select-demo'],
+    ['Snackbar', '/snackbar-demo'],
+    ['Switch', '/switch-demo'],
+    ['Table', '/table-demo'],
+    ['Tabs', '/tabs-demo'],
+    ['Tooltip', '/tooltip-demo'],
+    ['Typography', '/typography'],
+    ['Video', '/video-demo'],
+    ['AppBar', '/appbar-demo'],
+    ['Speed Dial', '/speeddial-demo'],
+    ['Stepper', '/stepper-demo'],
+    ['Tree', '/tree-demo'],
+  ];
+
+  const demos: [string, string][] = [
+    ['Presets', '/presets'],
+    ['Form', '/form'],
+    ['Parallax', '/parallax'],
+    ['Radio Button', '/test'],
+  ];
+
+  interface Item { label: string; path?: string }
+
+  const treeData: TreeNode<Item>[] = [
+    {
+      id: 'getting-started',
+      data: { label: 'Getting Started' },
+      children: [
+        { id: '/overview', data: { label: 'Overview', path: '/overview' } },
+        { id: '/installation', data: { label: 'Installation', path: '/installation' } },
+        { id: '/usage', data: { label: 'Usage', path: '/usage' } },
+      ],
+    },
+    {
+      id: 'components',
+      data: { label: 'Components' },
+      children: components.map(([label, path]) => ({
+        id: path,
+        data: { label, path },
+      })),
+    },
+    {
+      id: 'demos',
+      data: { label: 'Demos' },
+      children: demos.map(([label, path]) => ({
+        id: path,
+        data: { label, path },
+      })),
+    },
+  ];
+
+  return (
+    <Drawer responsive anchor="left" size="16rem">
+      <Tree<Item>
+        nodes={treeData}
+        getLabel={(n) => n.label}
+        variant="list"
+        selected={location.pathname}
+        defaultExpanded={['getting-started', 'components', 'demos']}
+        onNodeSelect={(n) => n.path && navigate(n.path)}
+        style={{ padding: theme.spacing(1) }}
+      />
+    </Drawer>
+  );
+}

--- a/docs/src/pages/Installation.tsx
+++ b/docs/src/pages/Installation.tsx
@@ -2,15 +2,19 @@
 // src/pages/Installation.tsx  | valet
 // Getting started installation page
 // ─────────────────────────────────────────────────────────────
-import { Surface, Stack, Typography, Button, Panel } from '@archway/valet';
+import { Surface, Stack, Typography, Button, Panel, useSurface } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import DocsDrawer from '../components/DocsDrawer';
 
 export default function InstallationPage() {
   const navigate = useNavigate();
+  const { width, height } = useSurface();
+  const landscape = width >= height;
 
   return (
     <Surface>
-      <Stack spacing={1} preset="showcaseStack">
+      <DocsDrawer />
+      <Stack spacing={1} preset="showcaseStack" style={{ marginLeft: landscape ? '16rem' : undefined }}>
         <Typography variant="h2" bold>Installation</Typography>
         <Typography>Install via npm:</Typography>
         <Panel>

--- a/docs/src/pages/MainPage.tsx
+++ b/docs/src/pages/MainPage.tsx
@@ -2,93 +2,20 @@
 // src/pages/MainPage.tsx  | valet
 // Doc home with responsive drawer navigation
 // ─────────────────────────────────────────────────────────────
-import { useNavigate, useLocation } from 'react-router-dom';
+
 import {
   Surface,
-  Drawer,
   Stack,
   Button,
   Typography,
-  Tree,
-  type TreeNode,
   useTheme,
   useSurface,
 } from '@archway/valet';
+import DocsDrawer from '../components/DocsDrawer';
 
 export default function MainPage() {
-  const navigate = useNavigate();
-  const location = useLocation();
   const { theme, mode, toggleMode } = useTheme();
 
-  const components: [string, string][] = [
-    ['Accordion', '/accordion-demo'],
-    ['Avatar', '/avatar-demo'],
-    ['Box', '/box-demo'],
-    ['Button', '/button-demo'],
-    ['Checkbox', '/checkbox-demo'],
-    ['Chat', '/chat-demo'],
-    ['Drawer', '/drawer-demo'],
-    ['FormControl + Textfield', '/text-form-demo'],
-    ['Grid', '/grid-demo'],
-    ['Icon', '/icon-demo'],
-    ['Icon Button', '/icon-button-demo'],
-    ['List', '/list-demo'],
-    ['Modal', '/modal-demo'],
-    ['Pagination', '/pagination-demo'],
-    ['Panel', '/panel-demo'],
-    ['Progress', '/progress-demo'],
-    ['Radio Group', '/radio-demo'],
-    ['Slider', '/slider-demo'],
-    ['Select', '/select-demo'],
-    ['Snackbar', '/snackbar-demo'],
-    ['Switch', '/switch-demo'],
-    ['Table', '/table-demo'],
-    ['Tabs', '/tabs-demo'],
-    ['Tooltip', '/tooltip-demo'],
-    ['Typography', '/typography'],
-    ['Video', '/video-demo'],
-    ['AppBar', '/appbar-demo'],
-    ['Speed Dial', '/speeddial-demo'],
-    ['Stepper', '/stepper-demo'],
-    ['Tree', '/tree-demo'],
-  ];
-
-  const demos: [string, string][] = [
-    ['Presets', '/presets'],
-    ['Form', '/form'],
-    ['Parallax', '/parallax'],
-    ['Radio Button', '/test'],
-  ];
-
-  interface Item { label: string; path?: string }
-
-  const treeData: TreeNode<Item>[] = [
-    {
-      id: 'getting-started',
-      data: { label: 'Getting Started' },
-      children: [
-        { id: '/overview', data: { label: 'Overview', path: '/overview' } },
-        { id: '/installation', data: { label: 'Installation', path: '/installation' } },
-        { id: '/usage', data: { label: 'Usage', path: '/usage' } },
-      ],
-    },
-    {
-      id: 'components',
-      data: { label: 'Components' },
-      children: components.map(([label, path]) => ({
-        id: path,
-        data: { label, path },
-      })),
-    },
-    {
-      id: 'demos',
-      data: { label: 'Demos' },
-      children: demos.map(([label, path]) => ({
-        id: path,
-        data: { label, path },
-      })),
-    },
-  ];
 
   function Content() {
     const { width, height } = useSurface();
@@ -118,17 +45,7 @@ export default function MainPage() {
 
   return (
     <Surface>
-      <Drawer responsive anchor="left" size="16rem">
-        <Tree<Item>
-          nodes={treeData}
-          getLabel={(n) => n.label}
-          variant="list"
-          selected={location.pathname}
-          defaultExpanded={['getting-started', 'components', 'demos']}
-          onNodeSelect={(n) => n.path && navigate(n.path)}
-          style={{ padding: theme.spacing(1) }}
-        />
-      </Drawer>
+      <DocsDrawer />
       <Content />
     </Surface>
   );

--- a/docs/src/pages/Overview.tsx
+++ b/docs/src/pages/Overview.tsx
@@ -2,15 +2,22 @@
 // src/pages/Overview.tsx  | valet
 // Getting started overview page
 // ─────────────────────────────────────────────────────────────
-import { Surface, Stack, Typography, Button } from '@archway/valet';
+import { Surface, Stack, Typography, Button, useSurface } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import DocsDrawer from '../components/DocsDrawer';
 
 export default function OverviewPage() {
   const navigate = useNavigate();
+  const { width, height } = useSurface();
+  const landscape = width >= height;
 
   return (
     <Surface>
-      <Stack preset="showcaseStack">
+      <DocsDrawer />
+      <Stack
+        preset="showcaseStack"
+        style={{ marginLeft: landscape ? '16rem' : undefined }}
+      >
         <Typography variant="h2">Overview</Typography>
         <Typography>
           valet offers an opinionated collection of accessible UI components with

--- a/docs/src/pages/Usage.tsx
+++ b/docs/src/pages/Usage.tsx
@@ -2,15 +2,19 @@
 // src/pages/Usage.tsx  | valet
 // Getting started usage page
 // ─────────────────────────────────────────────────────────────
-import { Surface, Stack, Typography, Button } from '@archway/valet';
+import { Surface, Stack, Typography, Button, useSurface } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import DocsDrawer from '../components/DocsDrawer';
 
 export default function UsagePage() {
   const navigate = useNavigate();
+  const { width, height } = useSurface();
+  const landscape = width >= height;
 
   return (
     <Surface>
-      <Stack spacing={1} preset="showcaseStack">
+      <DocsDrawer />
+      <Stack spacing={1} preset="showcaseStack" style={{ marginLeft: landscape ? '16rem' : undefined }}>
         <Typography variant="h2" bold>Usage</Typography>
         <Typography>
           Import components as needed and wrap each route in a <code>{'<Surface>'}</code>.


### PR DESCRIPTION
## Summary
- create `DocsDrawer` component for docs navigation
- use the shared drawer on main, overview, installation and usage pages

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68701ebbdc288320a01590b9f7478e1c