### PR TITLE
Rename Drawer responsive prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Renamed `Drawer` prop `responsive` to `adaptive`
 
 ## [0.10.1]
 - `AppBar` uses the surface store to offset content and now renders via portal

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -162,7 +162,7 @@ export default function NavDrawer() {
     }
   };
   return (
-    <Drawer responsive anchor="left" size="16rem">
+    <Drawer adaptive anchor="left" size="16rem">
       <Tree<Item>
         nodes={treeData}
         getLabel={(n) => n.label}

--- a/docs/src/pages/DrawerDemo.tsx
+++ b/docs/src/pages/DrawerDemo.tsx
@@ -84,12 +84,12 @@ export default function DrawerDemoPage() {
           </Stack>
         </Drawer>
 
-        {/* 4. Responsive drawer */}
-        <Typography variant="h3">4. Responsive drawer</Typography>
-        <Drawer responsive anchor="right" size="16rem">
+        {/* 4. Adaptive drawer */}
+        <Typography variant="h3">4. Adaptive drawer</Typography>
+        <Drawer adaptive anchor="right" size="16rem">
           <Stack style={{ padding: theme.spacing(1) }}>
             <Typography variant="h4" bold>
-              Responsive Drawer
+              Adaptive Drawer
             </Typography>
             <Typography>
               Persistent in landscape, icon in portrait.

--- a/docs/src/pages/MainPage.tsx
+++ b/docs/src/pages/MainPage.tsx
@@ -1,6 +1,6 @@
 // ─────────────────────────────────────────────────────────────
 // src/pages/MainPage.tsx  | valet
-// Doc home with responsive drawer navigation
+// Doc home with adaptive drawer navigation
 // ─────────────────────────────────────────────────────────────
 
 import {

--- a/src/components/widgets/Drawer.tsx
+++ b/src/components/widgets/Drawer.tsx
@@ -34,8 +34,8 @@ export interface DrawerProps extends Presettable {
   disableEscapeKeyDown?: boolean;
   /** Drawer remains visible without backdrop */
   persistent?: boolean;
-  /** Responsive behaviour (persistent in landscape, overlay in portrait) */
-  responsive?: boolean;
+  /** Adaptive behaviour (persistent in landscape, overlay in portrait) */
+  adaptive?: boolean;
   /** Icon for the portrait toggle button */
   toggleIcon?: string;
   /** Close button icon when portrait */
@@ -65,7 +65,7 @@ const Panel = styled('div')<{
   $text: string;
   $primary: string;
   $persistent: boolean;
-  $responsive: boolean;
+  $adaptive: boolean;
 }>`
   position: fixed;
   z-index: ${({ $persistent }) => ($persistent ? 9998 : 9999)};
@@ -77,8 +77,8 @@ const Panel = styled('div')<{
     $anchor === 'top' || $anchor === 'bottom' ? 'auto' : 'visible'};
   background: ${({ $bg }) => $bg};
   color: ${({ $text }) => $text};
-  box-shadow: ${({ $responsive }) =>
-    $responsive ? 'none' : '0 4px 16px rgba(0, 0, 0, 0.3)'};
+  box-shadow: ${({ $adaptive }) =>
+    $adaptive ? 'none' : '0 4px 16px rgba(0, 0, 0, 0.3)'};
   ${({ $anchor, $primary }) =>
     $anchor === 'left'
       ? `border-right:0.25rem solid ${$primary};`
@@ -124,7 +124,7 @@ export const Drawer: React.FC<DrawerProps> = ({
   disableBackdropClick = false,
   disableEscapeKeyDown = false,
   persistent = false,
-  responsive = false,
+  adaptive = false,
   toggleIcon = 'mdi:menu',
   closeIcon = 'mdi:close',
   children,
@@ -140,8 +140,8 @@ export const Drawer: React.FC<DrawerProps> = ({
     : 0;
   const presetClasses = presetKey ? preset(presetKey) : '';
   const portrait = height > width;
-  const responsiveMode = responsive && (anchor === 'left' || anchor === 'right');
-  const orientationPersistent = responsiveMode && !portrait;
+  const adaptiveMode = adaptive && (anchor === 'left' || anchor === 'right');
+  const orientationPersistent = adaptiveMode && !portrait;
   const persistentEffective = persistent || orientationPersistent;
 
   const uncontrolled = controlledOpen === undefined;
@@ -155,8 +155,8 @@ export const Drawer: React.FC<DrawerProps> = ({
 
   useEffect(() => {
     if (orientationPersistent) setOpenState(true);
-    else if (responsiveMode && portrait) setOpenState(false);
-  }, [orientationPersistent, responsiveMode, portrait]);
+    else if (adaptiveMode && portrait) setOpenState(false);
+  }, [orientationPersistent, adaptiveMode, portrait]);
 
   const requestClose = useCallback(() => {
     if (orientationPersistent) return;
@@ -204,7 +204,7 @@ export const Drawer: React.FC<DrawerProps> = ({
   }, [element, persistentEffective, anchor, size]);
 
   if (!open && !persistentEffective) {
-    if (responsiveMode && portrait) {
+    if (adaptiveMode && portrait) {
       return (
         <IconButton
           icon={toggleIcon}
@@ -235,7 +235,7 @@ export const Drawer: React.FC<DrawerProps> = ({
         $text={theme.colors.text}
         $primary={theme.colors.primary}
         $persistent={persistentEffective}
-        $responsive={responsiveMode}
+        $adaptive={adaptiveMode}
         className={presetClasses}
         style={
           anchor === 'left' || anchor === 'right' || anchor === 'top'
@@ -243,7 +243,7 @@ export const Drawer: React.FC<DrawerProps> = ({
             : undefined
         }
       >
-        {responsiveMode && portrait && (
+        {adaptiveMode && portrait && (
           <div
             style={{
               alignSelf: anchor === 'left' ? 'flex-end' : 'flex-start',


### PR DESCRIPTION
## Summary
- rename `responsive` prop to `adaptive`
- update docs to use the new prop
- note prop rename in changelog

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68756be351d08320aa72158fd112d0ef