### PR TITLE
Add adaptive prop to Grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Grid now supports an `adaptive` prop for portrait layouts
 
 ## [0.11.0]
 - Renamed `Drawer` prop `responsive` to `adaptive`

--- a/docs/src/pages/GridDemo.tsx
+++ b/docs/src/pages/GridDemo.tsx
@@ -47,6 +47,12 @@ export default function GridDemoPage() {
       description: 'Spacing between cells (numbers use theme.spacing)',
     },
     {
+      prop: <code>adaptive</code>,
+      type: <code>boolean</code>,
+      default: <code>false</code>,
+      description: 'Portrait orientation uses a single column',
+    },
+    {
       prop: <code>preset</code>,
       type: <code>string | string[]</code>,
       default: <code>-</code>,
@@ -114,6 +120,23 @@ export default function GridDemoPage() {
                   style={{
                     background: theme.colors['primary'] as string,
                     color: theme.colors['primaryText'] as string,
+                    padding: theme.spacing(1),
+                    textAlign: 'center',
+                  }}
+                >
+                  {n}
+                </Box>
+              ))}
+            </Grid>
+
+            <Typography variant="h3">4. Adaptive grid</Typography>
+            <Grid columns={4} gap={1} adaptive>
+              {['1', '2', '3', '4', '5', '6', '7', '8'].map((n) => (
+                <Box
+                  key={n}
+                  style={{
+                    background: theme.colors['secondary'] as string,
+                    color: theme.colors['secondaryText'] as string,
                     padding: theme.spacing(1),
                     textAlign: 'center',
                   }}

--- a/src/components/layout/Grid.tsx
+++ b/src/components/layout/Grid.tsx
@@ -6,6 +6,8 @@ import React from 'react';
 import { styled } from '../../css/createStyled';
 import { preset } from '../../css/stylePresets';
 import { useTheme } from '../../system/themeStore';
+import { useSurface } from '../../system/surfaceStore';
+import { shallow } from 'zustand/shallow';
 import type { Presettable } from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
@@ -14,6 +16,7 @@ export interface GridProps
     Presettable {
   columns?: number;
   gap?: number | string;
+  adaptive?: boolean;
 }
 
 /*───────────────────────────────────────────────────────────*/
@@ -31,6 +34,7 @@ const Root = styled('div')<{ $cols: number; $gap: string; $pad: string }>`
 export const Grid: React.FC<GridProps> = ({
   columns = 2,
   gap = 2,
+  adaptive = false,
   preset: p,
   style,
   className,
@@ -38,6 +42,13 @@ export const Grid: React.FC<GridProps> = ({
   ...rest
 }) => {
   const { theme } = useTheme();
+  const { width, height } = useSurface(
+    s => ({ width: s.width, height: s.height }),
+    shallow,
+  );
+
+  const portrait = height > width;
+  const effectiveCols = adaptive && portrait ? 1 : columns;
 
   let g: string;
   if (typeof gap === 'number') {
@@ -53,7 +64,7 @@ export const Grid: React.FC<GridProps> = ({
   return (
     <Root
       {...rest}
-      $cols={columns}
+      $cols={effectiveCols}
       $gap={g}
       $pad={pad}
       style={style}


### PR DESCRIPTION
## Summary
- support `adaptive` on Grid like Drawer
- document Grid's adaptive behavior
- demo adaptive Grid example
- note change in Unreleased section

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68757bc7fa888320b35ceb396c4a3267