### PR TITLE
Refactor component folders and update docs nav

### DIFF
--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -15,38 +15,47 @@ interface Item {
   path?: string;
 }
 
-const components: [string, string][] = [
-  ['Accordion', '/accordion-demo'],
-  ['Avatar', '/avatar-demo'],
+const primitives: [string, string][] = [
   ['Box', '/box-demo'],
+  ['Typography', '/typography'],
+  ['Icon', '/icon-demo'],
+  ['Panel', '/panel-demo'],
+];
+
+const layoutPrimitives: [string, string][] = [
+  ['Grid', '/grid-demo'],
+];
+
+const fields: [string, string][] = [
   ['Button', '/button-demo'],
   ['Checkbox', '/checkbox-demo'],
-  ['Chat', '/chat-demo'],
-  ['Drawer', '/drawer-demo'],
-  ['DateTime Picker', '/datetime-demo'],
-  ['FormControl + Textfield', '/text-form-demo'],
-  ['Grid', '/grid-demo'],
-  ['Icon', '/icon-demo'],
-  ['Icon Button', '/icon-button-demo'],
-  ['List', '/list-demo'],
-  ['Modal', '/modal-demo'],
-  ['Pagination', '/pagination-demo'],
-  ['Panel', '/panel-demo'],
-  ['Progress', '/progress-demo'],
+  ['Switch', '/switch-demo'],
   ['Radio Group', '/radio-demo'],
   ['Slider', '/slider-demo'],
+  ['FormControl + Textfield', '/text-form-demo'],
   ['Select', '/select-demo'],
-  ['Snackbar', '/snackbar-demo'],
-  ['Switch', '/switch-demo'],
-  ['Table', '/table-demo'],
+];
+
+const widgets: [string, string][] = [
+  ['Accordion', '/accordion-demo'],
   ['Tabs', '/tabs-demo'],
+  ['Drawer', '/drawer-demo'],
+  ['Modal', '/modal-demo'],
+  ['Stepper', '/stepper-demo'],
+  ['Speed Dial', '/speeddial-demo'],
+  ['Pagination', '/pagination-demo'],
+  ['Table', '/table-demo'],
+  ['Video', '/video-demo'],
+  ['Avatar', '/avatar-demo'],
+  ['Chat', '/chat-demo'],
+  ['DateTime Picker', '/datetime-demo'],
+  ['Icon Button', '/icon-button-demo'],
+  ['List', '/list-demo'],
+  ['Progress', '/progress-demo'],
+  ['Snackbar', '/snackbar-demo'],
   ['Tooltip', '/tooltip-demo'],
   ['Tree', '/tree-demo'],
-  ['Typography', '/typography'],
-  ['Video', '/video-demo'],
   ['AppBar', '/appbar-demo'],
-  ['Speed Dial', '/speeddial-demo'],
-  ['Stepper', '/stepper-demo'],
 ];
 
 const demos: [string, string][] = [
@@ -73,10 +82,28 @@ const treeData: TreeNode<Item>[] = [
   {
     id: 'components',
     data: { label: 'Components' },
-    children: components.map(([label, path]) => ({
-      id: path,
-      data: { label, path },
-    })),
+    children: [
+      {
+        id: 'primitives',
+        data: { label: 'Primitives' },
+        children: primitives.map(([label, path]) => ({ id: path, data: { label, path } })),
+      },
+      {
+        id: 'layout-primitives',
+        data: { label: 'Layout Primitives' },
+        children: layoutPrimitives.map(([label, path]) => ({ id: path, data: { label, path } })),
+      },
+      {
+        id: 'fields',
+        data: { label: 'Fields' },
+        children: fields.map(([label, path]) => ({ id: path, data: { label, path } })),
+      },
+      {
+        id: 'widgets',
+        data: { label: 'Widgets' },
+        children: widgets.map(([label, path]) => ({ id: path, data: { label, path } })),
+      },
+    ],
   },
   {
     id: 'demos',
@@ -99,7 +126,7 @@ export default function NavDrawer() {
         getLabel={(n) => n.label}
         variant="list"
         selected={location.pathname}
-        defaultExpanded={['getting-started', 'components', 'demos']}
+        defaultExpanded={['getting-started', 'components', 'primitives', 'layout-primitives', 'fields', 'widgets', 'demos']}
         onNodeSelect={(n) => n.path && navigate(n.path)}
         style={{ padding: theme.spacing(1) }}
       />

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -15,12 +15,12 @@ import { useSurface } from '../system/surfaceStore';
 import { shallow } from 'zustand/shallow';
 import { preset } from '../css/stylePresets';
 import IconButton from './IconButton';
-import TextField from './TextField';
-import Panel from './Panel';
-import Typography from './Typography';
+import TextField from './fields/TextField';
+import Panel from './primitives/Panel';
+import Typography from './primitives/Typography';
 import Avatar from './Avatar';
 import type { Presettable } from '../types';
-import Stack from './Stack';
+import Stack from './layout/Stack';
 
 /*───────────────────────────────────────────────────────────*/
 /* Types                                                      */

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -8,7 +8,7 @@ import { useTheme }            from '../system/themeStore';
 import type { Theme }          from '../system/themeStore';
 import { preset }              from '../css/stylePresets';
 import type { Presettable }    from '../types';
-import { Icon }                from './Icon';
+import { Icon }                from './primitives/Icon';
 
 /*───────────────────────────────────────────────────────────*/
 /* Public API                                                */

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -7,7 +7,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import { styled }                 from '../css/createStyled';
 import { useTheme }               from '../system/themeStore';
 import { preset }                 from '../css/stylePresets';
-import { Typography }             from './Typography';
+import { Typography }             from './primitives/Typography';
 import { stripe, toRgb, mix, toHex } from '../helpers/color';
 import type { Presettable }       from '../types';
 

--- a/src/components/Snackbar.tsx
+++ b/src/components/Snackbar.tsx
@@ -23,7 +23,7 @@ import { useTheme }             from '../system/themeStore';
 import { useSurface }           from '../system/surfaceStore';
 import { shallow }              from 'zustand/shallow';
 import { preset }               from '../css/stylePresets';
-import { Typography }           from './Typography';
+import { Typography }           from './primitives/Typography';
 import type { Presettable }     from '../types';
 
 /*───────────────────────────────────────────────────────────*/

--- a/src/components/Tree.tsx
+++ b/src/components/Tree.tsx
@@ -3,7 +3,7 @@
 // Basic accessible tree view component
 // ─────────────────────────────────────────────────────────────
 import React, { useMemo, useState, useRef, KeyboardEvent } from 'react';
-import Icon from './Icon';
+import Icon from './primitives/Icon';
 import { styled } from '../css/createStyled';
 import { useTheme } from '../system/themeStore';
 import { preset } from '../css/stylePresets';

--- a/src/components/fields/Button.tsx
+++ b/src/components/fields/Button.tsx
@@ -1,14 +1,14 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/Button.tsx | valet
+// src/components/fields/Button.tsx | valet
 // Theme-aware <Button /> – automatic Typography wrapping
 // ─────────────────────────────────────────────────────────────
 import React from 'react';
-import { styled }           from '../css/createStyled';
-import { useTheme }         from '../system/themeStore';
-import type { Theme }       from '../system/themeStore';
-import { preset }           from '../css/stylePresets';
-import { Typography }       from './Typography';
-import type { Presettable } from '../types';
+import { styled }           from '../../css/createStyled';
+import { useTheme }         from '../../system/themeStore';
+import type { Theme }       from '../../system/themeStore';
+import { preset }           from '../../css/stylePresets';
+import { Typography }       from '../primitives/Typography';
+import type { Presettable } from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
 export type ButtonVariant = 'contained' | 'outlined';

--- a/src/components/fields/Checkbox.tsx
+++ b/src/components/fields/Checkbox.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────────────────────
-// src/components/Checkbox.tsx | valet
+// src/components/fields/Checkbox.tsx | valet
 // Theme-aware, accessible Checkbox – consistent outline, no blue flash,
 // greyed-out disabled styling (Accordion-style).
 // ─────────────────────────────────────────────────────────────────────────────
@@ -11,13 +11,13 @@ import React, {
   ChangeEvent,
   ReactNode,
 } from 'react';
-import { styled }         from '../css/createStyled';
-import { useTheme }       from '../system/themeStore';
-import { preset }         from '../css/stylePresets';
-import { useForm }        from './FormControl';
-import { toRgb, mix, toHex } from '../helpers/color';
-import type { Theme }     from '../system/themeStore';
-import type { Presettable } from '../types';
+import { styled }         from '../../css/createStyled';
+import { useTheme }       from '../../system/themeStore';
+import { preset }         from '../../css/stylePresets';
+import { useForm }        from '../FormControl';
+import { toRgb, mix, toHex } from '../../helpers/color';
+import type { Theme }     from '../../system/themeStore';
+import type { Presettable } from '../../types';
 
 /*───────────────────────────────────────────────────────────────────────────*/
 /* Public prop contracts                                                    */

--- a/src/components/fields/RadioGroup.tsx
+++ b/src/components/fields/RadioGroup.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/RadioGroup.tsx | valet
+// src/components/fields/RadioGroup.tsx | valet
 // Theme-aware radio groups with keyboard nav & refined spacing
 // • Disabled state now mirrors Accordion / Checkbox colour recipe
 // • Inner (radio–label) gap tight; vertical option gap = theme.spacing(1.5)
@@ -16,12 +16,12 @@ import React, {
   KeyboardEvent,
   createContext,
 } from 'react';
-import { styled }           from '../css/createStyled';
-import { preset }           from '../css/stylePresets';
-import { useTheme }         from '../system/themeStore';
-import { toRgb, mix, toHex } from '../helpers/color';
-import type { Theme }       from '../system/themeStore';
-import type { Presettable } from '../types';
+import { styled }           from '../../css/createStyled';
+import { preset }           from '../../css/stylePresets';
+import { useTheme }         from '../../system/themeStore';
+import { toRgb, mix, toHex } from '../../helpers/color';
+import type { Theme }       from '../../system/themeStore';
+import type { Presettable } from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
 /* Context                                                   */

--- a/src/components/fields/Select.tsx
+++ b/src/components/fields/Select.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/Select.tsx | valet
+// src/components/fields/Select.tsx | valet
 // Fully-typed, FormControl-aware <Select/> (single + multiple).
 // © 2025 Off-Court Creations – MIT licence
 // ─────────────────────────────────────────────────────────────
@@ -12,12 +12,12 @@ import React, {
     useRef,
     useState,
   }                               from 'react';
-  import { styled }               from '../css/createStyled';
-  import { useTheme }             from '../system/themeStore';
-  import { preset }               from '../css/stylePresets';
-  import { useForm }              from './FormControl';
-  import type { Presettable }     from '../types';
-  import type { Theme }           from '../system/themeStore';
+  import { styled }               from '../../css/createStyled';
+  import { useTheme }             from '../../system/themeStore';
+  import { preset }               from '../../css/stylePresets';
+  import { useForm }              from '../FormControl';
+  import type { Presettable }     from '../../types';
+  import type { Theme }           from '../../system/themeStore';
   
   type Primitive = string | number;
   

--- a/src/components/fields/Slider.tsx
+++ b/src/components/fields/Slider.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/Slider.tsx | valet
+// src/components/fields/Slider.tsx | valet
 // Theme-aware, ultra-fast <Slider/> for @archway/valet
 // – Un/controlled, FormControl-aware, preset-friendly
 // – Optional min/max & live value labels, ticks, three snap modes
@@ -17,12 +17,12 @@ import React, {
     KeyboardEvent,
     MutableRefObject,
   } from 'react';
-  import { styled }            from '../css/createStyled';
-  import { useTheme }          from '../system/themeStore';
-  import { preset }            from '../css/stylePresets';
-  import { useForm }           from './FormControl';
-  import type { Theme }        from '../system/themeStore';
-  import type { Presettable }  from '../types';
+  import { styled }            from '../../css/createStyled';
+  import { useTheme }          from '../../system/themeStore';
+  import { preset }            from '../../css/stylePresets';
+  import { useForm }           from '../FormControl';
+  import type { Theme }        from '../../system/themeStore';
+  import type { Presettable }  from '../../types';
   
   /*───────────────────────────────────────────────────────────*/
   /* Size map                                                  */

--- a/src/components/fields/Switch.tsx
+++ b/src/components/fields/Switch.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/Switch.tsx | valet
+// src/components/fields/Switch.tsx | valet
 // Theme-aware, accessible boolean <Switch /> component
 // – Un / controlled, FormControl-aware, preset-friendly
 // ─────────────────────────────────────────────────────────────
@@ -10,12 +10,12 @@ import React, {
     useState,
     MouseEventHandler,
   } from 'react';
-  import { styled }             from '../css/createStyled';
-  import { useTheme }           from '../system/themeStore';
-  import { preset }             from '../css/stylePresets';
-  import { useForm }            from './FormControl';
-  import type { Theme }         from '../system/themeStore';
-  import type { Presettable }   from '../types';
+  import { styled }             from '../../css/createStyled';
+  import { useTheme }           from '../../system/themeStore';
+  import { preset }             from '../../css/stylePresets';
+  import { useForm }            from '../FormControl';
+  import type { Theme }         from '../../system/themeStore';
+  import type { Presettable }   from '../../types';
   
   /*───────────────────────────────────────────────────────────*/
   /* Size map helper                                           */

--- a/src/components/fields/TextField.tsx
+++ b/src/components/fields/TextField.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/TextField.tsx  | valet
+// src/components/fields/TextField.tsx  | valet
 // controlled text input integrating with FormControl
 // ─────────────────────────────────────────────────────────────
 import React, {
@@ -9,12 +9,12 @@ import React, {
   InputHTMLAttributes,
   TextareaHTMLAttributes,
 } from 'react';
-import { styled } from '../css/createStyled';
-import { useTheme } from '../system/themeStore';
-import { preset } from '../css/stylePresets';
-import { useForm } from './FormControl';
-import type { Theme } from '../system/themeStore';
-import type { Presettable } from '../types';
+import { styled } from '../../css/createStyled';
+import { useTheme } from '../../system/themeStore';
+import { preset } from '../../css/stylePresets';
+import { useForm } from '../FormControl';
+import type { Theme } from '../../system/themeStore';
+import type { Presettable } from '../../types';
 
 /*───────────────────────────────────────────────────────────────────────────*/
 /* Prop contracts                                                            */

--- a/src/components/layout/Grid.tsx
+++ b/src/components/layout/Grid.tsx
@@ -1,12 +1,12 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/Grid.tsx  | valet
+// src/components/layout/Grid.tsx  | valet
 // simple css grid container
 // ─────────────────────────────────────────────────────────────
 import React from 'react';
-import { styled } from '../css/createStyled';
-import { preset } from '../css/stylePresets';
-import { useTheme } from '../system/themeStore';
-import type { Presettable } from '../types';
+import { styled } from '../../css/createStyled';
+import { preset } from '../../css/stylePresets';
+import { useTheme } from '../../system/themeStore';
+import type { Presettable } from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
 export interface GridProps

--- a/src/components/layout/Stack.tsx
+++ b/src/components/layout/Stack.tsx
@@ -1,12 +1,12 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/Stack.tsx  | valet
+// src/components/layout/Stack.tsx  | valet
 // strict‑optional safe typings
 // ─────────────────────────────────────────────────────────────
 import React from 'react';
-import { styled }            from '../css/createStyled';
-import { useTheme }   from '../system/themeStore';
-import { preset }            from '../css/stylePresets';
-import type { Presettable }  from '../types';
+import { styled }            from '../../css/createStyled';
+import { useTheme }   from '../../system/themeStore';
+import { preset }            from '../../css/stylePresets';
+import type { Presettable }  from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
 /* Public props                                              */

--- a/src/components/layout/Surface.tsx
+++ b/src/components/layout/Surface.tsx
@@ -1,18 +1,18 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/Surface.tsx  | valet
+// src/components/layout/Surface.tsx  | valet
 // top-level wrapper that applies theme backgrounds and breakpoints
 // ─────────────────────────────────────────────────────────────
 import React, { useContext, useEffect, useRef, useState } from 'react';
-import { Breakpoint, useTheme } from '../system/themeStore';
-import { useFonts } from '../system/fontStore';
-import LoadingBackdrop from './LoadingBackdrop';
+import { Breakpoint, useTheme } from '../../system/themeStore';
+import { useFonts } from '../../system/fontStore';
+import LoadingBackdrop from '../LoadingBackdrop';
 import {
   createSurfaceStore,
   SurfaceCtx,
   useSurface as useSurfaceState,
-} from '../system/surfaceStore';
-import { preset } from '../css/stylePresets';
-import type { Presettable } from '../types';
+} from '../../system/surfaceStore';
+import { preset } from '../../css/stylePresets';
+import type { Presettable } from '../../types';
 
 /** Surface Props definition */
 export interface SurfaceProps

--- a/src/components/primitives/Box.tsx
+++ b/src/components/primitives/Box.tsx
@@ -1,12 +1,12 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/Box.tsx  | valet
+// src/components/primitives/Box.tsx  | valet
 // patched for strict optional props
 // ─────────────────────────────────────────────────────────────
 import React from 'react';
-import { styled } from '../css/createStyled';
-import { useTheme } from '../system/themeStore';
-import { preset } from '../css/stylePresets';
-import type { Presettable } from '../types';
+import { styled } from '../../css/createStyled';
+import { useTheme } from '../../system/themeStore';
+import { preset } from '../../css/stylePresets';
+import type { Presettable } from '../../types';
 
 /*───────────────────────────────────────────────────────────────*/
 /* Public props                                                  */

--- a/src/components/primitives/Icon.tsx
+++ b/src/components/primitives/Icon.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/Icon.tsx  | valet
+// src/components/primitives/Icon.tsx  | valet
 // strict‑optional safe typings
 // ─────────────────────────────────────────────────────────────
 import React, {
@@ -8,9 +8,9 @@ import React, {
   PropsWithChildren,
 } from 'react';
 import { Icon as Iconify }     from '@iconify/react';
-import { styled }              from '../css/createStyled';
-import { preset }              from '../css/stylePresets';
-import type { Presettable }    from '../types';
+import { styled }              from '../../css/createStyled';
+import { preset }              from '../../css/stylePresets';
+import type { Presettable }    from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
 /* Public props                                              */

--- a/src/components/primitives/Panel.tsx
+++ b/src/components/primitives/Panel.tsx
@@ -1,12 +1,12 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/Panel.tsx  | valet
+// src/components/primitives/Panel.tsx  | valet
 // strict‑optional safe typings
 // ─────────────────────────────────────────────────────────────
 import React from 'react';
-import { styled }            from '../css/createStyled';
-import { useTheme }          from '../system/themeStore';
-import { preset }            from '../css/stylePresets';
-import type { Presettable }  from '../types';
+import { styled }            from '../../css/createStyled';
+import { useTheme }          from '../../system/themeStore';
+import { preset }            from '../../css/stylePresets';
+import type { Presettable }  from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
 /* Public types                                              */

--- a/src/components/primitives/Typography.tsx
+++ b/src/components/primitives/Typography.tsx
@@ -1,14 +1,14 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/Typography.tsx | valet
+// src/components/primitives/Typography.tsx | valet
 // Semantic text variants with responsive sizes, colour vars
 // ─────────────────────────────────────────────────────────────
 import React from 'react';
-import { styled } from '../css/createStyled';
-import { useTheme } from '../system/themeStore';
-import { useSurface } from '../system/surfaceStore';
+import { styled } from '../../css/createStyled';
+import { useTheme } from '../../system/themeStore';
+import { useSurface } from '../../system/surfaceStore';
 import { shallow } from 'zustand/shallow';
-import { preset } from '../css/stylePresets';
-import type { Presettable } from '../types';
+import { preset } from '../../css/stylePresets';
+import type { Presettable } from '../../types';
 
 export type Variant =
   | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'

--- a/src/components/widgets/Accordion.tsx
+++ b/src/components/widgets/Accordion.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/Accordion.tsx | valet
+// src/components/widgets/Accordion.tsx | valet
 // Fully-typed, theme-aware <Accordion /> component
 // – Composition API (Accordion.Item / .Header / .Content)
 // – Controlled & uncontrolled modes, single- or multi-expand
@@ -18,13 +18,13 @@ import React, {
   useId,
   useEffect,
 } from 'react';
-import { styled }               from '../css/createStyled';
-import { useTheme }             from '../system/themeStore';
-import { preset }               from '../css/stylePresets';
-import { toRgb, mix, toHex }    from '../helpers/color';
-import { useSurface }           from '../system/surfaceStore';
+import { styled }               from '../../css/createStyled';
+import { useTheme }             from '../../system/themeStore';
+import { preset }               from '../../css/stylePresets';
+import { toRgb, mix, toHex }    from '../../helpers/color';
+import { useSurface }           from '../../system/surfaceStore';
 import { shallow }              from 'zustand/shallow';
-import type { Presettable }     from '../types';
+import type { Presettable }     from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
 /* Context                                                   */

--- a/src/components/widgets/Drawer.tsx
+++ b/src/components/widgets/Drawer.tsx
@@ -1,18 +1,18 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/Drawer.tsx  | valet
+// src/components/widgets/Drawer.tsx  | valet
 // Minimal sliding drawer component akin to MUI's Drawer.
 // Controlled/uncontrolled, with backdrop and escape handling.
 // ─────────────────────────────────────────────────────────────
 
 import React, { useCallback, useLayoutEffect, useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { styled } from '../css/createStyled';
-import { useTheme } from '../system/themeStore';
-import { useSurface } from '../system/surfaceStore';
+import { styled } from '../../css/createStyled';
+import { useTheme } from '../../system/themeStore';
+import { useSurface } from '../../system/surfaceStore';
 import { shallow } from 'zustand/shallow';
-import { preset } from '../css/stylePresets';
-import type { Presettable } from '../types';
-import { IconButton } from './IconButton';
+import { preset } from '../../css/stylePresets';
+import type { Presettable } from '../../types';
+import { IconButton } from '../IconButton';
 
 /*───────────────────────────────────────────────────────────*/
 export type DrawerAnchor = 'left' | 'right' | 'top' | 'bottom';

--- a/src/components/widgets/Modal.tsx
+++ b/src/components/widgets/Modal.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/Modal.tsx | valet
+// src/components/widgets/Modal.tsx | valet
 // Accessible, theme‑aware Modal component that supports both “dialog” and
 // “alert” semantics. Fully controlled/uncontrolled, focus‑trapping, backdrop &
 // ESC/Click dismissal, no external deps.
@@ -14,10 +14,10 @@ import React, {
     useState,
   } from 'react';
   import { createPortal } from 'react-dom';
-  import { styled } from '../css/createStyled';
-  import { useTheme } from '../system/themeStore';
-  import { preset } from '../css/stylePresets';
-  import type { Presettable } from '../types';
+  import { styled } from '../../css/createStyled';
+  import { useTheme } from '../../system/themeStore';
+  import { preset } from '../../css/stylePresets';
+  import type { Presettable } from '../../types';
   
   /*───────────────────────────────────────────────────────────*/
   /* Styled primitives                                         */

--- a/src/components/widgets/Pagination.tsx
+++ b/src/components/widgets/Pagination.tsx
@@ -1,12 +1,12 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/Pagination.tsx  | valet
+// src/components/widgets/Pagination.tsx  | valet
 // Tab-style pagination with thick underline for active page
 // ─────────────────────────────────────────────────────────────
 import React from 'react';
-import { styled } from '../css/createStyled';
-import { preset } from '../css/stylePresets';
-import { useTheme } from '../system/themeStore';
-import type { Presettable } from '../types';
+import { styled } from '../../css/createStyled';
+import { preset } from '../../css/stylePresets';
+import { useTheme } from '../../system/themeStore';
+import type { Presettable } from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
 /* Public props                                              */

--- a/src/components/widgets/SpeedDial.tsx
+++ b/src/components/widgets/SpeedDial.tsx
@@ -1,12 +1,12 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/SpeedDial.tsx | valet
+// src/components/widgets/SpeedDial.tsx | valet
 // Floating action button with expandable actions
 // ─────────────────────────────────────────────────────────────
 import React, { useState } from 'react';
-import { styled }          from '../css/createStyled';
-import { preset }          from '../css/stylePresets';
-import { useTheme }        from '../system/themeStore';
-import type { Presettable } from '../types';
+import { styled }          from '../../css/createStyled';
+import { preset }          from '../../css/stylePresets';
+import { useTheme }        from '../../system/themeStore';
+import type { Presettable } from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
 export interface SpeedDialAction {

--- a/src/components/widgets/Stepper.tsx
+++ b/src/components/widgets/Stepper.tsx
@@ -1,12 +1,12 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/Stepper.tsx  | valet
+// src/components/widgets/Stepper.tsx  | valet
 // minimal stepper component
 // ─────────────────────────────────────────────────────────────
 import React from 'react';
-import { styled } from '../css/createStyled';
-import { useTheme } from '../system/themeStore';
-import { preset } from '../css/stylePresets';
-import type { Presettable } from '../types';
+import { styled } from '../../css/createStyled';
+import { useTheme } from '../../system/themeStore';
+import { preset } from '../../css/stylePresets';
+import type { Presettable } from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
 export interface StepperProps

--- a/src/components/widgets/Table.tsx
+++ b/src/components/widgets/Table.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/Table.tsx  | valet
+// src/components/widgets/Table.tsx  | valet
 // Row-hover highlight fixed and now more saturated hover colour.
 // ─────────────────────────────────────────────────────────────
 import React, {
@@ -10,14 +10,14 @@ import React, {
   useRef,
   useId,
 } from 'react';
-import { styled }                 from '../css/createStyled';
-import { useTheme }               from '../system/themeStore';
-import { useSurface }             from '../system/surfaceStore';
+import { styled }                 from '../../css/createStyled';
+import { useTheme }               from '../../system/themeStore';
+import { useSurface }             from '../../system/surfaceStore';
 import { shallow }                from 'zustand/shallow';
-import { preset }                 from '../css/stylePresets';
-import { Checkbox }               from './Checkbox';
-import { stripe, toRgb, mix, toHex } from '../helpers/color';
-import type { Presettable }       from '../types';
+import { preset }                 from '../../css/stylePresets';
+import { Checkbox }               from '../fields/Checkbox';
+import { stripe, toRgb, mix, toHex } from '../../helpers/color';
+import type { Presettable }       from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
 /* Column definition                                          */

--- a/src/components/widgets/Tabs.tsx
+++ b/src/components/widgets/Tabs.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/Tabs.tsx | valet
+// src/components/widgets/Tabs.tsx | valet
 // Grid-based valet <Tabs> — bullet-proof placement: top / bottom / left / right
 // ─────────────────────────────────────────────────────────────
 import React, {
@@ -14,10 +14,10 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { styled }           from '../css/createStyled';
-import { useTheme }         from '../system/themeStore';
-import { preset }           from '../css/stylePresets';
-import type { Presettable } from '../types';
+import { styled }           from '../../css/createStyled';
+import { useTheme }         from '../../system/themeStore';
+import { preset }           from '../../css/stylePresets';
+import type { Presettable } from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
 /* Context                                                   */

--- a/src/components/widgets/Video.tsx
+++ b/src/components/widgets/Video.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/Video.tsx  | valet
+// src/components/widgets/Video.tsx  | valet
 // flexible <Video /> component with lazy loading & fullscreen
 // ─────────────────────────────────────────────────────────────
 import React, {
@@ -8,9 +8,9 @@ import React, {
   useEffect,
   KeyboardEvent,
 } from 'react';
-import { styled } from '../css/createStyled';
-import { preset } from '../css/stylePresets';
-import type { Presettable } from '../types';
+import { styled } from '../../css/createStyled';
+import { preset } from '../../css/stylePresets';
+import type { Presettable } from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
 /* Public types                                               */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,44 +1,44 @@
 // src/index.ts | valet
-export * from './components/Accordion';
-export * from './components/Box';
-export * from './components/Button';
-export * from './components/Checkbox';
+export * from './components/widgets/Accordion';
+export * from './components/primitives/Box';
+export * from './components/fields/Button';
+export * from './components/fields/Checkbox';
 export * from './components/Chat';
 export * from './components/FormControl';
-export * from './components/Icon';
+export * from './components/primitives/Icon';
 export * from './components/IconButton';
 export * from './components/Avatar';
 export * from './components/DateTimePicker';
-export * from './components/Modal';
-export * from './components/Drawer';
+export * from './components/widgets/Modal';
+export * from './components/widgets/Drawer';
 export * from './components/AppBar';
-export * from './components/Panel';
-export * from './components/Pagination';
-export * from './components/Table';
-export * from './components/Stepper';
-export * from './components/SpeedDial';
-export * from './components/Grid';
+export * from './components/primitives/Panel';
+export * from './components/widgets/Pagination';
+export * from './components/widgets/Table';
+export * from './components/widgets/Stepper';
+export * from './components/widgets/SpeedDial';
+export * from './components/layout/Grid';
 export * from './components/List';
 export * from './components/Tree';
 export * from './components/Parallax';
 export * from './components/Progress';
-export * from './components/RadioGroup';
-export * from './components/Slider';
+export * from './components/fields/RadioGroup';
+export * from './components/fields/Slider';
 export * from './components/Snackbar';
-export * from './components/Stack';
-export { default as Select } from './components/Select';  // ← gives you `Select`
+export * from './components/layout/Stack';
+export { default as Select } from './components/fields/Select';  // ← gives you `Select`
 export type {
   SelectProps,
   OptionProps as SelectOptionProps,
-} from './components/Select';
-export * from './components/Surface';
+} from './components/fields/Select';
+export * from './components/layout/Surface';
 export * from './components/LoadingBackdrop';
-export * from './components/Switch';
-export * from './components/Tabs';
-export * from './components/TextField';
+export * from './components/fields/Switch';
+export * from './components/widgets/Tabs';
+export * from './components/fields/TextField';
 export * from './components/Tooltip';
-export * from './components/Typography';
-export * from './components/Video';
+export * from './components/primitives/Typography';
+export * from './components/widgets/Video';
 export * from './css/createStyled';
 export * from './css/stylePresets';
 export * from './system/createFormStore';


### PR DESCRIPTION
## Summary
- reorganize components into primitives, layout, fields, and widgets
- adjust all relative imports for the new folders
- update library exports accordingly
- revise docs navigation drawer to display categories

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68729686e2c88320953fdc1d97d72c16