### PR TITLE
Add ProgressButton

### DIFF
--- a/docs/src/pages/ButtonDemoPage.tsx
+++ b/docs/src/pages/ButtonDemoPage.tsx
@@ -8,10 +8,12 @@ import {
   Box,
   Typography,
   Button,
+  ProgressButton,
   useTheme,
   Tabs,
   Table,
 } from '@archway/valet';
+import { useState } from 'react';
 import type { TableColumn } from '@archway/valet';
 import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -21,6 +23,7 @@ import NavDrawer from '../components/NavDrawer';
 export default function ButtonDemoPage() {
   const { theme, toggleMode } = useTheme();
   const navigate = useNavigate();
+  const [progress, setProgress] = useState<number | undefined>();
 
   interface Row {
     prop: ReactNode;
@@ -74,6 +77,22 @@ export default function ButtonDemoPage() {
       description: 'Apply style presets',
     },
   ];
+
+  const trigger = () => {
+    setProgress(undefined);
+    return new Promise<void>((resolve) => {
+      let pct = 0;
+      const id = setInterval(() => {
+        pct += 20;
+        setProgress(pct);
+        if (pct >= 100) {
+          clearInterval(id);
+          setTimeout(() => setProgress(undefined), 200);
+          resolve();
+        }
+      }, 200);
+    });
+  };
 
   return (
     <Surface>
@@ -156,8 +175,22 @@ export default function ButtonDemoPage() {
           </Button>
         </Stack>
 
-            {/* 9 ▸ Theme toggle (LAST) ------------------------------------- */}
-            <Typography variant="h3">9. Theme toggle</Typography>
+        {/* 9 ▸ ProgressButton ----------------------------------------- */}
+        <Typography variant="h3">9. ProgressButton</Typography>
+        <Stack direction="row" spacing={1}>
+          <ProgressButton action={() => new Promise((r) => setTimeout(r, 1200))}>
+            Indeterminate
+          </ProgressButton>
+          <ProgressButton
+            {...(progress !== undefined ? { progress } : {})}
+            action={trigger}
+          >
+            Determinate
+          </ProgressButton>
+        </Stack>
+
+            {/* 10 ▸ Theme toggle (LAST) ------------------------------------ */}
+            <Typography variant="h3">10. Theme toggle</Typography>
             <Button variant="outlined" onClick={toggleMode}>
               Toggle light / dark mode
             </Button>

--- a/src/components/ProgressButton.tsx
+++ b/src/components/ProgressButton.tsx
@@ -1,0 +1,82 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/ProgressButton.tsx  | valet
+// button with built-in progress indicator
+// ─────────────────────────────────────────────────────────────
+import React, { useEffect, useState } from 'react';
+import { Progress } from './Progress';
+import { Button, type ButtonProps, type ButtonSize } from './Button';
+
+export interface ProgressButtonProps extends ButtonProps {
+  /** Async action executed on click before normal onClick */
+  action?: () => Promise<unknown>;
+  /** 0-100 value for determinate progress */
+  progress?: number;
+}
+
+export const ProgressButton: React.FC<ProgressButtonProps> = ({
+  action,
+  progress,
+  children,
+  onClick,
+  size = 'md',
+  disabled,
+  ...rest
+}) => {
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (progress !== undefined && progress >= 100) setLoading(false);
+  }, [progress]);
+
+  const handleClick = async (
+    e: React.MouseEvent<HTMLButtonElement, MouseEvent>,
+  ) => {
+    if (loading) return;
+    if (action) {
+      e.preventDefault();
+      try {
+        setLoading(true);
+        await action();
+      } finally {
+        setLoading(false);
+        onClick?.(e);
+      }
+      return;
+    }
+    const res = onClick?.(e);
+    if (res && typeof (res as any).then === 'function') {
+      try {
+        setLoading(true);
+        await res;
+      } finally {
+        setLoading(false);
+      }
+    }
+  };
+
+  const mode = progress === undefined ? 'indeterminate' : 'determinate';
+  const map: Record<ButtonSize, ButtonSize> = { sm: 'sm', md: 'md', lg: 'lg' };
+
+  return (
+    <Button
+      {...rest}
+      size={size}
+      disabled={disabled || loading}
+      onClick={handleClick}
+    >
+      {loading ? (
+        <Progress
+          variant="circular"
+          mode={mode}
+          value={progress}
+          size={map[size]}
+          color="currentColor"
+        />
+      ) : (
+        children
+      )}
+    </Button>
+  );
+};
+
+export default ProgressButton;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ export * from './components/List';
 export * from './components/Tree';
 export * from './components/Parallax';
 export * from './components/Progress';
+export * from './components/ProgressButton';
 export * from './components/RadioGroup';
 export * from './components/Slider';
 export * from './components/Snackbar';


### PR DESCRIPTION
## Summary
- add ProgressButton with async progress feedback
- demo ProgressButton in the docs

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6871388954408329a2ff8b02248a20aa