### PR TITLE
Add NavDrawer to more demos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. The format 
 - Avatar, Box, Button, and Checkbox pages now use the drawer
 - Modal, Pagination, Panel, Progress, TextForm, Radio Group, Slider,
   Select, Snackbar, Switch, Tooltip, and Typography pages now use the drawer
+- AppBar, SpeedDial, Stepper, Tree, and Video pages now use the drawer
 
 ## [v0.8.5]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file. The format 
 ### Added
 - Shared navigation drawer component for docs
 - Avatar, Box, Button, and Checkbox pages now use the drawer
+- Modal, Pagination, Panel, Progress, TextForm, Radio Group, Slider,
+  Select, Snackbar, Switch, Tooltip, and Typography pages now use the drawer
 
 ## [v0.8.5]
 ### Added

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -40,12 +40,12 @@ const components: [string, string][] = [
   ['Table', '/table-demo'],
   ['Tabs', '/tabs-demo'],
   ['Tooltip', '/tooltip-demo'],
+  ['Tree', '/tree-demo'],
   ['Typography', '/typography'],
   ['Video', '/video-demo'],
   ['AppBar', '/appbar-demo'],
   ['Speed Dial', '/speeddial-demo'],
   ['Stepper', '/stepper-demo'],
-  ['Tree', '/tree-demo'],
 ];
 
 const demos: [string, string][] = [

--- a/docs/src/pages/AppBarDemo.tsx
+++ b/docs/src/pages/AppBarDemo.tsx
@@ -1,6 +1,7 @@
 // src/pages/AppBarDemo.tsx
 import { Surface, Stack, Typography, Button, AppBar, Box, useTheme } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 export default function AppBarDemoPage() {
   const { toggleMode } = useTheme();
@@ -8,6 +9,7 @@ export default function AppBarDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/ModalDemo.tsx
+++ b/docs/src/pages/ModalDemo.tsx
@@ -16,6 +16,7 @@ import {
   Modal,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Presets                                                                    */
@@ -39,6 +40,7 @@ export default function ModalDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/PaginationDemo.tsx
+++ b/docs/src/pages/PaginationDemo.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { Surface, Stack, Typography, Button, Pagination, useTheme } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 export default function PaginationDemoPage() {
   const { theme, toggleMode } = useTheme();
@@ -10,6 +11,7 @@ export default function PaginationDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/PanelDemo.tsx
+++ b/docs/src/pages/PanelDemo.tsx
@@ -11,6 +11,7 @@ import {
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Demo page                                                                  */
@@ -21,6 +22,7 @@ export default function PanelDemoPage() {
 
   return (
     <Surface /* Surface already defaults to theme background */>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/ProgressDemo.tsx
+++ b/docs/src/pages/ProgressDemo.tsx
@@ -17,6 +17,7 @@ import {
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Demo page                                                                  */
@@ -46,6 +47,7 @@ export default function ProgressDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/RadioGroupDemo.tsx
+++ b/docs/src/pages/RadioGroupDemo.tsx
@@ -18,6 +18,7 @@ import {
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Style Presets                                                              */
@@ -62,6 +63,7 @@ export default function RadioGroupDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/SelectDemo.tsx
+++ b/docs/src/pages/SelectDemo.tsx
@@ -17,6 +17,7 @@ import {
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*───────────────────────────────────────────────────────────*/
 /* Local form store                                          */
@@ -42,6 +43,7 @@ export default function SelectDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/SliderDemo.tsx
+++ b/docs/src/pages/SliderDemo.tsx
@@ -14,6 +14,7 @@ import {
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Example-wide constants                                                     */
@@ -31,6 +32,7 @@ export default function SliderDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/SnackbarDemo.tsx
+++ b/docs/src/pages/SnackbarDemo.tsx
@@ -14,6 +14,7 @@ import {
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Helpers                                                                    */
@@ -40,6 +41,7 @@ export default function SnackbarDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack spacing={1} preset="showcaseStack">
         {/* Header --------------------------------------------------------- */}
         <Typography variant="h2" bold>

--- a/docs/src/pages/SpeedDialDemo.tsx
+++ b/docs/src/pages/SpeedDialDemo.tsx
@@ -1,6 +1,7 @@
 // src/pages/SpeedDialDemo.tsx
 import { Surface, Stack, Typography, Button, SpeedDial, Icon, useTheme } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 export default function SpeedDialDemoPage() {
   const { theme, toggleMode } = useTheme();
@@ -14,6 +15,7 @@ export default function SpeedDialDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/StepperDemo.tsx
+++ b/docs/src/pages/StepperDemo.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { Surface, Stack, Typography, Button, Stepper, useTheme } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 export default function StepperDemoPage() {
   const { theme, toggleMode } = useTheme();
@@ -12,6 +13,7 @@ export default function StepperDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/SwitchDemo.tsx
+++ b/docs/src/pages/SwitchDemo.tsx
@@ -16,6 +16,7 @@ import {
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Local form store for demo                                                  */
@@ -58,6 +59,7 @@ export default function SwitchDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/TextFormDemo.tsx
+++ b/docs/src/pages/TextFormDemo.tsx
@@ -14,6 +14,7 @@ import {
   createFormStore
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Local form store for the demo                                              */
@@ -40,6 +41,7 @@ export default function TextFieldDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/TooltipDemo.tsx
+++ b/docs/src/pages/TooltipDemo.tsx
@@ -15,6 +15,7 @@ import {
   definePreset,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Style presets                                                              */
@@ -44,6 +45,7 @@ export default function TooltipDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack
         spacing={1}
         preset="showcaseStack"

--- a/docs/src/pages/TreeDemo.tsx
+++ b/docs/src/pages/TreeDemo.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { Surface, Stack, Typography, Button, Tree, type TreeNode, useTheme } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 
 interface Item {
   label: React.ReactNode;
@@ -66,6 +67,7 @@ export default function TreeDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack spacing={1} preset="showcaseStack">
         <Typography variant="h2" bold>Tree Showcase</Typography>
         <Typography variant="subtitle">Nested list with keyboard navigation</Typography>

--- a/docs/src/pages/TypographyDemoPage.tsx
+++ b/docs/src/pages/TypographyDemoPage.tsx
@@ -1,5 +1,6 @@
 // src/pages/TypographyDemoPage.tsx
 import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
 import {
   Surface,
   Stack,
@@ -97,6 +98,7 @@ export default function TypographyDemoPage() {
 
   return (
     <Surface>
+      <NavDrawer />
       <Stack>
         <Typography variant="h2">
           Typography

--- a/docs/src/pages/VideoDemo.tsx
+++ b/docs/src/pages/VideoDemo.tsx
@@ -6,9 +6,10 @@ import {
     Surface,
     Stack,
     Typography,
-    Video,
-    useTheme,
-  } from '@archway/valet';
+  Video,
+  useTheme,
+} from '@archway/valet';
+import NavDrawer from '../components/NavDrawer';
   
   /*─────────────────────────────────────────────────────────────*/
   /* Demo page                                                   */
@@ -17,6 +18,7 @@ import {
   
     return (
       <Surface>
+        <NavDrawer />
         <Stack
           spacing={1}
           style={{


### PR DESCRIPTION
## Summary
- show navigation drawer in RadioGroup demo
- show navigation drawer in Slider demo
- show navigation drawer in Select demo
- show navigation drawer in Snackbar demo
- show navigation drawer in Switch demo
- show navigation drawer in Tooltip demo
- show navigation drawer in Typography demo
- note docs pages using drawer in CHANGELOG

## Testing
- `npm run -s build`
- `cd docs && npm run -s lint` *(fails: couldn't find ESLint config)*
- `npm run -s build` in `docs` directory

------
https://chatgpt.com/codex/tasks/task_e_68703d0a0bfc83208af68fa89cee5d93