### PR TITLE
Add ProgressButton component

### DIFF
--- a/docs/src/pages/ButtonDemoPage.tsx
+++ b/docs/src/pages/ButtonDemoPage.tsx
@@ -8,6 +8,7 @@ import {
   Box,
   Typography,
   Button,
+  ProgressButton,
   useTheme,
   Tabs,
   Table,
@@ -156,11 +157,26 @@ export default function ButtonDemoPage() {
           </Button>
         </Stack>
 
-            {/* 9 ▸ Theme toggle (LAST) ------------------------------------- */}
-            <Typography variant="h3">9. Theme toggle</Typography>
-            <Button variant="outlined" onClick={toggleMode}>
-              Toggle light / dark mode
-            </Button>
+        {/* 9 ▸ Progress buttons ---------------------------------------- */}
+        <Typography variant="h3">9. Progress buttons</Typography>
+        <Stack direction="row" spacing={1}>
+          <ProgressButton onClick={() => new Promise(r => setTimeout(r, 1500))}>
+            Save
+          </ProgressButton>
+          <ProgressButton
+            variant="outlined"
+            progressMode="determinate"
+            value={60}
+            onClick={() => new Promise(r => setTimeout(r, 1500))}
+          >
+            Upload
+          </ProgressButton>
+        </Stack>
+        {/* 10 ▸ Theme toggle (LAST) ------------------------------------ */}
+        <Typography variant="h3">10. Theme toggle</Typography>
+        <Button variant="outlined" onClick={toggleMode}>
+          Toggle light / dark mode
+        </Button>
           </Tabs.Panel>
 
           <Tabs.Tab label="Reference" />

--- a/src/components/ProgressButton.tsx
+++ b/src/components/ProgressButton.tsx
@@ -1,0 +1,74 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/ProgressButton.tsx | valet
+// Button with built-in loading state via <Progress/>
+// ─────────────────────────────────────────────────────────────
+import React, { useState } from 'react';
+import Button, { type ButtonProps, type ButtonSize } from './Button';
+import { Progress } from './Progress';
+import type { ProgressMode, ProgressSize } from './Progress';
+
+export interface ProgressButtonProps extends ButtonProps {
+  /** Controlled loading state. If undefined, state is derived from async onClick */
+  loading?: boolean;
+  /** Progress mode; defaults to "indeterminate" */
+  progressMode?: ProgressMode;
+  /** Progress value for determinate mode */
+  value?: number;
+  /** Explicit progress size override */
+  progressSize?: ProgressSize;
+}
+
+const sizeMap: Record<ButtonSize, ProgressSize> = {
+  sm: 'sm',
+  md: 'md',
+  lg: 'lg',
+};
+
+export const ProgressButton: React.FC<ProgressButtonProps> = ({
+  loading,
+  progressMode = 'indeterminate',
+  value = 0,
+  progressSize,
+  onClick,
+  size = 'md',
+  disabled,
+  children,
+  ...rest
+}) => {
+  const [selfLoading, setSelfLoading] = useState(false);
+
+  const isLoading = loading ?? selfLoading;
+
+  const handleClick: React.MouseEventHandler<HTMLButtonElement> = (e) => {
+    const result = onClick?.(e);
+    if (loading === undefined && result && typeof (result as any).then === 'function') {
+      setSelfLoading(true);
+      (result as Promise<unknown>).finally(() => setSelfLoading(false));
+    }
+  };
+
+  const pSize = progressSize ?? sizeMap[size];
+
+  return (
+    <Button
+      {...rest}
+      size={size}
+      disabled={disabled || isLoading}
+      onClick={handleClick}
+    >
+      {isLoading ? (
+        <Progress
+          variant="circular"
+          mode={progressMode}
+          value={value}
+          size={pSize}
+          color="currentColor"
+        />
+      ) : (
+        children
+      )}
+    </Button>
+  );
+};
+
+export default ProgressButton;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export * from './components/List';
 export * from './components/Tree';
 export * from './components/Parallax';
 export * from './components/Progress';
+export * from './components/ProgressButton';
 export * from './components/RadioGroup';
 export * from './components/Slider';
 export * from './components/Snackbar';


### PR DESCRIPTION
## Summary
- add `ProgressButton` component for loading states
- export `ProgressButton` from library entry
- showcase progress buttons in docs Button demo

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6871388954408329a2ff8b02248a20aa