### PR TITLE
Add DateTimePicker component and demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Added DateTimePicker component with form integration and demo
 
 ## [v0.8.6]
 ### Added

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -45,6 +45,7 @@ const GridDemoPage          = page(() => import('./pages/GridDemo'));
 const PaginationDemoPage    = page(() => import('./pages/PaginationDemo'));
 const SpeedDialDemoPage     = page(() => import('./pages/SpeedDialDemo'));
 const StepperDemoPage       = page(() => import('./pages/StepperDemo'));
+const DateTimePickerDemoPage= page(() => import('./pages/DateTimePickerDemo'));
 const RadioGroupDemoPage    = page(() => import('./pages/RadioGroupDemo'));
 const VideoDemoPage         = page(() => import('./pages/VideoDemo'));
 const SnackbarDemoPage      = page(() => import('./pages/SnackbarDemo'));
@@ -110,6 +111,7 @@ export function App() {
         <Route path="/pagination-demo" element={<PaginationDemoPage />} />
         <Route path="/speeddial-demo"  element={<SpeedDialDemoPage />} />
         <Route path="/stepper-demo"    element={<StepperDemoPage />} />
+        <Route path="/datetime-demo"   element={<DateTimePickerDemoPage />} />
         <Route path="/radio-demo"      element={<RadioGroupDemoPage />} />
         <Route path="/video-demo"      element={<VideoDemoPage />} />
         <Route path="/chat-demo"       element={<ChatDemoPage />} />

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -46,6 +46,7 @@ const components: [string, string][] = [
   ['AppBar', '/appbar-demo'],
   ['Speed Dial', '/speeddial-demo'],
   ['Stepper', '/stepper-demo'],
+  ['Date Time Picker', '/datetime-demo'],
 ];
 
 const demos: [string, string][] = [

--- a/docs/src/pages/DateTimePickerDemo.tsx
+++ b/docs/src/pages/DateTimePickerDemo.tsx
@@ -1,0 +1,93 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// src/pages/DateTimePickerDemo.tsx | valet
+// Demonstrates DateTimePicker usage and embedding
+// ─────────────────────────────────────────────────────────────────────────────
+import React, { useState } from 'react';
+import {
+  Surface,
+  Stack,
+  Typography,
+  Button,
+  Panel,
+  DateTimePicker,
+  FormControl,
+  createFormStore,
+  useTheme,
+} from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
+
+/*─────────────────────────────────────────────────────────────────────────────*/
+/* Local form store                                                            */
+interface BookingValues {
+  date: string;
+  time: string;
+}
+
+const useBookingForm = createFormStore<BookingValues>({
+  date: '',
+  time: '',
+});
+
+/*─────────────────────────────────────────────────────────────────────────────*/
+/* Demo page                                                                   */
+export default function DateTimePickerDemoPage() {
+  const { theme, toggleMode } = useTheme();
+  const navigate = useNavigate();
+
+  const [controlledDate, setControlledDate] = useState('');
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack spacing={1} preset="showcaseStack">
+        <Typography variant="h2" bold>
+          Date &amp; Time Picker
+        </Typography>
+        <Typography variant="subtitle">
+          Collect dates, times, or both in a single component
+        </Typography>
+
+        {/* 1. Stand-alone examples --------------------------------------- */}
+        <Typography variant="h3">1. Stand-alone</Typography>
+        <Stack spacing={1} style={{ maxWidth: 320 }}>
+          <DateTimePicker
+            label="Controlled date"
+            mode="date"
+            value={controlledDate}
+            onChange={setControlledDate}
+          />
+          <DateTimePicker label="Time only" mode="time" />
+          <DateTimePicker label="Date + Time" mode="datetime" />
+        </Stack>
+
+        {/* 2. FormControl integration ------------------------------------ */}
+        <Typography variant="h3">2. FormControl demo</Typography>
+        <Panel variant="alt" style={{ padding: theme.spacing(1) }}>
+          <FormControl
+            useStore={useBookingForm}
+            onSubmitValues={(vals) =>
+              // eslint-disable-next-line no-alert -- demo only
+              alert(JSON.stringify(vals, null, 2))
+            }
+            style={{ display: 'flex', flexDirection: 'column', gap: theme.spacing(1) }}
+          >
+            <DateTimePicker name="date" label="Date" mode="date" />
+            <DateTimePicker name="time" label="Time" mode="time" />
+            <Button type="submit" variant="contained">
+              Submit
+            </Button>
+          </FormControl>
+        </Panel>
+
+        {/* Theme toggle + back nav --------------------------------------- */}
+        <Stack direction="row" spacing={1}>
+          <Button variant="outlined" onClick={toggleMode}>
+            Toggle light / dark
+          </Button>
+          <Button onClick={() => navigate(-1)}>← Back</Button>
+        </Stack>
+      </Stack>
+    </Surface>
+  );
+}

--- a/src/components/DateTimePicker.tsx
+++ b/src/components/DateTimePicker.tsx
@@ -1,0 +1,151 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/DateTimePicker.tsx | valet
+// accessible date/time picker with optional FormControl binding
+// ─────────────────────────────────────────────────────────────
+import React, {
+  forwardRef,
+  useId,
+  useState,
+  InputHTMLAttributes,
+  ChangeEventHandler,
+} from 'react';
+import { styled } from '../css/createStyled';
+import { useTheme } from '../system/themeStore';
+import { preset } from '../css/stylePresets';
+import { useForm } from './FormControl';
+import type { Theme } from '../system/themeStore';
+import type { Presettable } from '../types';
+
+/*───────────────────────────────────────────────────────────*/
+/* Props                                                      */
+export interface DateTimePickerProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'type' | 'value' | 'defaultValue'>,
+    Presettable {
+  /** Controlled ISO value */
+  value?: string;
+  /** Uncontrolled default ISO value */
+  defaultValue?: string;
+  /** Fired whenever value changes */
+  onChange?: (value: string) => void;
+  /** Mode of the picker */
+  mode?: 'date' | 'time' | 'datetime';
+  /** Field name for FormControl binding */
+  name?: string;
+  /** Optional label */
+  label?: string;
+  /** Helper text beneath the field */
+  helperText?: string;
+  /** Error state styling */
+  error?: boolean;
+}
+
+/*───────────────────────────────────────────────────────────*/
+/* Styled primitives                                         */
+interface StyledFieldProps { theme: Theme; $error?: boolean; }
+
+const sharedFieldCSS = ({ theme, $error }: StyledFieldProps) => `
+  padding: ${theme.spacing(1)} ${theme.spacing(1)};
+  border: 1px solid ${($error ? theme.colors.secondary : theme.colors.text) + '44'};
+  border-radius: 4px;
+  background: ${theme.colors.background};
+  color: ${theme.colors.text};
+  font-size: 0.875rem;
+  width: 100%;
+  &:focus {
+    outline: 2px solid ${theme.colors.primary};
+    outline-offset: 1px;
+  }
+`;
+
+const Input = styled('input')<StyledFieldProps>`
+  ${sharedFieldCSS}
+`;
+
+const Wrapper = styled('div')<{ theme: Theme }>`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing(1)};
+`;
+
+const Label = styled('label')<{ theme: Theme }>`
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+const Helper = styled('span')<{ theme: Theme; $error?: boolean }>`
+  font-size: 0.75rem;
+  color: ${({ theme, $error }) => ($error ? theme.colors.secondary : theme.colors.text) + 'AA'};
+`;
+
+/*───────────────────────────────────────────────────────────*/
+/* Component                                                 */
+export const DateTimePicker = forwardRef<HTMLInputElement, DateTimePickerProps>(
+  (props, ref) => {
+    const {
+      mode = 'date',
+      name,
+      label,
+      helperText,
+      error = false,
+      preset: presetName,
+      className,
+      onChange: userChange,
+      value: valueProp,
+      defaultValue = '',
+      ...rest
+    } = props;
+
+    const id = useId();
+    const { theme } = useTheme();
+
+    /* optional FormControl binding */
+    let form: ReturnType<typeof useForm<any>> | null = null;
+    try { form = useForm<any>(); } catch {}
+
+    const formVal = form && name ? form.values[name] : undefined;
+    const controlled = formVal !== undefined || valueProp !== undefined;
+
+    const [self, setSelf] = useState(defaultValue);
+    const current = controlled ? (formVal !== undefined ? formVal : valueProp!) : self;
+
+    const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+      const v = e.target.value;
+      if (!controlled) setSelf(v);
+      form?.setField(name as any, v);
+      userChange?.(v);
+    };
+
+    const presetCls = presetName ? preset(presetName) : '';
+    const inputType = mode === 'datetime' ? 'datetime-local' : mode;
+
+    return (
+      <Wrapper theme={theme} className={[presetCls, className].filter(Boolean).join(' ')}>
+        {label && (
+          <Label theme={theme} htmlFor={id}>
+            {label}
+          </Label>
+        )}
+        <Input
+          {...rest}
+          id={id}
+          ref={ref}
+          name={name}
+          type={inputType}
+          theme={theme}
+          $error={error}
+          value={current}
+          onChange={handleChange}
+        />
+        {helperText && (
+          <Helper theme={theme} $error={error}>
+            {helperText}
+          </Helper>
+        )}
+      </Wrapper>
+    );
+  }
+);
+
+DateTimePicker.displayName = 'DateTimePicker';
+
+export default DateTimePicker;

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ export * from './components/RadioGroup';
 export * from './components/Slider';
 export * from './components/Snackbar';
 export * from './components/Stack';
+export * from './components/DateTimePicker';
 export { default as Select } from './components/Select';  // ← gives you `Select`
 export type {
   SelectProps,


### PR DESCRIPTION
## Summary
- create `DateTimePicker` component for date, time or datetime values
- export the new component
- document it with `DateTimePickerDemo` page
- wire the demo into docs navigation and routes
- note the addition in the changelog

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6870486144d88320a6b16ab214c5e88f