### PR TITLE
Responsive drawer offsets content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+### Added
+- Shared navigation drawer component for docs
+- Avatar, Box, Button, and Checkbox pages now use the drawer
+
 ## [v0.8.5]
 ### Added
 - Tree component demonstrating nested navigation (renamed from TreeView)

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -1,0 +1,103 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/NavDrawer.tsx  | valet docs
+// Reusable navigation drawer for docs
+// ─────────────────────────────────────────────────────────────
+import { useNavigate, useLocation } from 'react-router-dom';
+import {
+  Drawer,
+  Tree,
+  type TreeNode,
+  useTheme,
+} from '@archway/valet';
+
+interface Item {
+  label: string;
+  path?: string;
+}
+
+const components: [string, string][] = [
+  ['Accordion', '/accordion-demo'],
+  ['Avatar', '/avatar-demo'],
+  ['Box', '/box-demo'],
+  ['Button', '/button-demo'],
+  ['Checkbox', '/checkbox-demo'],
+  ['Chat', '/chat-demo'],
+  ['Drawer', '/drawer-demo'],
+  ['FormControl + Textfield', '/text-form-demo'],
+  ['Grid', '/grid-demo'],
+  ['Icon', '/icon-demo'],
+  ['Icon Button', '/icon-button-demo'],
+  ['List', '/list-demo'],
+  ['Modal', '/modal-demo'],
+  ['Pagination', '/pagination-demo'],
+  ['Panel', '/panel-demo'],
+  ['Progress', '/progress-demo'],
+  ['Radio Group', '/radio-demo'],
+  ['Slider', '/slider-demo'],
+  ['Select', '/select-demo'],
+  ['Snackbar', '/snackbar-demo'],
+  ['Switch', '/switch-demo'],
+  ['Table', '/table-demo'],
+  ['Tabs', '/tabs-demo'],
+  ['Tooltip', '/tooltip-demo'],
+  ['Typography', '/typography'],
+  ['Video', '/video-demo'],
+  ['AppBar', '/appbar-demo'],
+  ['Speed Dial', '/speeddial-demo'],
+  ['Stepper', '/stepper-demo'],
+  ['Tree', '/tree-demo'],
+];
+
+const demos: [string, string][] = [
+  ['Presets', '/presets'],
+  ['Form', '/form'],
+  ['Parallax', '/parallax'],
+  ['Radio Button', '/test'],
+];
+
+const treeData: TreeNode<Item>[] = [
+  {
+    id: 'getting-started',
+    data: { label: 'Getting Started' },
+    children: [
+      { id: '/overview', data: { label: 'Overview', path: '/overview' } },
+      { id: '/installation', data: { label: 'Installation', path: '/installation' } },
+      { id: '/usage', data: { label: 'Usage', path: '/usage' } },
+    ],
+  },
+  {
+    id: 'components',
+    data: { label: 'Components' },
+    children: components.map(([label, path]) => ({
+      id: path,
+      data: { label, path },
+    })),
+  },
+  {
+    id: 'demos',
+    data: { label: 'Demos' },
+    children: demos.map(([label, path]) => ({
+      id: path,
+      data: { label, path },
+    })),
+  },
+];
+
+export default function NavDrawer() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { theme } = useTheme();
+  return (
+    <Drawer responsive anchor="left" size="16rem">
+      <Tree<Item>
+        nodes={treeData}
+        getLabel={(n) => n.label}
+        variant="list"
+        selected={location.pathname}
+        defaultExpanded={['getting-started', 'components', 'demos']}
+        onNodeSelect={(n) => n.path && navigate(n.path)}
+        style={{ padding: theme.spacing(1) }}
+      />
+    </Drawer>
+  );
+}

