### PR TITLE
Add DateTimePicker component

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -49,6 +49,7 @@ const RadioGroupDemoPage    = page(() => import('./pages/RadioGroupDemo'));
 const VideoDemoPage         = page(() => import('./pages/VideoDemo'));
 const SnackbarDemoPage      = page(() => import('./pages/SnackbarDemo'));
 const TreeDemoPage          = page(() => import('./pages/TreeDemo'));
+const DateTimeDemoPage      = page(() => import('./pages/DateTimeDemo'));
 const OverviewPage          = page(() => import('./pages/Overview'));
 const InstallationPage      = page(() => import('./pages/Installation'));
 const UsagePage             = page(() => import('./pages/Usage'));
@@ -115,6 +116,7 @@ export function App() {
         <Route path="/chat-demo"       element={<ChatDemoPage />} />
         <Route path="/snackbar-demo"   element={<SnackbarDemoPage />} />
         <Route path="/tree-demo"      element={<TreeDemoPage />} />
+        <Route path="/datetime-demo"  element={<DateTimeDemoPage />} />
       </Routes>
     </Suspense>
   );

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -23,6 +23,7 @@ const components: [string, string][] = [
   ['Checkbox', '/checkbox-demo'],
   ['Chat', '/chat-demo'],
   ['Drawer', '/drawer-demo'],
+  ['DateTime Picker', '/datetime-demo'],
   ['FormControl + Textfield', '/text-form-demo'],
   ['Grid', '/grid-demo'],
   ['Icon', '/icon-demo'],

--- a/docs/src/pages/DateTimeDemo.tsx
+++ b/docs/src/pages/DateTimeDemo.tsx
@@ -1,0 +1,102 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// src/pages/DateTimeDemo.tsx | valet
+// Showcase for DateTimePicker component
+// ─────────────────────────────────────────────────────────────────────────────
+import React, { useState } from 'react';
+import {
+  Surface,
+  Stack,
+  Typography,
+  Button,
+  Panel,
+  FormControl,
+  TextField,
+  DateTimePicker,
+  createFormStore,
+  useTheme,
+} from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
+
+interface Booking {
+  when: string;
+  note: string;
+}
+
+const useBookingForm = createFormStore<Booking>({
+  when: '',
+  note: '',
+});
+
+export default function DateTimeDemoPage() {
+  const { theme, toggleMode } = useTheme();
+  const navigate = useNavigate();
+
+  const [ctl, setCtl] = useState('2025-01-01T12:00');
+  const [submitted, setSubmitted] = useState<Booking | null>(null);
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack spacing={1} preset="showcaseStack">
+        <Typography variant="h2" bold>
+          DateTimePicker Showcase
+        </Typography>
+        <Typography variant="subtitle">
+          Uncontrolled, controlled and FormControl examples
+        </Typography>
+
+        <Typography variant="h3">1. Uncontrolled</Typography>
+        <DateTimePicker />
+
+        <Typography variant="h3">2. Controlled</Typography>
+        <Stack spacing={1}>
+          <DateTimePicker value={ctl} onChange={setCtl} />
+          <Typography>
+            Current value: <code>{ctl}</code>
+          </Typography>
+        </Stack>
+
+        <Typography variant="h3">3. Date only</Typography>
+        <DateTimePicker showTime={false} />
+
+        <Typography variant="h3">4. Time only</Typography>
+        <DateTimePicker showDate={false} />
+
+        <Typography variant="h3">5. With seconds</Typography>
+        <DateTimePicker showSeconds />
+
+        <Typography variant="h3">6. FormControl</Typography>
+        <Panel variant="alt" style={{ padding: theme.spacing(1) }}>
+          <FormControl
+            useStore={useBookingForm}
+            onSubmitValues={(vals) => setSubmitted(vals)}
+            style={{ display: 'flex', flexDirection: 'column', gap: theme.spacing(1) }}
+          >
+            <DateTimePicker name="when" label="When" />
+            <TextField name="note" placeholder="Note" />
+            <Button type="submit">Submit</Button>
+          </FormControl>
+        </Panel>
+        {submitted && (
+          <Typography>
+            Submitted:&nbsp;<code>{JSON.stringify(submitted)}</code>
+          </Typography>
+        )}
+
+        <Typography variant="h3">7. Theme toggle</Typography>
+        <Button variant="outlined" onClick={toggleMode}>
+          Toggle light / dark
+        </Button>
+
+        <Button
+          size="lg"
+          onClick={() => navigate(-1)}
+          style={{ marginTop: theme.spacing(1) }}
+        >
+          ← Back
+        </Button>
+      </Stack>
+    </Surface>
+  );
+}

