### PR TITLE
Improve surface state hook

### DIFF
--- a/src/components/Accordion.tsx
+++ b/src/components/Accordion.tsx
@@ -23,6 +23,7 @@ import { useTheme }             from '../system/themeStore';
 import { preset }               from '../css/stylePresets';
 import { toRgb, mix, toHex }    from '../helpers/color';
 import { useSurface }           from '../system/surfaceStore';
+import { shallow }              from 'zustand/shallow';
 import type { Presettable }     from '../types';
 
 /*───────────────────────────────────────────────────────────*/
@@ -172,7 +173,15 @@ export const Accordion: React.FC<AccordionProps> & {
   ...divProps
 }) => {
   const { theme } = useTheme();
-  const surface = useSurface();
+  const surface = useSurface(
+    s => ({
+      element: s.element,
+      height: s.height,
+      registerChild: s.registerChild,
+      unregisterChild: s.unregisterChild,
+    }),
+    shallow,
+  );
   const wrapRef = useRef<HTMLDivElement>(null);
   const uniqueId = useId();
   const [maxHeight, setMaxHeight] = useState<number>();

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -12,6 +12,7 @@ import React, {
 import { styled } from '../css/createStyled';
 import { useTheme } from '../system/themeStore';
 import { useSurface } from '../system/surfaceStore';
+import { shallow } from 'zustand/shallow';
 import { preset } from '../css/stylePresets';
 import IconButton from './IconButton';
 import TextField from './TextField';
@@ -91,7 +92,15 @@ export const Chat: React.FC<ChatProps> = ({
   ...rest
 }) => {
   const { theme } = useTheme();
-  const surface = useSurface();
+  const surface = useSurface(
+    s => ({
+      element: s.element,
+      height: s.height,
+      registerChild: s.registerChild,
+      unregisterChild: s.unregisterChild,
+    }),
+    shallow,
+  );
   const wrapRef = useRef<HTMLDivElement>(null);
   const uniqueId = useId();
   const [maxHeight, setMaxHeight] = useState<number>();

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -9,6 +9,7 @@ import { createPortal } from 'react-dom';
 import { styled } from '../css/createStyled';
 import { useTheme } from '../system/themeStore';
 import { useSurface } from '../system/surfaceStore';
+import { shallow } from 'zustand/shallow';
 import { preset } from '../css/stylePresets';
 import type { Presettable } from '../types';
 import { IconButton } from './IconButton';
@@ -130,10 +131,11 @@ export const Drawer: React.FC<DrawerProps> = ({
   preset: presetKey,
 }) => {
   const { theme } = useTheme();
-  const surface = useSurface();
+  const { width, height, element } = useSurface(
+    s => ({ width: s.width, height: s.height, element: s.element }),
+    shallow,
+  );
   const presetClasses = presetKey ? preset(presetKey) : '';
-
-  const { width, height } = surface;
   const portrait = height > width;
   const responsiveMode = responsive && (anchor === 'left' || anchor === 'right');
   const orientationPersistent = responsiveMode && !portrait;
@@ -183,7 +185,7 @@ export const Drawer: React.FC<DrawerProps> = ({
 
   // When persistent, offset the current surface so content isn't hidden
   useLayoutEffect(() => {
-    const node = surface.element;
+    const node = element;
     if (!node) return;
     const horizontal = anchor === 'left' || anchor === 'right';
     if (persistentEffective && horizontal) {
@@ -196,7 +198,7 @@ export const Drawer: React.FC<DrawerProps> = ({
       };
     }
     return;
-  }, [surface.element, persistentEffective, anchor, size]);
+  }, [element, persistentEffective, anchor, size]);
 
   if (!open && !persistentEffective) {
     if (responsiveMode && portrait) {

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -21,6 +21,7 @@ import React, {
 import { styled }               from '../css/createStyled';
 import { useTheme }             from '../system/themeStore';
 import { useSurface }           from '../system/surfaceStore';
+import { shallow }              from 'zustand/shallow';
 import { preset }               from '../css/stylePresets';
 import { Typography }           from './Typography';
 import type { Presettable }     from '../types';
@@ -101,7 +102,13 @@ export const Snackbar: React.FC<SnackbarProps> = ({
   ...rest
 }) => {
   const { theme } = useTheme();
-  const surface   = useSurface();
+  const surface   = useSurface(
+    s => ({
+      registerChild: s.registerChild,
+      unregisterChild: s.unregisterChild,
+    }),
+    shallow,
+  );
   const ref       = useRef<HTMLDivElement>(null);
   const id        = useId();
 

--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -13,6 +13,7 @@ import React, {
 import { styled }                 from '../css/createStyled';
 import { useTheme }               from '../system/themeStore';
 import { useSurface }             from '../system/surfaceStore';
+import { shallow }                from 'zustand/shallow';
 import { preset }                 from '../css/stylePresets';
 import { Checkbox }               from './Checkbox';
 import { stripe, toRgb, mix, toHex } from '../helpers/color';
@@ -133,7 +134,15 @@ export function Table<T extends object>({
   ...rest
 }:TableProps<T>) {
   const { theme } = useTheme();
-  const surface = useSurface();
+  const surface = useSurface(
+    s => ({
+      element: s.element,
+      height: s.height,
+      registerChild: s.registerChild,
+      unregisterChild: s.unregisterChild,
+    }),
+    shallow,
+  );
   const wrapRef = useRef<HTMLDivElement>(null);
   const uniqueId = useId();
   const [maxHeight, setMaxHeight] = useState<number>();

--- a/src/components/Typography.tsx
+++ b/src/components/Typography.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { styled } from '../css/createStyled';
 import { useTheme } from '../system/themeStore';
 import { useSurface } from '../system/surfaceStore';
+import { shallow } from 'zustand/shallow';
 import { preset } from '../css/stylePresets';
 import type { Presettable } from '../types';
 
@@ -53,7 +54,7 @@ export const Typography: React.FC<TypographyProps> = ({
 }) => {
   const Tag = mapping[variant];
   const { theme } = useTheme();
-  const { breakpoint } = useSurface();
+  const breakpoint = useSurface(s => s.breakpoint, shallow);
 
   const defaultSize = theme.typography[variant].md;
   let size = autoSize ? theme.typography[variant][breakpoint] : defaultSize;

--- a/src/system/surfaceStore.ts
+++ b/src/system/surfaceStore.ts
@@ -107,9 +107,18 @@ export type SurfaceStore = ReturnType<typeof createSurfaceStore>
 
 export const SurfaceCtx = React.createContext<SurfaceStore | null>(null)
 
-export const useSurface = () => {
+export function useSurface(): SurfaceState
+export function useSurface<U>(
+  selector: (state: SurfaceState) => U,
+  equality?: (a: U, b: U) => boolean,
+): U
+export function useSurface<U>(
+  selector?: (state: SurfaceState) => U,
+  equality?: (a: U, b: U) => boolean,
+): U | SurfaceState {
   const store = React.useContext(SurfaceCtx)
   if (!store)
     throw new Error('useSurface must be used within a <Surface> component')
-  return store()
+  const sel = selector ?? ((s) => s as unknown as U)
+  return store(sel as any, equality as any)
 }


### PR DESCRIPTION
## Summary
- refine surface store usage to prevent re-renders
- apply new selector form of `useSurface` across components
- update Drawer responsive logic

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687150a3f08c8320a967a5b1c8f45d33