### PR TITLE
Add xl size for icon components

### DIFF
--- a/docs/src/pages/IconButtonDemoPage.tsx
+++ b/docs/src/pages/IconButtonDemoPage.tsx
@@ -71,7 +71,7 @@ export default function IconButtonDemoPage() {
     },
     {
       prop: <code>size</code>,
-      type: <code>'sm' | 'md' | 'lg'</code>,
+      type: <code>'sm' | 'md' | 'lg' | 'xl'</code>,
       default: <code>'md'</code>,
       description: 'Overall button dimensions',
     },
@@ -125,6 +125,7 @@ export default function IconButtonDemoPage() {
           <IconButton icon="mdi:play" size="sm" aria-label="Play small" />
           <IconButton icon="mdi:play" size="md" aria-label="Play medium" />
           <IconButton icon="mdi:play" size="lg" aria-label="Play large" />
+          <IconButton icon="mdi:play" size="xl" aria-label="Play extra" />
         </Stack>
 
         {/* 2. Outlined sizes ---------------------------------------------- */}
@@ -147,6 +148,12 @@ export default function IconButtonDemoPage() {
             icon="mdi:pause"
             size="lg"
             aria-label="Pause large"
+          />
+          <IconButton
+            variant="outlined"
+            icon="mdi:pause"
+            size="xl"
+            aria-label="Pause extra"
           />
         </Stack>
 

--- a/docs/src/pages/IconDemoPage.tsx
+++ b/docs/src/pages/IconDemoPage.tsx
@@ -78,9 +78,9 @@ export default function IconDemoPage() {
     },
     {
       prop: <code>size</code>,
-      type: <code>number | string</code>,
-      default: <code>'1em'</code>,
-      description: 'CSS size of the icon',
+      type: <code>'sm' | 'md' | 'lg' | 'xl' | number | string</code>,
+      default: <code>'md'</code>,
+      description: 'Icon dimensions',
     },
     {
       prop: <code>color</code>,
@@ -125,10 +125,10 @@ export default function IconDemoPage() {
         {/* 2. Sizing -------------------------------------------------------- */}
         <Typography variant="h3">2. Size prop</Typography>
         <Stack direction="row">
-          <Icon icon="mdi:home" size={16} aria-label="home-sm" />
-          <Icon icon="mdi:home" size="24px" aria-label="home-md" />
-          <Icon icon="mdi:home" size="2.5rem" aria-label="home-lg" />
-          <Icon icon="mdi:home" size={64} aria-label="home-xl" />
+          <Icon icon="mdi:home" size="sm" aria-label="home-sm" />
+          <Icon icon="mdi:home" size="md" aria-label="home-md" />
+          <Icon icon="mdi:home" size="lg" aria-label="home-lg" />
+          <Icon icon="mdi:home" size="xl" aria-label="home-xl" />
         </Stack>
 
         {/* 3. Color override ---------------------------------------------- */}

--- a/src/components/fields/IconButton.tsx
+++ b/src/components/fields/IconButton.tsx
@@ -13,7 +13,7 @@ import { Icon }                from '../primitives/Icon';
 /*───────────────────────────────────────────────────────────*/
 /* Public API                                                */
 export type IconButtonVariant = 'contained' | 'outlined';
-export type IconButtonSize    = 'sm' | 'md' | 'lg';
+export type IconButtonSize    = 'sm' | 'md' | 'lg' | 'xl';
 
 export interface IconButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -33,6 +33,7 @@ const geom: (t: Theme) => Record<IconButtonSize, Geometry> = () => ({
   sm: { d: '2.25rem', icon: '1rem'   },
   md: { d: '2.75rem', icon: '1.25rem'},
   lg: { d: '3.25rem', icon: '1.5rem' },
+  xl: { d: '3.75rem', icon: '1.75rem' },
 });
 
 /*───────────────────────────────────────────────────────────*/

--- a/src/components/primitives/Icon.tsx
+++ b/src/components/primitives/Icon.tsx
@@ -12,6 +12,8 @@ import { styled }              from '../../css/createStyled';
 import { preset }              from '../../css/stylePresets';
 import type { Presettable }    from '../../types';
 
+export type IconSize = 'sm' | 'md' | 'lg' | 'xl';
+
 /*───────────────────────────────────────────────────────────*/
 /* Public props                                              */
 /*  – We extend span-level attributes so they match <Wrapper> */
@@ -26,8 +28,8 @@ export interface IconProps
    * • **ReactElement** – a full `<svg>` element
    */
   svg?: string | ReactElement<SVGSVGElement>;
-  /** Icon size. `number` ⇒ "Npx", `string` ⇒ any CSS length. Default "1em". */
-  size?: number | string;
+  /** Icon size token or explicit CSS size. */
+  size?: IconSize | number | string;
   /** Explicit colour override; otherwise inherits `currentColor`. */
   color?: string | undefined;
 }
@@ -46,11 +48,18 @@ const Wrapper = styled('span')<{ $size: string }>`
   }
 `;
 
+const sizeMap: Record<IconSize, string> = {
+  sm: '1rem',
+  md: '1.25rem',
+  lg: '1.5rem',
+  xl: '1.75rem',
+};
+
 /*───────────────────────────────────────────────────────────*/
 export const Icon: React.FC<PropsWithChildren<IconProps>> = ({
   icon,
   svg,
-  size = '1em',
+  size = 'md',
   color,
   preset: p,
   className,
@@ -62,7 +71,10 @@ export const Icon: React.FC<PropsWithChildren<IconProps>> = ({
   const presetClasses = p ? preset(p) : '';
 
   /* ----- normalise size & colour ------------------------- */
-  const finalSize   = typeof size === 'number' ? `${size}px` : size;
+  const finalSize =
+    typeof size === 'number'
+      ? `${size}px`
+      : sizeMap[size as IconSize] ?? size;
   const colourStyle = color ? { color } : undefined;
 
   /*─────────────────────────────────────────────────────────*/


### PR DESCRIPTION
## Summary
- support `xl` size for `IconButton`
- add size tokens to `Icon`
- demo size tokens in docs

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6875cdfc42f88320b9e5375f6ed99bfb