--- a/src/components/DateTimePicker.tsx
+++ b/src/components/DateTimePicker.tsx
@@ -1,0 +1,305 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/DateTimePicker.tsx | valet
+// accessible date/time picker with optional fields
+// ─────────────────────────────────────────────────────────────
+import React, { forwardRef, useId, useState, ChangeEvent } from 'react';
+import { styled } from '../css/createStyled';
+import { useTheme } from '../system/themeStore';
+import { preset } from '../css/stylePresets';
+import { useForm } from './FormControl';
+import type { Theme } from '../system/themeStore';
+import type { Presettable } from '../types';
+
+/*───────────────────────────────────────────────────────────*/
+/* Prop contracts                                            */
+export interface DateTimePickerProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'>,
+    Presettable {
+  /** Controlled ISO value: "YYYY-MM-DD", "HH:mm", or "YYYY-MM-DDTHH:mm" */
+  value?: string;
+  /** Uncontrolled default value */
+  defaultValue?: string;
+  /** Fires with the combined value whenever it changes */
+  onChange?: (value: string) => void;
+  /** Show the date field */
+  showDate?: boolean;
+  /** Show the time field */
+  showTime?: boolean;
+  /** Show seconds when selecting a time */
+  showSeconds?: boolean;
+  /** Field name when used inside FormControl */
+  name?: string;
+  /** Disabled state */
+  disabled?: boolean;
+  label?: string;
+  helperText?: string;
+  error?: boolean;
+}
+
+/*───────────────────────────────────────────────────────────*/
+/* Styled primitives                                         */
+const Wrapper = styled('div')<{ theme: Theme }>`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.spacing(1)};
+`;
+
+const Row = styled('div')<{ theme: Theme }>`
+  display: flex;
+  gap: ${({ theme }) => theme.spacing(1)};
+`;
+
+const TimeWrapper = styled('div')<{ theme: Theme }>`
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+`;
+
+const TimeNumber = styled('input')<{ theme: Theme; $error?: boolean }>`
+  padding: ${({ theme }) => `${theme.spacing(0.5)} ${theme.spacing(0.5)}`};
+  border: 1px solid
+    ${({ theme, $error }) =>
+      ($error ? theme.colors.secondary : theme.colors.text) + '44'};
+  border-radius: 4px;
+  background: ${({ theme }) => theme.colors.background};
+  color: ${({ theme }) => theme.colors.text};
+  font-size: 0.875rem;
+  width: 4ch;
+  text-align: center;
+  &:focus {
+    outline: 2px solid ${({ theme }) => theme.colors.primary};
+    outline-offset: 1px;
+  }
+`;
+
+const Field = styled('input')<{ theme: Theme; $error?: boolean }>`
+  padding: ${({ theme }) => `${theme.spacing(1)} ${theme.spacing(1)}`};
+  border: 1px solid
+    ${({ theme, $error }) =>
+      ($error ? theme.colors.secondary : theme.colors.text) + '44'};
+  border-radius: 4px;
+  background: ${({ theme }) => theme.colors.background};
+  color: ${({ theme }) => theme.colors.text};
+  font-size: 0.875rem;
+  width: 100%;
+  &:focus {
+    outline: 2px solid ${({ theme }) => theme.colors.primary};
+    outline-offset: 1px;
+  }
+`;
+
+const Label = styled('label')<{ theme: Theme }>`
+  font-size: 0.75rem;
+  color: ${({ theme }) => theme.colors.text};
+`;
+
+const Helper = styled('span')<{ theme: Theme; $error?: boolean }>`
+  font-size: 0.75rem;
+  color: ${({ theme, $error }) =>
+    ($error ? theme.colors.secondary : theme.colors.text) + 'AA'};
+`;
+
+/*───────────────────────────────────────────────────────────*/
+/* Helpers                                                   */
+const parse = (v?: string) => {
+  let date = '';
+  let time = '';
+  if (!v) return { date, time };
+  if (v.includes('T')) {
+    [date, time] = v.split('T');
+  } else if (v.includes('-')) {
+    date = v;
+  } else if (v.includes(':')) {
+    time = v;
+  }
+  return { date, time };
+};
+
+const parseTime = (t: string) => {
+  const [h = '', m = '', s = ''] = t.split(':');
+  return { h, m, s };
+};
+
+const combineTime = (
+  h: string,
+  m: string,
+  s: string,
+  showSeconds: boolean,
+) => {
+  if (!h && !m && !s) return '';
+  const pad = (v: string) => v.padStart(2, '0');
+  const hm = `${pad(h)}:${pad(m || '0')}`;
+  return showSeconds ? `${hm}:${pad(s || '0')}` : hm;
+};
+
+const combine = (
+  date: string,
+  time: string,
+  showDate: boolean,
+  showTime: boolean,
+) => {
+  if (showDate && showTime) return date && time ? `${date}T${time}` : '';
+  return showDate ? date : showTime ? time : '';
+};
+
+/*───────────────────────────────────────────────────────────*/
+/* Component                                                 */
+export const DateTimePicker = forwardRef<HTMLDivElement, DateTimePickerProps>(
+  (
+    {
+      value: valueProp,
+      defaultValue,
+      onChange,
+      showDate = true,
+      showTime = true,
+      showSeconds = false,
+      name,
+      disabled = false,
+      label,
+      helperText,
+      error = false,
+      preset: p,
+      className,
+      style,
+      ...rest
+    },
+    ref,
+  ) => {
+    const { theme } = useTheme();
+
+    let form: ReturnType<typeof useForm<any>> | null = null;
+    try {
+      form = useForm<any>();
+    } catch {}
+
+    const formVal = form && name ? (form.values[name] as string) : undefined;
+    const controlled = formVal !== undefined || valueProp !== undefined;
+
+    const initial = parse(controlled ? formVal ?? valueProp : defaultValue);
+    const [date, setDate] = useState(initial.date);
+    const parsedTime = parseTime(initial.time);
+    const [hour, setHour] = useState(parsedTime.h);
+    const [minute, setMinute] = useState(parsedTime.m);
+    const [second, setSecond] = useState(parsedTime.s);
+
+    const controlledParts = (() => {
+      if (!controlled) return null;
+      const t = parse(formVal ?? valueProp).time;
+      return parseTime(t);
+    })();
+
+    const currentDate = controlled ? parse(formVal ?? valueProp).date : date;
+    const currentHour = controlledParts ? controlledParts.h : hour;
+    const currentMinute = controlledParts ? controlledParts.m : minute;
+    const currentSecond = controlledParts ? controlledParts.s : second;
+
+    const commit = (d: string, h: string, m: string, s: string) => {
+      const t = combineTime(h, m, s, showSeconds);
+      const combo = combine(d, t, showDate, showTime);
+      if (!controlled) {
+        setDate(d);
+        setHour(h);
+        setMinute(m);
+        setSecond(s);
+      }
+      if (form && name) form.setField(name as any, combo);
+      onChange?.(combo);
+    };
+
+    const handleDate = (e: ChangeEvent<HTMLInputElement>) => {
+      commit(e.target.value, currentHour, currentMinute, currentSecond);
+    };
+    const handleHour = (e: ChangeEvent<HTMLInputElement>) => {
+      commit(currentDate, e.target.value, currentMinute, currentSecond);
+    };
+    const handleMinute = (e: ChangeEvent<HTMLInputElement>) => {
+      commit(currentDate, currentHour, e.target.value, currentSecond);
+    };
+    const handleSecond = (e: ChangeEvent<HTMLInputElement>) => {
+      commit(currentDate, currentHour, currentMinute, e.target.value);
+    };
+
+    const presetCls = p ? preset(p) : '';
+    const mergedCls = [presetCls, className].filter(Boolean).join(' ') || undefined;
+
+    const id = useId();
+
+    return (
+      <Wrapper
+        {...rest}
+        ref={ref}
+        theme={theme}
+        className={mergedCls}
+        style={style}
+      >
+        {label && (
+          <Label theme={theme} htmlFor={`${id}-date`}>
+            {label}
+          </Label>
+        )}
+        <Row theme={theme}>
+          {showDate && (
+            <Field
+              id={`${id}-date`}
+              type="date"
+              value={currentDate}
+              onChange={handleDate}
+              disabled={disabled}
+              theme={theme}
+              $error={error}
+            />
+          )}
+          {showTime && (
+            <TimeWrapper theme={theme}>
+              <TimeNumber
+                type="number"
+                min="0"
+                max="23"
+                value={currentHour}
+                onChange={handleHour}
+                disabled={disabled}
+                theme={theme}
+                $error={error}
+              />
+              <span>:</span>
+              <TimeNumber
+                type="number"
+                min="0"
+                max="59"
+                value={currentMinute}
+                onChange={handleMinute}
+                disabled={disabled}
+                theme={theme}
+                $error={error}
+              />
+              {showSeconds && (
+                <>
+                  <span>:</span>
+                  <TimeNumber
+                    type="number"
+                    min="0"
+                    max="59"
+                    value={currentSecond}
+                    onChange={handleSecond}
+                    disabled={disabled}
+                    theme={theme}
+                    $error={error}
+                  />
+                </>
+              )}
+            </TimeWrapper>
+          )}
+        </Row>
+        {helperText && (
+          <Helper theme={theme} $error={error}>
+            {helperText}
+          </Helper>
+        )}
+      </Wrapper>
+    );
+  },
+);
+
+DateTimePicker.displayName = 'DateTimePicker';
+export default DateTimePicker;
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export * from './components/FormControl';
 export * from './components/Icon';
 export * from './components/IconButton';
 export * from './components/Avatar';
+export * from './components/DateTimePicker';
 export * from './components/Modal';
 export * from './components/Drawer';
 export * from './components/AppBar';


### PR DESCRIPTION
## Summary
- add `DateTimePicker` component for selecting date and/or time
- expose the new component from the library
- create demo page with controlled, uncontrolled and form examples
- wire demo route into docs navigation
- refine the time picker UI for better mouse usage

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6870486144d88320a6b16ab214c5e88f