### PR TITLE
AppBar uses surface offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- `AppBar` uses the surface store to offset content and now renders via portal
+  above responsive drawers
+- Docs demo updated to show scroll behind the AppBar
+- Drawer components account for AppBar height when responsive
 
 ## [0.10.0]
 - `Stack` spacing defaults to 1 and respects `compact` unless explicitly set

--- a/docs/src/pages/AppBarDemo.tsx
+++ b/docs/src/pages/AppBarDemo.tsx
@@ -10,19 +10,19 @@ export default function AppBarDemoPage() {
   return (
     <Surface>
       <NavDrawer />
-      <Stack
-        preset="showcaseStack"
-      >
+      <AppBar>
+        <Typography variant="h6">Fixed</Typography>
+      </AppBar>
+      <Stack preset="showcaseStack">
         <Typography variant="h2" bold>
           AppBar Showcase
         </Typography>
         <Typography variant="subtitle">
           Basic usage and positioning
         </Typography>
-
-        <AppBar>
-          <Typography variant="h6">Fixed</Typography>
-        </AppBar>
+        <Typography variant="body">
+          Scroll to see content move under the AppBar.
+        </Typography>
 
         <Stack>
           <Typography variant="h1">

--- a/src/components/widgets/AppBar.tsx
+++ b/src/components/widgets/AppBar.tsx
@@ -2,9 +2,12 @@
 // src/components/widgets/AppBar.tsx  | valet
 // minimal top navigation bar
 // ─────────────────────────────────────────────────────────────
-import React from 'react';
+import React, { useLayoutEffect, useRef, useId } from 'react';
+import { createPortal } from 'react-dom';
 import { styled } from '../../css/createStyled';
 import { useTheme } from '../../system/themeStore';
+import { useSurface } from '../../system/surfaceStore';
+import { shallow } from 'zustand/shallow';
 import { preset } from '../../css/stylePresets';
 import type { Presettable } from '../../types';
 
@@ -28,7 +31,6 @@ const Bar = styled('header')<{
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin: ${({ $gap }) => $gap};
   padding: 0.5rem 1rem;
   & > * {
     padding: ${({ $gap }) => $gap};
@@ -37,7 +39,7 @@ const Bar = styled('header')<{
   top: 0;
   left: 0;
   right: 0;
-  z-index: 1000;
+  z-index: 10000;
   background: ${({ $bg }) => $bg};
   color: ${({ $text }) => $text};
 `;
@@ -53,6 +55,16 @@ export const AppBar: React.FC<AppBarProps> = ({
   ...rest
 }) => {
   const { theme } = useTheme();
+  const { element, registerChild, unregisterChild } = useSurface(
+    s => ({
+      element: s.element,
+      registerChild: s.registerChild,
+      unregisterChild: s.unregisterChild,
+    }),
+    shallow,
+  );
+  const ref = useRef<HTMLElement>(null);
+  const id = useId();
 
   const isToken = (v: any): v is AppBarToken =>
     v === 'primary' || v === 'secondary' || v === 'tertiary';
@@ -73,8 +85,24 @@ export const AppBar: React.FC<AppBarProps> = ({
   const presetClass = p ? preset(p) : '';
   const gap = theme.spacing(1);
 
-  return (
+  useLayoutEffect(() => {
+    const node = ref.current;
+    const surfEl = element;
+    if (!node || !surfEl) return;
+    const prev = (surfEl.style as any).marginTop;
+    const update = (m: { height: number }) => {
+      (surfEl.style as any).marginTop = `${m.height}px`;
+    };
+    registerChild(id, node, update);
+    return () => {
+      unregisterChild(id);
+      (surfEl.style as any).marginTop = prev;
+    };
+  }, [element]);
+
+  const bar = (
     <Bar
+      ref={ref}
       {...rest}
       $bg={bg}
       $text={text}
@@ -85,6 +113,8 @@ export const AppBar: React.FC<AppBarProps> = ({
       {children}
     </Bar>
   );
+
+  return createPortal(bar, document.body);
 };
 
 export default AppBar;

--- a/src/components/widgets/Drawer.tsx
+++ b/src/components/widgets/Drawer.tsx
@@ -135,6 +135,9 @@ export const Drawer: React.FC<DrawerProps> = ({
     s => ({ width: s.width, height: s.height, element: s.element }),
     shallow,
   );
+  const surfOffset = element
+    ? parseFloat(window.getComputedStyle(element).marginTop || '0')
+    : 0;
   const presetClasses = presetKey ? preset(presetKey) : '';
   const portrait = height > width;
   const responsiveMode = responsive && (anchor === 'left' || anchor === 'right');
@@ -208,7 +211,7 @@ export const Drawer: React.FC<DrawerProps> = ({
           onClick={() => setOpenState(true)}
           style={{
             position: 'fixed',
-            top: theme.spacing(1),
+            top: `calc(${theme.spacing(1)} + ${surfOffset}px)`,
             [anchor]: theme.spacing(1),
             zIndex: 9999,
           }}
@@ -234,6 +237,11 @@ export const Drawer: React.FC<DrawerProps> = ({
         $persistent={persistentEffective}
         $responsive={responsiveMode}
         className={presetClasses}
+        style={
+          anchor === 'left' || anchor === 'right' || anchor === 'top'
+            ? { top: `${surfOffset}px` }
+            : undefined
+        }
       >
         {responsiveMode && portrait && (
           <div


### PR DESCRIPTION
## Summary
- position the AppBar above responsive drawers
- push Surface content below the AppBar using the surface store
- render the AppBar with a portal so content scrolls behind
- update the AppBar demo to showcase the behaviour
- document the change

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68746bf36db08320b3308d0d8d5412a8