### PR TITLE
Add progress-aware button

### DIFF
--- a/docs/src/pages/ButtonDemoPage.tsx
+++ b/docs/src/pages/ButtonDemoPage.tsx
@@ -8,6 +8,7 @@ import {
   Box,
   Typography,
   Button,
+  ProgressButton,
   useTheme,
   Tabs,
   Table,
@@ -156,8 +157,29 @@ export default function ButtonDemoPage() {
           </Button>
         </Stack>
 
-            {/* 9 ▸ Theme toggle (LAST) ------------------------------------- */}
-            <Typography variant="h3">9. Theme toggle</Typography>
+        {/* 9 ▸ Progress button ----------------------------------------- */}
+        <Typography variant="h3">9. Progress button</Typography>
+        <Stack direction="row" spacing={1}>
+          <ProgressButton onClick={() => new Promise((r) => setTimeout(r, 1500))}>
+            Async
+          </ProgressButton>
+          <ProgressButton
+            variant="outlined"
+            size="sm"
+            onClick={() => new Promise((r) => setTimeout(r, 1500))}
+          >
+            Outlined
+          </ProgressButton>
+          <ProgressButton
+            color="secondary"
+            size="lg"
+            onClick={() => new Promise((r) => setTimeout(r, 1500))}
+          >
+            Large
+          </ProgressButton>
+        </Stack>
+            {/* 10 ▸ Theme toggle (LAST) ------------------------------------ */}
+            <Typography variant="h3">10. Theme toggle</Typography>
             <Button variant="outlined" onClick={toggleMode}>
               Toggle light / dark mode
             </Button>

--- a/src/components/ProgressButton.tsx
+++ b/src/components/ProgressButton.tsx
@@ -1,0 +1,63 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/ProgressButton.tsx  | valet
+// button with built-in progress indicator
+// ─────────────────────────────────────────────────────────────
+import React, { useEffect, useState } from 'react';
+import Button, { type ButtonProps, ButtonSize } from './Button';
+import { Progress, type ProgressMode, type ProgressSize } from './Progress';
+
+export interface ProgressButtonProps extends ButtonProps {
+  loading?: boolean;
+  mode?: ProgressMode;
+  value?: number;
+}
+
+export const ProgressButton: React.FC<ProgressButtonProps> = ({
+  loading: loadingProp,
+  mode = 'indeterminate',
+  value = 0,
+  size = 'md',
+  onClick,
+  children,
+  disabled,
+  ...rest
+}) => {
+  const [internal, setInternal] = useState(false);
+  const controlled = loadingProp !== undefined;
+  const loading = controlled ? loadingProp : internal;
+
+  useEffect(() => {
+    if (controlled) setInternal(!!loadingProp);
+  }, [loadingProp, controlled]);
+
+  const handleClick = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    const res = onClick?.(e);
+    if (res && typeof (res as any).then === 'function') {
+      if (!controlled) setInternal(true);
+      try {
+        await res;
+      } finally {
+        if (!controlled) setInternal(false);
+      }
+    }
+  };
+
+  const progressSize: ProgressSize = size as ProgressSize;
+
+  return (
+    <Button
+      {...rest}
+      size={size as ButtonSize}
+      onClick={handleClick}
+      disabled={loading || disabled}
+    >
+      {loading ? (
+        <Progress variant="circular" mode={mode} value={value} size={progressSize} />
+      ) : (
+        children
+      )}
+    </Button>
+  );
+};
+
+export default ProgressButton;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export * from './components/List';
 export * from './components/Tree';
 export * from './components/Parallax';
 export * from './components/Progress';
+export * from './components/ProgressButton';
 export * from './components/RadioGroup';
 export * from './components/Slider';
 export * from './components/Snackbar';


### PR DESCRIPTION
## Summary
- add `ProgressButton` component for showing progress while async actions run
- export the component
- showcase `ProgressButton` in the button demo

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6871388954408329a2ff8b02248a20aa