### PR TITLE
Add DateTimePicker component and docs demo

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -49,6 +49,7 @@ const RadioGroupDemoPage    = page(() => import('./pages/RadioGroupDemo'));
 const VideoDemoPage         = page(() => import('./pages/VideoDemo'));
 const SnackbarDemoPage      = page(() => import('./pages/SnackbarDemo'));
 const TreeDemoPage          = page(() => import('./pages/TreeDemo'));
+const DateTimeDemoPage      = page(() => import('./pages/DateTimeDemo'));
 const OverviewPage          = page(() => import('./pages/Overview'));
 const InstallationPage      = page(() => import('./pages/Installation'));
 const UsagePage             = page(() => import('./pages/Usage'));
@@ -115,6 +116,7 @@ export function App() {
         <Route path="/chat-demo"       element={<ChatDemoPage />} />
         <Route path="/snackbar-demo"   element={<SnackbarDemoPage />} />
         <Route path="/tree-demo"      element={<TreeDemoPage />} />
+        <Route path="/datetime-demo"  element={<DateTimeDemoPage />} />
       </Routes>
     </Suspense>
   );

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -46,6 +46,7 @@ const components: [string, string][] = [
   ['AppBar', '/appbar-demo'],
   ['Speed Dial', '/speeddial-demo'],
   ['Stepper', '/stepper-demo'],
+  ['DateTimePicker', '/datetime-demo'],
 ];
 
 const demos: [string, string][] = [

--- a/docs/src/pages/DateTimeDemo.tsx
+++ b/docs/src/pages/DateTimeDemo.tsx
@@ -1,0 +1,95 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/DateTimeDemo.tsx | valet
+// Demonstrates DateTimePicker component
+// ─────────────────────────────────────────────────────────────
+import React, { useState } from 'react';
+import {
+  Surface,
+  Stack,
+  Typography,
+  Button,
+  Panel,
+  Chat,
+  FormControl,
+  createFormStore,
+  DateTimePicker,
+  type ChatMessage,
+  useTheme,
+} from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
+
+export default function DateTimeDemoPage() {
+  const { theme } = useTheme();
+  const navigate = useNavigate();
+
+  const [controlled, setControlled] = useState('');
+
+  type FormVals = { when: string };
+  const useForm = createFormStore<FormVals>({ when: '' });
+  const [submitted, setSubmitted] = useState<FormVals | null>(null);
+
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+
+  const handleSend = (m: ChatMessage) => {
+    setMessages((prev) => [...prev, m]);
+  };
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack spacing={1} preset="showcaseStack">
+        <Typography variant="h2" bold>DateTimePicker</Typography>
+        <Typography variant="subtitle">
+          Date, time or both – integrates with FormControl
+        </Typography>
+
+        <Typography variant="h3">1. Uncontrolled (date &amp; time)</Typography>
+        <DateTimePicker />
+
+        <Typography variant="h3">2. Date only</Typography>
+        <DateTimePicker showTime={false} />
+
+        <Typography variant="h3">3. Time only</Typography>
+        <DateTimePicker showDate={false} />
+
+        <Typography variant="h3">4. Controlled value</Typography>
+        <Stack direction="row" spacing={1}>
+          <DateTimePicker value={controlled} onChange={setControlled} />
+          <Typography>{controlled || '–'}</Typography>
+        </Stack>
+
+        <Typography variant="h3">5. FormControl</Typography>
+        <Panel variant="alt" style={{ padding: theme.spacing(1) }}>
+          <FormControl
+            useStore={useForm}
+            onSubmitValues={(vals) => setSubmitted(vals)}
+            style={{ display: 'flex', gap: theme.spacing(1) }}
+          >
+            <DateTimePicker name="when" />
+            <Button type="submit">Submit</Button>
+          </FormControl>
+          {submitted && (
+            <pre style={{ marginTop: theme.spacing(1) }}>
+              {JSON.stringify(submitted, null, 2)}
+            </pre>
+          )}
+        </Panel>
+
+        <Typography variant="h3">6. Embedded in Chat</Typography>
+        <Panel variant="alt" style={{ padding: theme.spacing(1) }}>
+          <Chat messages={messages} onSend={handleSend} />
+          <DateTimePicker />
+        </Panel>
+
+        <Button
+          size="lg"
+          onClick={() => navigate(-1)}
+          style={{ marginTop: theme.spacing(1) }}
+        >
+          ← Back
+        </Button>
+      </Stack>
+    </Surface>
+  );
+}

