### PR TITLE
Refine panel and video docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Unreleased
 - `Stack` spacing defaults to 1 and respects `compact` unless explicitly set
 - Docs now include a Surface usage explainer
+- Panel and Video docs use tabs with reference tables
 
 ## [0.9.0]
 ### Added

--- a/docs/src/pages/PanelDemo.tsx
+++ b/docs/src/pages/PanelDemo.tsx
@@ -4,21 +4,70 @@
 // ─────────────────────────────────────────────────────────────────────────────
 import {
   Surface,
-  Stack,          // tidy vertical layout
+  Stack,
   Panel,
   Typography,
   Button,
+  Tabs,
+  Table,
   useTheme,
 } from '@archway/valet';
-import { useNavigate } from 'react-router-dom';
+import type { TableColumn } from '@archway/valet';
+import type { ReactNode } from 'react';
 import NavDrawer from '../components/NavDrawer';
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Demo page                                                                  */
 
 export default function PanelDemoPage() {
-  const { theme, toggleMode } = useTheme();      // live theme switch
-  const navigate = useNavigate();
+  const { theme, toggleMode } = useTheme(); // live theme switch
+
+  interface Row {
+    prop: ReactNode;
+    type: ReactNode;
+    default: ReactNode;
+    description: ReactNode;
+  }
+
+  const columns: TableColumn<Row>[] = [
+    { header: 'Prop', accessor: 'prop' },
+    { header: 'Type', accessor: 'type' },
+    { header: 'Default', accessor: 'default' },
+    { header: 'Description', accessor: 'description' },
+  ];
+
+  const data: Row[] = [
+    {
+      prop: <code>variant</code>,
+      type: <code>'main' | 'alt'</code>,
+      default: <code>'main'</code>,
+      description: 'Visual style selection',
+    },
+    {
+      prop: <code>background</code>,
+      type: <code>string</code>,
+      default: <code>-</code>,
+      description: 'Background colour override',
+    },
+    {
+      prop: <code>fullWidth</code>,
+      type: <code>boolean</code>,
+      default: <code>false</code>,
+      description: 'Expand to full width',
+    },
+    {
+      prop: <code>compact</code>,
+      type: <code>boolean</code>,
+      default: <code>false</code>,
+      description: 'Remove margin and padding',
+    },
+    {
+      prop: <code>preset</code>,
+      type: <code>string | string[]</code>,
+      default: <code>-</code>,
+      description: 'Apply style presets',
+    },
+  ];
 
   return (
     <Surface /* Surface already defaults to theme background */>
@@ -34,11 +83,13 @@ export default function PanelDemoPage() {
           All props & tricks, neatly demonstrated
         </Typography>
 
-        {/* 1. Default Panel ------------------------------------------------- */}
-        <Typography variant="h3">1. Default Panel (variant=&quot;main&quot;)</Typography>
-        <Panel style={{ padding: theme.spacing(1) }}>
-          <Typography>(no props) — inherits theme backgroundAlt &amp; text</Typography>
-        </Panel>
+        <Tabs>
+          <Tabs.Tab label="Usage" />
+          <Tabs.Panel>
+            <Typography variant="h3">1. Default Panel (variant=&quot;main&quot;)</Typography>
+            <Panel style={{ padding: theme.spacing(1) }}>
+              <Typography>(no props) — inherits theme backgroundAlt &amp; text</Typography>
+            </Panel>
 
         {/* 2. alt variant --------------------------------------------------- */}
         <Typography variant="h3">2. variant=&quot;alt&quot;</Typography>
@@ -122,14 +173,14 @@ export default function PanelDemoPage() {
           Toggle light / dark mode
         </Button>
 
-        {/* Back nav --------------------------------------------------------- */}
-        <Button
-          size="lg"
-          onClick={() => navigate(-1)}
-          style={{ marginTop: theme.spacing(1) }}
-        >
-          ← Back
-        </Button>
+          </Tabs.Panel>
+
+          <Tabs.Tab label="Reference" />
+          <Tabs.Panel>
+            <Typography variant="h3">Prop reference</Typography>
+            <Table data={data} columns={columns} constrainHeight={false} />
+          </Tabs.Panel>
+        </Tabs>
       </Stack>
     </Surface>
   );

--- a/docs/src/pages/VideoDemo.tsx
+++ b/docs/src/pages/VideoDemo.tsx
@@ -3,57 +3,126 @@
 // Simple showcase of the <Video /> component
 // ─────────────────────────────────────────────────────────────
 import {
-    Surface,
-    Stack,
-    Typography,
+  Surface,
+  Stack,
+  Typography,
   Video,
+  Tabs,
+  Table,
   useTheme,
 } from '@archway/valet';
+import type { TableColumn } from '@archway/valet';
+import type { ReactNode } from 'react';
 import NavDrawer from '../components/NavDrawer';
   
   /*─────────────────────────────────────────────────────────────*/
   /* Demo page                                                   */
-  export default function VideoDemoPage() {
-    const { theme } = useTheme();         // for consistent spacing etc.
-  
-    return (
-      <Surface>
-        <NavDrawer />
-        <Stack
-          style={{
-            padding : theme.spacing(1),
-            maxWidth: 1024,
-            margin  : '0 auto',
-          }}
-        >
-          {/* Header --------------------------------------------------- */}
-          <Typography variant="h2" bold>
-            Video Demo
-          </Typography>
-          <Typography variant="subtitle">
-            Basic usage of the&nbsp;
-            <code>&lt;Video /&gt;</code>&nbsp;component
-          </Typography>
-  
-          {/* Video ---------------------------------------------------- */}
-          <Video
-            sources={[
-              {
-                src : 'https://z-public-occ.s3.us-east-2.amazonaws.com/video/webm/Big_Buck_Bunny_1080p.webm',
-                type: 'video/webm',
-              },
-              
-            ]}
-            controls
-            autoPlay      // starts muted (default) for autoplay compliance
-            muted
-            loop
-            width="100%"
-            height="auto"
-            objectFit="contain"
-          />
-        </Stack>
-      </Surface>
-    );
+export default function VideoDemoPage() {
+  const { theme } = useTheme(); // for consistent spacing etc.
+
+  interface Row {
+    prop: ReactNode;
+    type: ReactNode;
+    default: ReactNode;
+    description: ReactNode;
   }
-  
+
+  const columns: TableColumn<Row>[] = [
+    { header: 'Prop', accessor: 'prop' },
+    { header: 'Type', accessor: 'type' },
+    { header: 'Default', accessor: 'default' },
+    { header: 'Description', accessor: 'description' },
+  ];
+
+  const data: Row[] = [
+    {
+      prop: <code>sources</code>,
+      type: <code>VideoSource[]</code>,
+      default: <code>-</code>,
+      description: 'Video source files',
+    },
+    {
+      prop: <code>poster</code>,
+      type: <code>string</code>,
+      default: <code>-</code>,
+      description: 'Poster image URL',
+    },
+    {
+      prop: <code>controls</code>,
+      type: <code>boolean</code>,
+      default: <code>true</code>,
+      description: 'Display native controls',
+    },
+    {
+      prop: <code>autoPlay</code>,
+      type: <code>boolean</code>,
+      default: <code>true</code>,
+      description: 'Autoplay when ready',
+    },
+    {
+      prop: <code>muted</code>,
+      type: <code>boolean</code>,
+      default: <code>true</code>,
+      description: 'Mute audio',
+    },
+    {
+      prop: <code>loop</code>,
+      type: <code>boolean</code>,
+      default: <code>false</code>,
+      description: 'Loop playback',
+    },
+    {
+      prop: <code>objectFit</code>,
+      type: <code>'contain' | 'cover'</code>,
+      default: <code>'contain'</code>,
+      description: 'Video object-fit style',
+    },
+    {
+      prop: <code>preset</code>,
+      type: <code>string | string[]</code>,
+      default: <code>-</code>,
+      description: 'Apply style presets',
+    },
+  ];
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack preset="showcaseStack">
+        <Typography variant="h2" bold>Video Demo</Typography>
+
+        <Tabs>
+          <Tabs.Tab label="Usage" />
+          <Tabs.Panel>
+            <Typography variant="subtitle">
+              Basic usage of the&nbsp;
+              <code>&lt;Video /&gt;</code>&nbsp;component
+            </Typography>
+
+            <Video
+              sources={[
+                {
+                  src: 'https://z-public-occ.s3.us-east-2.amazonaws.com/video/webm/Big_Buck_Bunny_1080p.webm',
+                  type: 'video/webm',
+                },
+              ]}
+              controls
+              autoPlay
+              muted
+              loop
+              width="100%"
+              height="auto"
+              objectFit="contain"
+            />
+          </Tabs.Panel>
+
+          <Tabs.Tab label="Reference" />
+          <Tabs.Panel>
+            <Typography variant="h3">Prop reference</Typography>
+            <Table data={data} columns={columns} constrainHeight={false} />
+          </Tabs.Panel>
+        </Tabs>
+      </Stack>
+    </Surface>
+  );
+}


### PR DESCRIPTION
## Summary
- refresh Panel docs with tabs and reference table
- update Video docs with tabs and reference table
- remove demo back button

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6873db2d09f88320a77e3f0b0ad56d9a