### PR TITLE
Update grid demo with reference tab

### DIFF
--- a/docs/src/pages/BoxDemo.tsx
+++ b/docs/src/pages/BoxDemo.tsx
@@ -14,14 +14,12 @@ import {
 } from '@archway/valet';
 import type { TableColumn } from '@archway/valet';
 import type { ReactNode } from 'react';
-import { useNavigate } from 'react-router-dom';
 import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Demo page                                                                  */
 export default function BoxDemoPage() {
   const { theme, toggleMode } = useTheme();   // live theme switch
-  const navigate = useNavigate();
 
   interface Row {
     prop: ReactNode;
@@ -166,14 +164,6 @@ export default function BoxDemoPage() {
             <Table data={data} columns={columns} constrainHeight={false} />
           </Tabs.Panel>
         </Tabs>
-
-        <Button
-          size="lg"
-          onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing(1) }}
-        >
-          ← Back
-        </Button>
       </Stack>
     </Surface>
   );

--- a/docs/src/pages/GridDemo.tsx
+++ b/docs/src/pages/GridDemo.tsx
@@ -6,7 +6,6 @@ import {
   Surface,
   Stack,
   Typography,
-  Button,
   Grid,
   Box,
   Tabs,
@@ -14,13 +13,11 @@ import {
   useTheme,
 } from '@archway/valet';
 import type { TableColumn } from '@archway/valet';
-import { useNavigate } from 'react-router-dom';
 import NavDrawer from '../components/NavDrawer';
 import type { ReactNode } from 'react';
 
 export default function GridDemoPage() {
-  const { theme, toggleMode } = useTheme();
-  const navigate = useNavigate();
+  const { theme } = useTheme();
 
   interface Row {
     prop: ReactNode;
@@ -133,17 +130,6 @@ export default function GridDemoPage() {
             <Table data={data} columns={columns} constrainHeight={false} />
           </Tabs.Panel>
         </Tabs>
-
-        <Button variant="outlined" onClick={toggleMode} style={{ marginTop: theme.spacing(1) }}>
-          Toggle light / dark
-        </Button>
-        <Button
-          size="lg"
-          onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing(1) }}
-        >
-          ← Back
-        </Button>
       </Stack>
     </Surface>
   );

--- a/docs/src/pages/GridDemo.tsx
+++ b/docs/src/pages/GridDemo.tsx
@@ -1,45 +1,149 @@
-// src/pages/GridDemo.tsx
-import { Surface, Stack, Typography, Button, Grid, Box, useTheme } from '@archway/valet';
+// ─────────────────────────────────────────────────────────────
+// src/pages/GridDemo.tsx | valet
+// Showcase of Grid layout primitive
+// ─────────────────────────────────────────────────────────────
+import {
+  Surface,
+  Stack,
+  Typography,
+  Button,
+  Grid,
+  Box,
+  Tabs,
+  Table,
+  useTheme,
+} from '@archway/valet';
+import type { TableColumn } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
 import NavDrawer from '../components/NavDrawer';
+import type { ReactNode } from 'react';
 
 export default function GridDemoPage() {
   const { theme, toggleMode } = useTheme();
   const navigate = useNavigate();
 
+  interface Row {
+    prop: ReactNode;
+    type: ReactNode;
+    default: ReactNode;
+    description: ReactNode;
+  }
+
+  const columns: TableColumn<Row>[] = [
+    { header: 'Prop', accessor: 'prop' },
+    { header: 'Type', accessor: 'type' },
+    { header: 'Default', accessor: 'default' },
+    { header: 'Description', accessor: 'description' },
+  ];
+
+  const data: Row[] = [
+    {
+      prop: <code>columns</code>,
+      type: <code>number</code>,
+      default: <code>2</code>,
+      description: 'Number of equal-width columns',
+    },
+    {
+      prop: <code>gap</code>,
+      type: <code>number | string</code>,
+      default: <code>2</code>,
+      description: 'Spacing between cells (numbers use theme.spacing)',
+    },
+    {
+      prop: <code>preset</code>,
+      type: <code>string | string[]</code>,
+      default: <code>-</code>,
+      description: 'Apply style presets',
+    },
+  ];
+
   return (
     <Surface>
       <NavDrawer />
-      <Stack
-        preset="showcaseStack"
-      >
-        <Typography variant="h2" bold>Grid Showcase</Typography>
-        <Typography variant="subtitle">Responsive column layout</Typography>
+      <Stack preset="showcaseStack">
+        <Typography variant="h2" bold>
+          Grid Showcase
+        </Typography>
 
-        <Typography variant="h3">1. Two columns</Typography>
-        <Grid columns={2} gap={2}>
-          <Box style={{ background: theme.colors['primary'] as string, color: theme.colors['primaryText'] as string, padding: theme.spacing(1) }}>A</Box>
-          <Box style={{ background: theme.colors['secondary'] as string, color: theme.colors['secondaryText'] as string, padding: theme.spacing(1) }}>B</Box>
-        </Grid>
+        <Tabs>
+          <Tabs.Tab label="Usage" />
+          <Tabs.Panel>
+            <Typography variant="subtitle">Responsive column layout</Typography>
 
-        <Typography variant="h3">2. Four columns</Typography>
-        <Grid columns={4} gap={1}>
-          {['1', '2', '3', '4', '5', '6', '7', '8'].map(n => (
-            <Box key={n} style={{ background: theme.colors['primary'] as string, color: theme.colors['primaryText'] as string, padding: theme.spacing(1), textAlign: 'center' }}>{n}</Box>
-          ))}
-        </Grid>
+            <Typography variant="h3">1. Two columns</Typography>
+            <Grid columns={2} gap={2}>
+              <Box
+                style={{
+                  background: theme.colors['primary'] as string,
+                  color: theme.colors['primaryText'] as string,
+                  padding: theme.spacing(1),
+                }}
+              >
+                A
+              </Box>
+              <Box
+                style={{
+                  background: theme.colors['secondary'] as string,
+                  color: theme.colors['secondaryText'] as string,
+                  padding: theme.spacing(1),
+                }}
+              >
+                B
+              </Box>
+            </Grid>
 
-        <Typography variant="h3">2. Eight columns</Typography>
-        <Grid columns={8} gap={1}>
-          {['1', '2', '3', '4', '5', '6', '7', '8'].map(n => (
-            <Box key={n} style={{ background: theme.colors['primary'] as string, color: theme.colors['primaryText'] as string, padding: theme.spacing(1), textAlign: 'center' }}>{n}</Box>
-          ))}
-        </Grid>
+            <Typography variant="h3">2. Four columns</Typography>
+            <Grid columns={4} gap={1}>
+              {['1', '2', '3', '4', '5', '6', '7', '8'].map((n) => (
+                <Box
+                  key={n}
+                  style={{
+                    background: theme.colors['primary'] as string,
+                    color: theme.colors['primaryText'] as string,
+                    padding: theme.spacing(1),
+                    textAlign: 'center',
+                  }}
+                >
+                  {n}
+                </Box>
+              ))}
+            </Grid>
 
-        <Stack direction="row">
-          <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
-          <Button onClick={() => navigate(-1)}>← Back</Button>
-        </Stack>
+            <Typography variant="h3">3. Eight columns</Typography>
+            <Grid columns={8} gap={1}>
+              {['1', '2', '3', '4', '5', '6', '7', '8'].map((n) => (
+                <Box
+                  key={n}
+                  style={{
+                    background: theme.colors['primary'] as string,
+                    color: theme.colors['primaryText'] as string,
+                    padding: theme.spacing(1),
+                    textAlign: 'center',
+                  }}
+                >
+                  {n}
+                </Box>
+              ))}
+            </Grid>
+          </Tabs.Panel>
+
+          <Tabs.Tab label="Reference" />
+          <Tabs.Panel>
+            <Typography variant="h3">Prop reference</Typography>
+            <Table data={data} columns={columns} constrainHeight={false} />
+          </Tabs.Panel>
+        </Tabs>
+
+        <Button variant="outlined" onClick={toggleMode} style={{ marginTop: theme.spacing(1) }}>
+          Toggle light / dark
+        </Button>
+        <Button
+          size="lg"
+          onClick={() => navigate(-1)}
+          style={{ marginTop: theme.spacing(1) }}
+        >
+          ← Back
+        </Button>
       </Stack>
     </Surface>
   );


### PR DESCRIPTION
## Summary
- add full header and restructure GridDemo into tabs
- document Grid props in a reference table

## Testing
- `npm run build` in `docs`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6873315b23cc8320925f0409161dc5e9