### PR TITLE
Update AppBar offset behaviour

### DIFF
--- a/docs/src/pages/AppBarDemo.tsx
+++ b/docs/src/pages/AppBarDemo.tsx
@@ -1,5 +1,5 @@
 // src/pages/AppBarDemo.tsx
-import { Surface, Stack, Typography, Button, AppBar, Box, useTheme } from '@archway/valet';
+import { Surface, Stack, Typography, Button, AppBar, useTheme } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
 import NavDrawer from '../components/NavDrawer';
 
@@ -10,48 +10,25 @@ export default function AppBarDemoPage() {
   return (
     <Surface>
       <NavDrawer />
-      <Stack
-        preset="showcaseStack"
-      >
-        <Typography variant="h2" bold>
-          AppBar Showcase
-        </Typography>
+      <AppBar>
+        <Typography variant="h6">Fixed AppBar</Typography>
+      </AppBar>
+      <Stack preset="showcaseStack">
+        <Typography variant="h2" bold>AppBar Showcase</Typography>
         <Typography variant="subtitle">
-          Basic usage and positioning
+          Fixed at the top, content scrolls behind
         </Typography>
-
-        <AppBar>
-          <Typography variant="h6">Fixed</Typography>
-        </AppBar>
 
         <Stack>
-          <Typography variant="h1">
-            placeholder
-          </Typography>
-          <Typography variant="h1">
-            placeholder
-          </Typography>
-          <Typography variant="h1">
-            placeholder
-          </Typography>
-          <Typography variant="h1">
-            placeholder
-          </Typography>
-          <Typography variant="h1">
-            placeholder
-          </Typography>
-          <Typography variant="h1">
-            placeholder
-          </Typography>
-          <Typography variant="h1">
-            placeholder
-          </Typography>
-          <Typography variant="h1">
-            placeholder
-          </Typography>
-          <Typography variant="h1">
-            placeholder
-          </Typography>
+          <Typography variant="h1">placeholder</Typography>
+          <Typography variant="h1">placeholder</Typography>
+          <Typography variant="h1">placeholder</Typography>
+          <Typography variant="h1">placeholder</Typography>
+          <Typography variant="h1">placeholder</Typography>
+          <Typography variant="h1">placeholder</Typography>
+          <Typography variant="h1">placeholder</Typography>
+          <Typography variant="h1">placeholder</Typography>
+          <Typography variant="h1">placeholder</Typography>
 
           <Button variant="outlined" onClick={toggleMode}>
             Toggle light / dark


### PR DESCRIPTION
## Summary
- ensure the AppBar stays above responsive drawers
- push surface content beneath the AppBar using the surface store
- refresh the AppBar demo to show scrolling content

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68746bf36db08320b3308d0d8d5412a8