### PR TITLE
Update accordion demos

### DIFF
--- a/docs/src/pages/AccordionConstrainedDemo.tsx
+++ b/docs/src/pages/AccordionConstrainedDemo.tsx
@@ -36,7 +36,7 @@ export default function AccordionConstrainedDemo() {
             ))}
           </Accordion>
         </Panel>
-        <Button size="lg" onClick={() => navigate('/accordion-demo')}>
+        <Button size="lg" onClick={() => navigate('/')}>
           ← Back
         </Button>
       </Stack>

--- a/docs/src/pages/AccordionDemo.tsx
+++ b/docs/src/pages/AccordionDemo.tsx
@@ -14,6 +14,7 @@ import {
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Helpers                                                                    */
@@ -34,6 +35,7 @@ export default function AccordionDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"
@@ -147,7 +149,7 @@ export default function AccordionDemoPage() {
         {/* Back nav -------------------------------------------------------- */}
         <Button
           size="lg"
-          onClick={() => navigate(-1)}
+          onClick={() => navigate('/')}
           style={{ marginTop: theme.spacing(1) }}
         >
           ← Back


### PR DESCRIPTION
## Summary
- add NavDrawer to Accordion demo page
- update navigation buttons to go to the home page

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6870382db2208320bb7ec4ff27809aac