--- a/src/components/DateTimePicker.tsx
+++ b/src/components/DateTimePicker.tsx
@@ -1,0 +1,179 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/DateTimePicker.tsx  | valet
+// accessible date & time picker
+// ─────────────────────────────────────────────────────────────
+import React, { forwardRef, useState, useEffect, useId } from 'react';
+import { styled } from '../css/createStyled';
+import { useTheme } from '../system/themeStore';
+import { preset } from '../css/stylePresets';
+import { useForm } from './FormControl';
+import type { Theme } from '../system/themeStore';
+import type { Presettable } from '../types';
+
+/*───────────────────────────────────────────────────────────*/
+/* Styled primitives                                         */
+interface StyledInputProps { theme: Theme; }
+
+const sharedInputCSS = ({ theme }: StyledInputProps) => `
+  padding: ${theme.spacing(1)} ${theme.spacing(1)};
+  border: 1px solid ${theme.colors.text + '44'};
+  border-radius: 4px;
+  background: ${theme.colors.background};
+  color: ${theme.colors.text};
+  font-size: 0.875rem;
+  width: 100%;
+  &:focus { outline: 2px solid ${theme.colors.primary}; outline-offset: 1px; }
+`;
+
+const Input = styled('input')<StyledInputProps>`
+  ${sharedInputCSS}
+`;
+
+const Wrapper = styled('div')<{ theme: Theme }>`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing(1)};
+`;
+
+const Label = styled('label')<{ theme: Theme }>`
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+const Row = styled('div')<{ theme: Theme }>`
+  display: flex;
+  gap: ${({ theme }) => theme.spacing(1)};
+  width: 100%;
+`;
+
+/*───────────────────────────────────────────────────────────*/
+/* Prop contracts                                            */
+export interface DateTimePickerProps
+  extends Presettable,
+    Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'> {
+  /** Field name for FormControl */
+  name?: string;
+  /** Optional label */
+  label?: string;
+  /** Show date input */
+  showDate?: boolean;
+  /** Show time input */
+  showTime?: boolean;
+  /** Controlled value in ISO format */
+  value?: string;
+  /** Uncontrolled initial value */
+  defaultValue?: string;
+  /** Change handler receiving ISO string */
+  onChange?: (val: string) => void;
+  disabled?: boolean;
+}
+
+/*───────────────────────────────────────────────────────────*/
+/* Helper functions                                          */
+const splitParts = (v: string | undefined) => {
+  const date = v?.split('T')[0] ?? '';
+  const time = v?.split('T')[1]?.slice(0,5) ?? '';
+  if (v && !v.includes('T')) {
+    if (v.includes(':')) return { date: '', time: v };
+    return { date: v, time: '' };
+  }
+  return { date, time };
+};
+
+const joinParts = (d: string, t: string, sd: boolean, st: boolean) => {
+  if (sd && st) {
+    if (!d && !t) return '';
+    return `${d}T${t}`.trim();
+  }
+  return sd ? d : t;
+};
+
+/*───────────────────────────────────────────────────────────*/
+/* Component                                                 */
+export const DateTimePicker = forwardRef<HTMLDivElement, DateTimePickerProps>(
+  (props, ref) => {
+    const {
+      name,
+      label,
+      showDate = true,
+      showTime = true,
+      value: valueProp,
+      defaultValue,
+      onChange,
+      disabled,
+      preset: presetKey,
+      className,
+      style,
+      ...rest
+    } = props;
+
+    const { theme } = useTheme();
+    const id = useId();
+
+    let form: ReturnType<typeof useForm<any>> | null = null;
+    try { form = useForm<any>(); } catch {}
+
+    const formVal = form && name ? form.values[name] : undefined;
+    const controlled = formVal !== undefined || valueProp !== undefined;
+
+    const [self, setSelf] = useState(defaultValue ?? '');
+    const cur = controlled ? (formVal ?? valueProp ?? '') : self;
+
+    const parts = splitParts(cur);
+    const [date, setDate] = useState(parts.date);
+    const [time, setTime] = useState(parts.time);
+
+    useEffect(() => {
+      const p = splitParts(cur);
+      setDate(p.date); setTime(p.time);
+    }, [cur]);
+
+    const commit = (d: string, t: string) => {
+      const next = joinParts(d, t, showDate, showTime);
+      if (!controlled) setSelf(next);
+      if (form && name) form.setField(name as any, next);
+      onChange?.(next);
+    };
+
+    const presetCls = presetKey ? preset(presetKey) : '';
+    const merged = [presetCls, className].filter(Boolean).join(' ') || undefined;
+
+    return (
+      <Wrapper ref={ref} theme={theme} className={merged} style={style} {...rest}>
+        {label && (
+          <Label theme={theme} htmlFor={id}>{label}</Label>
+        )}
+        <Row theme={theme}>
+          {showDate && (
+            <Input
+              theme={theme}
+              type="date"
+              value={date}
+              disabled={disabled}
+              onChange={(e) => {
+                setDate(e.target.value);
+                commit(e.target.value, time);
+              }}
+            />
+          )}
+          {showTime && (
+            <Input
+              theme={theme}
+              type="time"
+              value={time}
+              disabled={disabled}
+              onChange={(e) => {
+                setTime(e.target.value);
+                commit(date, e.target.value);
+              }}
+            />
+          )}
+        </Row>
+      </Wrapper>
+    );
+  }
+);
+
+DateTimePicker.displayName = 'DateTimePicker';
+
+export default DateTimePicker;

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ export * from './components/LoadingBackdrop';
 export * from './components/Switch';
 export * from './components/Tabs';
 export * from './components/TextField';
+export * from './components/DateTimePicker';
 export * from './components/Tooltip';
 export * from './components/Typography';
 export * from './components/Video';


### PR DESCRIPTION
## Summary
- add DateTimePicker component
- export component
- wire new demo route and nav entry
- document DateTimePicker usage

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6870486144d88320a6b16ab214c5e88f