### PR TITLE
Update accordion demos

### DIFF
--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -57,6 +57,10 @@ const demos: [string, string][] = [
 
 const treeData: TreeNode<Item>[] = [
   {
+    id: 'welcome',
+    data: { label: 'Welcome', path: '/' },
+  },
+  {
     id: 'getting-started',
     data: { label: 'Getting Started' },
     children: [

--- a/docs/src/pages/AccordionConstrainedDemo.tsx
+++ b/docs/src/pages/AccordionConstrainedDemo.tsx
@@ -36,7 +36,7 @@ export default function AccordionConstrainedDemo() {
             ))}
           </Accordion>
         </Panel>
-        <Button size="lg" onClick={() => navigate('/accordion-demo')}>
+        <Button size="lg" onClick={() => navigate('/')}>
           ← Back
         </Button>
       </Stack>

--- a/docs/src/pages/AccordionDemo.tsx
+++ b/docs/src/pages/AccordionDemo.tsx
@@ -14,6 +14,7 @@ import {
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Helpers                                                                    */
@@ -34,6 +35,7 @@ export default function AccordionDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"
@@ -147,7 +149,7 @@ export default function AccordionDemoPage() {
         {/* Back nav -------------------------------------------------------- */}
         <Button
           size="lg"
-          onClick={() => navigate(-1)}
+          onClick={() => navigate('/')}
           style={{ marginTop: theme.spacing(1) }}
         >
           ← Back

--- a/docs/src/pages/ChatDemo.tsx
+++ b/docs/src/pages/ChatDemo.tsx
@@ -12,6 +12,7 @@ import {
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 import type { ChatMessage } from '@archway/valet';
 import monkey from '../assets/monkey.jpg';
 import present from '../assets/present.jpg';
@@ -33,6 +34,7 @@ export default function ChatDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack spacing={1} preset="showcaseStack">
         <Typography variant="h2" bold>
           Chat Showcase

--- a/docs/src/pages/FormDemoPage.tsx
+++ b/docs/src/pages/FormDemoPage.tsx
@@ -13,6 +13,7 @@ import {
   definePreset,
   useTheme,
 } from '@archway/valet';
+import NavDrawer from '../components/NavDrawer';
 
 /*───────────────────────────────────────────────────────────────*/
 /* 1.  Create a typed store for this form                        */
@@ -52,6 +53,7 @@ export default function FormDemoPage() {
 
   return (
     <Surface style={{ backgroundColor: theme.colors['background'] }}>
+      <NavDrawer />
       <Box preset="cardForm">
         <Typography variant="h3" style={{ marginBottom: theme.spacing(1) }}>
           Contact Form Demo

--- a/docs/src/pages/GridDemo.tsx
+++ b/docs/src/pages/GridDemo.tsx
@@ -1,6 +1,7 @@
 // src/pages/GridDemo.tsx
 import { Surface, Stack, Typography, Button, Grid, Box, useTheme } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 export default function GridDemoPage() {
   const { theme, toggleMode } = useTheme();
@@ -8,6 +9,7 @@ export default function GridDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/IconButtonDemoPage.tsx
+++ b/docs/src/pages/IconButtonDemoPage.tsx
@@ -18,6 +18,7 @@ import {
 import type { TableColumn } from '@archway/valet';
 import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Style preset showcasing IconButton inside a card                            */
@@ -102,6 +103,7 @@ export default function IconButtonDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/IconDemoPage.tsx
+++ b/docs/src/pages/IconDemoPage.tsx
@@ -17,6 +17,7 @@ import {
 import type { TableColumn } from '@archway/valet';
 import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Style presets – demonstrate Icon inside themed containers                   */
@@ -97,6 +98,7 @@ export default function IconDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/ListDemoPage.tsx
+++ b/docs/src/pages/ListDemoPage.tsx
@@ -14,6 +14,7 @@ import {
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Demo data                                                                  */
@@ -48,6 +49,7 @@ export default function ListDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"


### PR DESCRIPTION
## Summary
- add NavDrawer to Accordion demo page
- update navigation buttons to go to the home page
- add NavDrawer to Chat, Formcontrol / Textfield, Grid, Icon, IconButton, and List pages

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870382db2208320bb7ec4ff27809aac