### PR TITLE
Add Surface explainer docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 - `Stack` spacing defaults to 1 and respects `compact` unless explicitly set
+- Docs now include a Surface usage explainer
 
 ## [0.9.0]
 ### Added

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -54,6 +54,7 @@ const DateTimeDemoPage      = page(() => import('./pages/DateTimeDemo'));
 const OverviewPage          = page(() => import('./pages/Overview'));
 const InstallationPage      = page(() => import('./pages/Installation'));
 const UsagePage             = page(() => import('./pages/Usage'));
+const SurfaceExplainerPage  = page(() => import('./pages/SurfaceExplainer'));
 
 /*───────────────────────────────────────────────────────────*/
 export function App() {
@@ -79,6 +80,7 @@ export function App() {
         <Route path="/overview"        element={<OverviewPage />} />
         <Route path="/installation"    element={<InstallationPage />} />
         <Route path="/usage"           element={<UsagePage />} />
+        <Route path="/surface"         element={<SurfaceExplainerPage />} />
         <Route path="/typography"      element={<TypographyDemoPage />} />
         <Route path="/presets"         element={<PresetDemoPage />} />
         <Route path="/form"            element={<FormDemoPage />} />

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -26,11 +26,11 @@ const primitives: [string, string][] = [
 ];
 
 const layoutPrimitives: [string, string][] = [
-  ['Surface', '/surface'],
   ['Box', '/box-demo'],
   ['Grid', '/grid-demo'],
   ['Panel', '/panel-demo'],
   ['Stack', '/stack-demo'],
+  ['Surface', '/surface'],
 ];
 
 const fields: [string, string][] = [

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -26,6 +26,7 @@ const primitives: [string, string][] = [
 ];
 
 const layoutPrimitives: [string, string][] = [
+  ['Surface', '/surface'],
   ['Box', '/box-demo'],
   ['Grid', '/grid-demo'],
   ['Panel', '/panel-demo'],

--- a/docs/src/pages/SurfaceExplainer.tsx
+++ b/docs/src/pages/SurfaceExplainer.tsx
@@ -1,0 +1,51 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/SurfaceExplainer.tsx | valet docs
+// Explainer for using <Surface>
+// ─────────────────────────────────────────────────────────────
+import { Surface, Stack, Typography, Panel, Button } from '@archway/valet';
+import NavDrawer from '../components/NavDrawer';
+import { useNavigate } from 'react-router-dom';
+
+export default function SurfaceExplainerPage() {
+  const navigate = useNavigate();
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack preset="showcaseStack">
+        <Typography variant="h2" bold>
+          Surface
+        </Typography>
+        <Typography>
+          The <code>{'<Surface>'}</code> component wraps each route and provides the background,
+          breakpoints and sizing variables for everything inside.
+        </Typography>
+        <Typography>
+          Never nest surfaces. Each route should render exactly one at the highest level
+          so components can subscribe to its store with <code>useSurface</code>.
+        </Typography>
+        <Panel compact fullWidth>
+          <Typography>
+            The surface store tracks screen size and every registered child element.
+            Components created with <code>createStyled</code> update their dimensions
+            via <code>--valet-el-width</code> and <code>--valet-el-height</code>. The surface
+            exposes <code>--valet-screen-width</code> and <code>--valet-screen-height</code> for
+            responsive layouts.
+          </Typography>
+        </Panel>
+        <Typography>
+          Other components such as Drawer, Accordion and Table read this store to align
+          themselves with the available space.
+        </Typography>
+        <Panel>
+          <Typography>
+            {`<Surface>`}
+            <br /> &nbsp;{`<MyRoute />`}
+            <br />{`</Surface>`}
+          </Typography>
+        </Panel>
+        <Button onClick={() => navigate(-1)}>← Back</Button>
+      </Stack>
+    </Surface>
+  );
+}

--- a/docs/src/pages/SurfaceExplainer.tsx
+++ b/docs/src/pages/SurfaceExplainer.tsx
@@ -13,7 +13,7 @@ export default function SurfaceExplainerPage() {
     <Surface>
       <NavDrawer />
       <Stack preset="showcaseStack">
-        <Typography variant="h2" bold>
+        <Typography variant="h2">
           Surface
         </Typography>
         <Typography>
@@ -21,7 +21,7 @@ export default function SurfaceExplainerPage() {
           breakpoints and sizing variables for everything inside.
         </Typography>
         <Typography>
-          Never nest surfaces. Each route should render exactly one at the highest level
+          <b>Never nest surfaces!</b> Each route should render exactly one at the highest level
           so components can subscribe to its store with <code>useSurface</code>.
         </Typography>
         <Panel compact fullWidth>
@@ -34,10 +34,10 @@ export default function SurfaceExplainerPage() {
           </Typography>
         </Panel>
         <Typography>
-          Other components such as Drawer, Accordion and Table read this store to align
-          themselves with the available space.
+          Other components such as <code>{'<Drawer>'}</code>, <code>{'<Accordion>'}</code> and <code>{'<Table>'}</code> read
+          this store to align themselves with the available space.
         </Typography>
-        <Panel>
+        <Panel compact>
           <Typography>
             {`<Surface>`}
             <br /> &nbsp;{`<MyRoute />`}


### PR DESCRIPTION
## Summary
- show how to use `Surface` in docs
- link Surface page in the layout section of the docs nav
- wire the route for `/surface`
- note new docs page in the changelog

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872b1645e5083208d6eb4b6e70d7f4d