### PR TITLE
Drawer manages layout offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Drawer applies `--valet-offset-*` variables when persistent to shift layouts
 
 ## [v0.8.5]
 ### Added

--- a/docs/src/pages/MainPage.tsx
+++ b/docs/src/pages/MainPage.tsx
@@ -12,7 +12,6 @@ import {
   Tree,
   type TreeNode,
   useTheme,
-  useSurface,
 } from '@archway/valet';
 
 export default function MainPage() {
@@ -91,15 +90,12 @@ export default function MainPage() {
   ];
 
   function Content() {
-    const { width, height } = useSurface();
-    const landscape = width >= height;
-
     return (
       <Stack
         spacing={1}
         style={{
           padding: theme.spacing(1),
-          marginLeft: landscape ? '16rem' : 0,
+          marginLeft: 'var(--valet-offset-left, 0)',
           maxWidth: 980,
         }}
       >

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -139,6 +139,28 @@ export const Drawer: React.FC<DrawerProps> = ({
   const orientationPersistent = responsiveMode && !portrait;
   const persistentEffective = persistent || orientationPersistent;
 
+  /* Apply layout offset when persistent --------------------*/
+  useLayoutEffect(() => {
+    const root = surface.getState().element;
+    if (!root) return;
+    const val = typeof size === 'number' ? `${size}px` : size;
+    const clear = () => {
+      root.style.removeProperty('--valet-offset-left');
+      root.style.removeProperty('--valet-offset-right');
+      root.style.removeProperty('--valet-offset-top');
+      root.style.removeProperty('--valet-offset-bottom');
+    };
+    clear();
+    if (persistentEffective) {
+      if (anchor === 'left') root.style.setProperty('--valet-offset-left', val);
+      else if (anchor === 'right')
+        root.style.setProperty('--valet-offset-right', val);
+      else if (anchor === 'top') root.style.setProperty('--valet-offset-top', val);
+      else root.style.setProperty('--valet-offset-bottom', val);
+    }
+    return clear;
+  }, [surface, anchor, size, persistentEffective]);
+
   const uncontrolled = controlledOpen === undefined;
   const [openState, setOpenState] = useState(defaultOpen);
   const open = persistentEffective


### PR DESCRIPTION
## Summary
- persistently mounted Drawer now sets `--valet-offset-*` CSS variables
- remove manual landscape margin on MainPage
- document offset variables in CHANGELOG

## Testing
- `npm run build` *(fails: rimraf not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870231eec7083208081b5efd9dd2f36