### PR TITLE
Add NavDrawer to more demos

### DIFF
--- a/docs/src/pages/ModalDemo.tsx
+++ b/docs/src/pages/ModalDemo.tsx
@@ -16,6 +16,7 @@ import {
   Modal,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Presets                                                                    */
@@ -39,6 +40,7 @@ export default function ModalDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/PaginationDemo.tsx
+++ b/docs/src/pages/PaginationDemo.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { Surface, Stack, Typography, Button, Pagination, useTheme } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 export default function PaginationDemoPage() {
   const { theme, toggleMode } = useTheme();
@@ -10,6 +11,7 @@ export default function PaginationDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/PanelDemo.tsx
+++ b/docs/src/pages/PanelDemo.tsx
@@ -11,6 +11,7 @@ import {
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Demo page                                                                  */
@@ -21,6 +22,7 @@ export default function PanelDemoPage() {
 
   return (
     <Surface /* Surface already defaults to theme background */>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/ProgressDemo.tsx
+++ b/docs/src/pages/ProgressDemo.tsx
@@ -17,6 +17,7 @@ import {
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Demo page                                                                  */
@@ -46,6 +47,7 @@ export default function ProgressDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/TextFormDemo.tsx
+++ b/docs/src/pages/TextFormDemo.tsx
@@ -14,6 +14,7 @@ import {
   createFormStore
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Local form store for the demo                                              */
@@ -40,6 +41,7 @@ export default function TextFieldDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"


### PR DESCRIPTION
## Summary
- show navigation drawer in ModalDemo
- show navigation drawer in PaginationDemo
- show navigation drawer in PanelDemo
- show navigation drawer in ProgressDemo
- show navigation drawer in TextFormDemo

## Testing
- `npm run -s build`
- `cd docs && npm run -s lint` *(fails: couldn't find config)*
- `npm run -s build`

------
https://chatgpt.com/codex/tasks/task_e_68703d0a0bfc83208af68fa89cee5d93