### PR TITLE
Add Image primitive with demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 - Grid now supports an `adaptive` prop for portrait layouts
+- Added `Image` primitive component and docs demo
 
 ## [0.11.0]
 - Renamed `Drawer` prop `responsive` to `adaptive`

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ These have been mostly tested in the [valet Docs](https://github.com/off-court-c
 | Tooltip       |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
 | Tree          |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
 | Typography    |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
+| Image         |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
 | Video         |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
 
 ## Hooks

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -24,6 +24,7 @@ const ButtonDemoPage        = page(() => import('./pages/ButtonDemoPage'));
 const TextFieldDemoPage     = page(() => import('./pages/TextFormDemo'));
 const IconDemoPage          = page(() => import('./pages/IconDemoPage'));
 const IconButtonDemoPage    = page(() => import('./pages/IconButtonDemoPage'));
+const ImageDemoPage         = page(() => import('./pages/ImageDemo'));
 const AvatarDemoPage        = page(() => import('./pages/AvatarDemo'));
 const ChatDemoPage          = page(() => import('./pages/ChatDemo'));
 const PanelDemoPage         = page(() => import('./pages/PanelDemo'));
@@ -90,6 +91,7 @@ export function App() {
         <Route path="/button-demo"     element={<ButtonDemoPage />} />
         <Route path="/text-form-demo"  element={<TextFieldDemoPage />} />
         <Route path="/icon-demo"       element={<IconDemoPage />} />
+        <Route path="/image-demo"      element={<ImageDemoPage />} />
         <Route path="/icon-button-demo"element={<IconButtonDemoPage />} />
         <Route path="/avatar-demo"    element={<AvatarDemoPage />} />
         <Route path="/panel-demo"      element={<PanelDemoPage />} />

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -19,6 +19,7 @@ interface Item {
 const primitives: [string, string][] = [
   ['Avatar', '/avatar-demo'],
   ['Icon', '/icon-demo'],
+  ['Image', '/image-demo'],
   ['Modal', '/modal-demo'],
   ['Progress', '/progress-demo'],
   ['Typography', '/typography'],

--- a/docs/src/pages/ImageDemo.tsx
+++ b/docs/src/pages/ImageDemo.tsx
@@ -1,0 +1,63 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/ImageDemo.tsx | valet
+// Showcase of Image component
+// ─────────────────────────────────────────────────────────────
+import { Surface, Stack, Typography, Image, Button, useTheme } from '@archway/valet';
+import NavDrawer from '../components/NavDrawer';
+import { useNavigate } from 'react-router-dom';
+
+export default function ImageDemoPage() {
+  const { theme } = useTheme();
+  const navigate = useNavigate();
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack preset="showcaseStack">
+        <Typography variant="h2" bold>
+          Image Showcase
+        </Typography>
+        <Typography variant="subtitle">
+          Responsive sizing, lazy loading and object-fit
+        </Typography>
+
+        <Typography variant="h3">1. Basic usage</Typography>
+        <Image
+          src="https://placekitten.com/800/400"
+          alt="Kitten"
+          width="100%"
+          height="auto"
+          rounded={8}
+        />
+
+        <Typography variant="h3">2. Lazy loaded</Typography>
+        <Image
+          src="https://placekitten.com/600/400"
+          alt="Lazy kitten"
+          width="100%"
+          height="300px"
+          lazy
+          placeholder="https://placehold.co/10x10"
+        />
+
+        <Typography variant="h3">3. Contain fit</Typography>
+        <Image
+          src="https://placekitten.com/400/500"
+          alt="Contained kitten"
+          width="100%"
+          height="300px"
+          objectFit="contain"
+          style={{ background: '#0003' }}
+        />
+
+        <Button
+          size="lg"
+          onClick={() => navigate(-1)}
+          style={{ marginTop: theme.spacing(1) }}
+        >
+          ← Back
+        </Button>
+      </Stack>
+    </Surface>
+  );
+}

--- a/src/components/primitives/Image.tsx
+++ b/src/components/primitives/Image.tsx
@@ -1,0 +1,90 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/primitives/Image.tsx  | valet
+// responsive, lazy-loading <Image /> component
+// ─────────────────────────────────────────────────────────────
+import React, { useRef, useState, useEffect } from 'react';
+import { styled } from '../../css/createStyled';
+import { preset } from '../../css/stylePresets';
+import type { Presettable } from '../../types';
+
+export interface ImageProps
+  extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'width' | 'height'>,
+    Presettable {
+  /** Image source URL */
+  src: string;
+  /** CSS width value (number ⇒ px) */
+  width?: number | string;
+  /** CSS height value (number ⇒ px) */
+  height?: number | string;
+  /** Object-fit value */
+  objectFit?: 'cover' | 'contain' | 'fill' | 'none' | 'scale-down';
+  /** Border radius */
+  rounded?: number | string;
+  /** Lazy load image when visible */
+  lazy?: boolean;
+  /** Placeholder src until loaded */
+  placeholder?: string;
+}
+
+const Img = styled('img')<{
+  $w?: string;
+  $h?: string;
+  $fit: string;
+  $radius?: string;
+}>`
+  display: block;
+  width: ${({ $w }) => $w || 'auto'};
+  height: ${({ $h }) => $h || 'auto'};
+  object-fit: ${({ $fit }) => $fit};
+  border-radius: ${({ $radius }) => $radius || 0};
+`;
+
+export const Image: React.FC<ImageProps> = ({
+  src,
+  width,
+  height,
+  objectFit = 'cover',
+  rounded,
+  lazy = false,
+  placeholder,
+  preset: p,
+  className,
+  style,
+  ...rest
+}) => {
+  const [ready, setReady] = useState(!lazy);
+  const ref = useRef<HTMLImageElement>(null);
+
+  useEffect(() => {
+    if (!lazy || ready || !('IntersectionObserver' in window)) return;
+    const img = ref.current;
+    if (!img) return;
+    const io = new IntersectionObserver(([e]) => {
+      if (e.isIntersecting) setReady(true);
+    }, { threshold: 0.1 });
+    io.observe(img);
+    return () => io.disconnect();
+  }, [lazy, ready]);
+
+  const presetCls = p ? preset(p) : '';
+  const w = typeof width === 'number' ? `${width}px` : width;
+  const h = typeof height === 'number' ? `${height}px` : height;
+  const r = typeof rounded === 'number' ? `${rounded}px` : rounded;
+
+  return (
+    <Img
+      {...rest}
+      ref={ref}
+      src={ready ? src : placeholder}
+      $w={w}
+      $h={h}
+      $fit={objectFit}
+      $radius={r}
+      loading={lazy ? 'lazy' : rest.loading}
+      className={[presetCls, className].filter(Boolean).join(' ')}
+      style={style}
+    />
+  );
+};
+
+export default Image;

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * from './components/primitives/Typography';
 export * from './components/primitives/Modal';
 export * from './components/primitives/Progress';
 export * from './components/primitives/Video';
+export * from './components/primitives/Image';
 
 // ─── Layout Primitives ──────────────────────────────────────
 export * from './components/layout/Grid';


### PR DESCRIPTION
## Summary
- introduce `Image` primitive component
- document new component in README and changelog
- add Image demo page and nav entry in docs
- register Image route in docs App

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6875bca153ec8320a6cbd943383f9405