### PR TITLE
Fix AppBar overlap

### DIFF
--- a/src/components/layout/Surface.tsx
+++ b/src/components/layout/Surface.tsx
@@ -124,7 +124,7 @@ export const Surface: React.FC<SurfaceProps> = ({
     ? {
         position: 'fixed',
         inset: 0,
-        paddingTop: 'env(safe-area-inset-top)',
+        paddingTop: 'calc(var(--valet-top-offset, 0px) + env(safe-area-inset-top))',
         paddingRight: 'env(safe-area-inset-right)',
         paddingBottom: 'env(safe-area-inset-bottom)',
         paddingLeft: 'env(safe-area-inset-left)',


### PR DESCRIPTION
## Summary
- push surface content below AppBar
- keep AppBar above drawers

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68746bf36db08320b3308d0d8d5412a8