--- a/docs/src/pages/AvatarDemo.tsx
+++ b/docs/src/pages/AvatarDemo.tsx
@@ -18,6 +18,7 @@ import {
 import type { TableColumn } from '@archway/valet';
 import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 import { useState } from 'react';
 
 interface EmailForm {
@@ -88,6 +89,7 @@ export default function AvatarDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack preset="showcaseStack">
         <Typography variant="h2">Avatar</Typography>
 

--- a/docs/src/pages/BoxDemo.tsx
+++ b/docs/src/pages/BoxDemo.tsx
@@ -15,6 +15,7 @@ import {
 import type { TableColumn } from '@archway/valet';
 import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Demo page                                                                  */
@@ -71,6 +72,7 @@ export default function BoxDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack preset="showcaseStack">
         <Typography variant="h2" bold>
           Box Showcase

--- a/docs/src/pages/ButtonDemoPage.tsx
+++ b/docs/src/pages/ButtonDemoPage.tsx
@@ -15,6 +15,7 @@ import {
 import type { TableColumn } from '@archway/valet';
 import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────*/
 export default function ButtonDemoPage() {
@@ -76,6 +77,7 @@ export default function ButtonDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack spacing={1} preset="showcaseStack">
         {/* Header ------------------------------------------------------- */}
         <Typography variant="h2" bold>

--- a/docs/src/pages/CheckBoxDemo.tsx
+++ b/docs/src/pages/CheckBoxDemo.tsx
@@ -19,6 +19,7 @@ import {
 import type { TableColumn } from '@archway/valet';
 import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Local form store for demo                                                  */
@@ -113,6 +114,7 @@ export default function CheckboxDemoPage() {
 
   return (
     <Surface /* Surface already defaults to theme background */>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/DrawerDemo.tsx
+++ b/docs/src/pages/DrawerDemo.tsx
@@ -30,7 +30,7 @@ export default function DrawerDemoPage() {
       </Drawer>
       <Stack
         spacing={1}
-        style={{ padding: theme.spacing(1), maxWidth: 980, margin: '0 auto', marginLeft: '16rem' }}
+        style={{ padding: theme.spacing(1), maxWidth: 980, margin: '0 auto' }}
       >
         <Typography variant="h2" bold>
           Drawer Showcase

--- a/docs/src/pages/Installation.tsx
+++ b/docs/src/pages/Installation.tsx
@@ -3,6 +3,7 @@
 // Getting started installation page
 // ─────────────────────────────────────────────────────────────
 import { Surface, Stack, Typography, Button, Panel } from '@archway/valet';
+import NavDrawer from '../components/NavDrawer';
 import { useNavigate } from 'react-router-dom';
 
 export default function InstallationPage() {
@@ -10,6 +11,7 @@ export default function InstallationPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack spacing={1} preset="showcaseStack">
         <Typography variant="h2" bold>Installation</Typography>
         <Typography>Install via npm:</Typography>

--- a/docs/src/pages/MainPage.tsx
+++ b/docs/src/pages/MainPage.tsx
@@ -2,104 +2,25 @@
 // src/pages/MainPage.tsx  | valet
 // Doc home with responsive drawer navigation
 // ─────────────────────────────────────────────────────────────
-import { useNavigate, useLocation } from 'react-router-dom';
+
 import {
   Surface,
-  Drawer,
   Stack,
   Button,
   Typography,
-  Tree,
-  type TreeNode,
   useTheme,
-  useSurface,
 } from '@archway/valet';
+import NavDrawer from '../components/NavDrawer';
 
 export default function MainPage() {
-  const navigate = useNavigate();
-  const location = useLocation();
   const { theme, mode, toggleMode } = useTheme();
 
-  const components: [string, string][] = [
-    ['Accordion', '/accordion-demo'],
-    ['Avatar', '/avatar-demo'],
-    ['Box', '/box-demo'],
-    ['Button', '/button-demo'],
-    ['Checkbox', '/checkbox-demo'],
-    ['Chat', '/chat-demo'],
-    ['Drawer', '/drawer-demo'],
-    ['FormControl + Textfield', '/text-form-demo'],
-    ['Grid', '/grid-demo'],
-    ['Icon', '/icon-demo'],
-    ['Icon Button', '/icon-button-demo'],
-    ['List', '/list-demo'],
-    ['Modal', '/modal-demo'],
-    ['Pagination', '/pagination-demo'],
-    ['Panel', '/panel-demo'],
-    ['Progress', '/progress-demo'],
-    ['Radio Group', '/radio-demo'],
-    ['Slider', '/slider-demo'],
-    ['Select', '/select-demo'],
-    ['Snackbar', '/snackbar-demo'],
-    ['Switch', '/switch-demo'],
-    ['Table', '/table-demo'],
-    ['Tabs', '/tabs-demo'],
-    ['Tooltip', '/tooltip-demo'],
-    ['Typography', '/typography'],
-    ['Video', '/video-demo'],
-    ['AppBar', '/appbar-demo'],
-    ['Speed Dial', '/speeddial-demo'],
-    ['Stepper', '/stepper-demo'],
-    ['Tree', '/tree-demo'],
-  ];
-
-  const demos: [string, string][] = [
-    ['Presets', '/presets'],
-    ['Form', '/form'],
-    ['Parallax', '/parallax'],
-    ['Radio Button', '/test'],
-  ];
-
-  interface Item { label: string; path?: string }
-
-  const treeData: TreeNode<Item>[] = [
-    {
-      id: 'getting-started',
-      data: { label: 'Getting Started' },
-      children: [
-        { id: '/overview', data: { label: 'Overview', path: '/overview' } },
-        { id: '/installation', data: { label: 'Installation', path: '/installation' } },
-        { id: '/usage', data: { label: 'Usage', path: '/usage' } },
-      ],
-    },
-    {
-      id: 'components',
-      data: { label: 'Components' },
-      children: components.map(([label, path]) => ({
-        id: path,
-        data: { label, path },
-      })),
-    },
-    {
-      id: 'demos',
-      data: { label: 'Demos' },
-      children: demos.map(([label, path]) => ({
-        id: path,
-        data: { label, path },
-      })),
-    },
-  ];
-
   function Content() {
-    const { width, height } = useSurface();
-    const landscape = width >= height;
-
     return (
       <Stack
         spacing={1}
         style={{
           padding: theme.spacing(1),
-          marginLeft: landscape ? '16rem' : 0,
           maxWidth: 980,
         }}
       >
@@ -118,17 +39,7 @@ export default function MainPage() {
 
   return (
     <Surface>
-      <Drawer responsive anchor="left" size="16rem">
-        <Tree<Item>
-          nodes={treeData}
-          getLabel={(n) => n.label}
-          variant="list"
-          selected={location.pathname}
-          defaultExpanded={['getting-started', 'components', 'demos']}
-          onNodeSelect={(n) => n.path && navigate(n.path)}
-          style={{ padding: theme.spacing(1) }}
-        />
-      </Drawer>
+      <NavDrawer />
       <Content />
     </Surface>
   );

--- a/docs/src/pages/Overview.tsx
+++ b/docs/src/pages/Overview.tsx
@@ -3,6 +3,7 @@
 // Getting started overview page
 // ─────────────────────────────────────────────────────────────
 import { Surface, Stack, Typography, Button } from '@archway/valet';
+import NavDrawer from '../components/NavDrawer';
 import { useNavigate } from 'react-router-dom';
 
 export default function OverviewPage() {
@@ -10,6 +11,7 @@ export default function OverviewPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack preset="showcaseStack">
         <Typography variant="h2">Overview</Typography>
         <Typography>

--- a/docs/src/pages/Usage.tsx
+++ b/docs/src/pages/Usage.tsx
@@ -3,6 +3,7 @@
 // Getting started usage page
 // ─────────────────────────────────────────────────────────────
 import { Surface, Stack, Typography, Button } from '@archway/valet';
+import NavDrawer from '../components/NavDrawer';
 import { useNavigate } from 'react-router-dom';
 
 export default function UsagePage() {
@@ -10,6 +11,7 @@ export default function UsagePage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack spacing={1} preset="showcaseStack">
         <Typography variant="h2" bold>Usage</Typography>
         <Typography>

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -181,6 +181,23 @@ export const Drawer: React.FC<DrawerProps> = ({
     if (e.target === e.currentTarget) requestClose();
   };
 
+  // When persistent, offset the current surface so content isn't hidden
+  useLayoutEffect(() => {
+    const node = surface.element;
+    if (!node) return;
+    const horizontal = anchor === 'left' || anchor === 'right';
+    if (persistentEffective && horizontal) {
+      const px = typeof size === 'number' ? `${size}px` : size;
+      const prop = anchor === 'left' ? 'marginLeft' : 'marginRight';
+      const prev = (node.style as any)[prop];
+      (node.style as any)[prop] = px;
+      return () => {
+        (node.style as any)[prop] = prev;
+      };
+    }
+    return;
+  }, [surface.element, persistentEffective, anchor, size]);
+
   if (!open && !persistentEffective) {
     if (responsiveMode && portrait) {
       return (


### PR DESCRIPTION
## Summary
- adjust Drawer so persistent/landscape drawers offset the Surface
- simplify MainPage layout
- remove manual margin from Drawer demo
- share docs navigation drawer across pages
- add NavDrawer to more demo pages

## Testing
- `npm run build`
- `npm install && npm run build` in docs

------
https://chatgpt.com/codex/tasks/task_e_6870231eec7083208081b5efd9dd2f36