### PR TITLE
Responsive drawer offsets content

### DIFF
--- a/docs/src/pages/DrawerDemo.tsx
+++ b/docs/src/pages/DrawerDemo.tsx
@@ -30,7 +30,7 @@ export default function DrawerDemoPage() {
       </Drawer>
       <Stack
         spacing={1}
-        style={{ padding: theme.spacing(1), maxWidth: 980, margin: '0 auto', marginLeft: '16rem' }}
+        style={{ padding: theme.spacing(1), maxWidth: 980, margin: '0 auto' }}
       >
         <Typography variant="h2" bold>
           Drawer Showcase

--- a/docs/src/pages/MainPage.tsx
+++ b/docs/src/pages/MainPage.tsx
@@ -12,7 +12,6 @@ import {
   Tree,
   type TreeNode,
   useTheme,
-  useSurface,
 } from '@archway/valet';
 
 export default function MainPage() {
@@ -91,15 +90,11 @@ export default function MainPage() {
   ];
 
   function Content() {
-    const { width, height } = useSurface();
-    const landscape = width >= height;
-
     return (
       <Stack
         spacing={1}
         style={{
           padding: theme.spacing(1),
-          marginLeft: landscape ? '16rem' : 0,
           maxWidth: 980,
         }}
       >

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -181,6 +181,23 @@ export const Drawer: React.FC<DrawerProps> = ({
     if (e.target === e.currentTarget) requestClose();
   };
 
+  // When persistent, offset the current surface so content isn't hidden
+  useLayoutEffect(() => {
+    const node = surface.element;
+    if (!node) return;
+    const horizontal = anchor === 'left' || anchor === 'right';
+    if (persistentEffective && horizontal) {
+      const px = typeof size === 'number' ? `${size}px` : size;
+      const prop = anchor === 'left' ? 'marginLeft' : 'marginRight';
+      const prev = (node.style as any)[prop];
+      (node.style as any)[prop] = px;
+      return () => {
+        (node.style as any)[prop] = prev;
+      };
+    }
+    return;
+  }, [surface.element, persistentEffective, anchor, size]);
+
   if (!open && !persistentEffective) {
     if (responsiveMode && portrait) {
       return (


### PR DESCRIPTION
## Summary
- adjust Drawer so persistent/landscape drawers offset the Surface
- simplify MainPage layout
- remove manual margin from Drawer demo

## Testing
- `npm run build`
- `npm install && npm run build` in docs

------
https://chatgpt.com/codex/tasks/task_e_6870231eec7083208081b5efd9dd2f36