### PR TITLE
Add ProgressButton component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- ProgressButton component
 
 ## [v0.8.7]
 ### Added

--- a/docs/src/pages/ButtonDemoPage.tsx
+++ b/docs/src/pages/ButtonDemoPage.tsx
@@ -8,12 +8,13 @@ import {
   Box,
   Typography,
   Button,
+  ProgressButton,
   useTheme,
   Tabs,
   Table,
 } from '@archway/valet';
 import type { TableColumn } from '@archway/valet';
-import type { ReactNode } from 'react';
+import { useState, type ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import NavDrawer from '../components/NavDrawer';
 
@@ -74,6 +75,34 @@ export default function ButtonDemoPage() {
       description: 'Apply style presets',
     },
   ];
+
+  const wait = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+  function ProgressDemo() {
+    const [val, setVal] = useState<number | undefined>();
+
+    const runIndet = () => wait(1000);
+
+    const runDet = async () => {
+      for (let v = 0; v <= 100; v += 20) {
+        setVal(v);
+        await wait(180);
+      }
+      setVal(undefined);
+    };
+
+    return (
+      <Stack direction="row" spacing={1}>
+        <ProgressButton onClick={runIndet}>Async</ProgressButton>
+        <ProgressButton
+          onClick={runDet}
+          {...(val !== undefined ? { progress: val } : {})}
+        >
+          Upload
+        </ProgressButton>
+      </Stack>
+    );
+  }
 
   return (
     <Surface>
@@ -156,8 +185,12 @@ export default function ButtonDemoPage() {
           </Button>
         </Stack>
 
-            {/* 9 ▸ Theme toggle (LAST) ------------------------------------- */}
-            <Typography variant="h3">9. Theme toggle</Typography>
+        {/* 9 ▸ ProgressButton ----------------------------------------- */}
+        <Typography variant="h3">9. ProgressButton</Typography>
+        <ProgressDemo />
+
+            {/* 10 ▸ Theme toggle (LAST) ----------------------------------- */}
+            <Typography variant="h3">10. Theme toggle</Typography>
             <Button variant="outlined" onClick={toggleMode}>
               Toggle light / dark mode
             </Button>

--- a/src/components/ProgressButton.tsx
+++ b/src/components/ProgressButton.tsx
@@ -1,0 +1,74 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/ProgressButton.tsx  | valet
+// Button variant that swaps content for a spinner while async
+// ─────────────────────────────────────────────────────────────
+import React, { useState } from 'react';
+import Button, { type ButtonProps, type ButtonSize } from './Button';
+import { Progress, type ProgressSize } from './Progress';
+
+export interface ProgressButtonProps extends ButtonProps {
+  /** Optional controlled progress value (0-100). */
+  progress?: number;
+  /** Spinner size override (defaults to button size). */
+  progressSize?: ProgressSize;
+  /** Spinner colour override (defaults to theme primary). */
+  progressColor?: string;
+  /** Async click handler. Returning a Promise shows progress until resolved. */
+  onClick?: (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => void | Promise<void>;
+}
+
+/*───────────────────────────────────────────────────────────*/
+const sizeMap: Record<ButtonSize, ProgressSize> = {
+  sm: 'sm',
+  md: 'md',
+  lg: 'lg',
+};
+
+export const ProgressButton: React.FC<ProgressButtonProps> = ({
+  progress,
+  progressSize,
+  progressColor,
+  size = 'md',
+  children,
+  onClick,
+  ...rest
+}) => {
+  const [busy, setBusy] = useState(false);
+
+  const handleClick: React.MouseEventHandler<HTMLButtonElement> = async (e) => {
+    if (!onClick) return;
+    const result = onClick(e);
+    if (result && typeof (result as any).then === 'function') {
+      try {
+        setBusy(true);
+        await result;
+      } finally {
+        setBusy(false);
+      }
+    }
+  };
+
+  const show = busy || progress !== undefined;
+  const mode = progress !== undefined ? 'determinate' : 'indeterminate';
+  const pSize = progressSize ?? sizeMap[size];
+
+  return (
+    <Button size={size} onClick={handleClick} {...rest}>
+      {show ? (
+        <Progress
+          variant="circular"
+          mode={mode}
+          value={progress}
+          size={pSize}
+          color={progressColor}
+        />
+      ) : (
+        children
+      )}
+    </Button>
+  );
+};
+
+export default ProgressButton;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export * from './components/List';
 export * from './components/Tree';
 export * from './components/Parallax';
 export * from './components/Progress';
+export * from './components/ProgressButton';
 export * from './components/RadioGroup';
 export * from './components/Slider';
 export * from './components/Snackbar';


### PR DESCRIPTION
## Summary
- add `ProgressButton` component
- document progress button usage in button demo
- expose new component in index
- note new component in changelog

## Testing
- `npm run build`
- `(cd docs && npm run build)`

------
https://chatgpt.com/codex/tasks/task_e_6871388954408329a2ff8b02248a20aa