### PR TITLE
Add Drawer pushContent option

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@archway/valet": "0.8.5",
+    "@archway/valet": "file:..",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.6.0"

--- a/docs/src/pages/MainPage.tsx
+++ b/docs/src/pages/MainPage.tsx
@@ -12,7 +12,6 @@ import {
   Tree,
   type TreeNode,
   useTheme,
-  useSurface,
 } from '@archway/valet';
 
 export default function MainPage() {
@@ -91,15 +90,11 @@ export default function MainPage() {
   ];
 
   function Content() {
-    const { width, height } = useSurface();
-    const landscape = width >= height;
-
     return (
       <Stack
         spacing={1}
         style={{
           padding: theme.spacing(1),
-          marginLeft: landscape ? '16rem' : 0,
           maxWidth: 980,
         }}
       >
@@ -118,7 +113,7 @@ export default function MainPage() {
 
   return (
     <Surface>
-      <Drawer responsive anchor="left" size="16rem">
+      <Drawer responsive anchor="left" size="16rem" pushContent>
         <Tree<Item>
           nodes={treeData}
           getLabel={(n) => n.label}

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -35,6 +35,8 @@ export interface DrawerProps extends Presettable {
   persistent?: boolean;
   /** Responsive behaviour (persistent in landscape, overlay in portrait) */
   responsive?: boolean;
+  /** Push document body when persistent */
+  pushContent?: boolean;
   /** Icon for the portrait toggle button */
   toggleIcon?: string;
   /** Close button icon when portrait */
@@ -124,6 +126,7 @@ export const Drawer: React.FC<DrawerProps> = ({
   disableEscapeKeyDown = false,
   persistent = false,
   responsive = false,
+  pushContent = false,
   toggleIcon = 'mdi:menu',
   closeIcon = 'mdi:close',
   children,
@@ -147,6 +150,24 @@ export const Drawer: React.FC<DrawerProps> = ({
     ? openState
     : controlledOpen!;
   const [fade, setFade] = useState(true);
+
+  useLayoutEffect(() => {
+    if (!pushContent || !persistentEffective) return;
+    const side =
+      anchor === 'left'
+        ? 'marginLeft'
+        : anchor === 'right'
+        ? 'marginRight'
+        : anchor === 'top'
+        ? 'marginTop'
+        : 'marginBottom';
+    const resolved = typeof size === 'number' ? `${size}px` : size;
+    const prev = (document.body.style as any)[side] as string;
+    (document.body.style as any)[side] = resolved;
+    return () => {
+      (document.body.style as any)[side] = prev;
+    };
+  }, [pushContent, persistentEffective, anchor, size]);
 
   useEffect(() => {
     if (orientationPersistent) setOpenState(true);


### PR DESCRIPTION
## Summary
- add `pushContent` option to Drawer
- push body margin when Drawer is persistent
- adjust docs main page to use pushContent
- link docs to local package for build

## Testing
- `npm install`
- `npm run build`
- `cd docs && npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687024ae61fc8320bbc6f98df41e4801