### PR TITLE
Allow numeric IconButton sizes

### DIFF
--- a/docs/src/pages/CheckBoxDemo.tsx
+++ b/docs/src/pages/CheckBoxDemo.tsx
@@ -78,7 +78,7 @@ export default function CheckboxDemoPage() {
     },
     {
       prop: <code>size</code>,
-      type: <code>'sm' | 'md' | 'lg'</code>,
+      type: <code>'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | string</code>,
       default: <code>'md'</code>,
       description: 'Checkbox dimensions',
     },
@@ -153,13 +153,22 @@ export default function CheckboxDemoPage() {
         {/* 3. Sizes --------------------------------------------------------- */}
         <Typography variant="h3">3. Sizes</Typography>
         <Stack>
+          <Checkbox name="xs" size="xs" defaultChecked label="size='xs'" />
           <Checkbox name="sm" size="sm" defaultChecked label="size='sm'" />
           <Checkbox name="md" size="md" defaultChecked label="size='md'" />
           <Checkbox name="lg" size="lg" defaultChecked label="size='lg'" />
+          <Checkbox name="xl" size="xl" defaultChecked label="size='xl'" />
         </Stack>
 
-        {/* 4. Disabled ------------------------------------------------------ */}
-        <Typography variant="h3">4. Disabled</Typography>
+        {/* 4. Custom sizes ------------------------------------------------- */}
+        <Typography variant="h3">4. Custom sizes</Typography>
+        <Stack>
+          <Checkbox name="c1" size="3rem" defaultChecked label="size='3rem'" />
+          <Checkbox name="c2" size={28} defaultChecked label="size={28}" />
+        </Stack>
+
+        {/* 5. Disabled ------------------------------------------------------ */}
+        <Typography variant="h3">5. Disabled</Typography>
         <Stack>
           <Checkbox
             name="d1"
@@ -170,8 +179,8 @@ export default function CheckboxDemoPage() {
           <Checkbox name="d2" disabled label="disabled & unchecked" />
         </Stack>
 
-        {/* 5. FormControl integration -------------------------------------- */}
-        <Typography variant="h3">5. FormControl Binding</Typography>
+        {/* 6. FormControl integration -------------------------------------- */}
+        <Typography variant="h3">6. FormControl Binding</Typography>
         <FormControl
           useStore={useSignupForm}
           onSubmitValues={handleSubmit}
@@ -191,8 +200,8 @@ export default function CheckboxDemoPage() {
           </Button>
         </FormControl>
 
-          {/* 6. Live theme validation ---------------------------------------- */}
-          <Typography variant="h3">6. Theme coupling</Typography>
+          {/* 7. Live theme validation ---------------------------------------- */}
+          <Typography variant="h3">7. Theme coupling</Typography>
           <Button variant="outlined" onClick={toggleMode}>
             Toggle light / dark mode
           </Button>

--- a/docs/src/pages/IconButtonDemoPage.tsx
+++ b/docs/src/pages/IconButtonDemoPage.tsx
@@ -71,7 +71,7 @@ export default function IconButtonDemoPage() {
     },
     {
       prop: <code>size</code>,
-      type: <code>'sm' | 'md' | 'lg' | 'xl'</code>,
+      type: <code>'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | string</code>,
       default: <code>'md'</code>,
       description: 'Overall button dimensions',
     },
@@ -122,6 +122,7 @@ export default function IconButtonDemoPage() {
         {/* 1. Contained sizes --------------------------------------------- */}
         <Typography variant="h3">1. Contained sizes</Typography>
         <Stack direction="row">
+          <IconButton icon="mdi:play" size="xs" aria-label="Play xs" />
           <IconButton icon="mdi:play" size="sm" aria-label="Play small" />
           <IconButton icon="mdi:play" size="md" aria-label="Play medium" />
           <IconButton icon="mdi:play" size="lg" aria-label="Play large" />
@@ -131,6 +132,12 @@ export default function IconButtonDemoPage() {
         {/* 2. Outlined sizes ---------------------------------------------- */}
         <Typography variant="h3">2. Outlined sizes</Typography>
         <Stack direction="row">
+          <IconButton
+            variant="outlined"
+            icon="mdi:pause"
+            size="xs"
+            aria-label="Pause xs"
+          />
           <IconButton
             variant="outlined"
             icon="mdi:pause"
@@ -179,8 +186,15 @@ export default function IconButtonDemoPage() {
           <IconButton svg={HeartSvg} aria-label="Heart" />
         </Stack>
 
-        {/* 5. Disabled & active states ------------------------------------ */}
-        <Typography variant="h3">5. Disabled state</Typography>
+        {/* 5. Custom sizes ------------------------------------------------- */}
+        <Typography variant="h3">5. Custom sizes</Typography>
+        <Stack direction="row">
+          <IconButton icon="mdi:play" size="3rem" aria-label="Play 3rem" />
+          <IconButton icon="mdi:star" size={56} aria-label="Star 56px" />
+        </Stack>
+
+        {/* 6. Disabled & active states ------------------------------------ */}
+        <Typography variant="h3">6. Disabled state</Typography>
         <IconButton
           icon="mdi:delete"
           size="md"
@@ -188,8 +202,8 @@ export default function IconButtonDemoPage() {
           aria-label="Delete disabled"
         />
 
-        {/* 6. Preset usage ------------------------------------------------- */}
-        <Typography variant="h3">6. Preset integration</Typography>
+        {/* 7. Preset usage ------------------------------------------------- */}
+        <Typography variant="h3">7. Preset integration</Typography>
         <Box preset="actionCard">
           <IconButton
             icon="mdi:credit-card"
@@ -199,8 +213,8 @@ export default function IconButtonDemoPage() {
           <Typography>Pay now</Typography>
         </Box>
 
-        {/* 7. Theme coupling ---------------------------------------------- */}
-            <Typography variant="h3">7. Theme demonstration</Typography>
+        {/* 8. Theme coupling ---------------------------------------------- */}
+            <Typography variant="h3">8. Theme demonstration</Typography>
             <Button variant="outlined" onClick={toggleMode}>
               Toggle light / dark mode&nbsp;
               <Icon icon="mdi:theme-light-dark" size="1.2rem" />

--- a/docs/src/pages/IconDemoPage.tsx
+++ b/docs/src/pages/IconDemoPage.tsx
@@ -78,7 +78,7 @@ export default function IconDemoPage() {
     },
     {
       prop: <code>size</code>,
-      type: <code>'sm' | 'md' | 'lg' | 'xl' | number | string</code>,
+      type: <code>'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | string</code>,
       default: <code>'md'</code>,
       description: 'Icon dimensions',
     },
@@ -125,6 +125,7 @@ export default function IconDemoPage() {
         {/* 2. Sizing -------------------------------------------------------- */}
         <Typography variant="h3">2. Size prop</Typography>
         <Stack direction="row">
+          <Icon icon="mdi:home" size="xs" aria-label="home-xs" />
           <Icon icon="mdi:home" size="sm" aria-label="home-sm" />
           <Icon icon="mdi:home" size="md" aria-label="home-md" />
           <Icon icon="mdi:home" size="lg" aria-label="home-lg" />

--- a/src/components/fields/Checkbox.tsx
+++ b/src/components/fields/Checkbox.tsx
@@ -21,7 +21,7 @@ import type { Presettable } from '../../types';
 
 /*───────────────────────────────────────────────────────────────────────────*/
 /* Public prop contracts                                                    */
-export type CheckboxSize = 'sm' | 'md' | 'lg';
+export type CheckboxSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 export interface CheckboxProps
   extends Omit<
@@ -33,16 +33,18 @@ export interface CheckboxProps
   defaultChecked?: boolean;
   name: string;
   label?: ReactNode;
-  size?: CheckboxSize;
+  size?: CheckboxSize | number | string;
   onChange?: (checked: boolean, event: ChangeEvent<HTMLInputElement>) => void;
 }
 
 /*───────────────────────────────────────────────────────────────────────────*/
 /* Size map helper                                                          */
 const createSizeMap = (t: Theme) => ({
-  sm : { box: '16px', tick: '10px', gap: t.spacing(1) },
-  md : { box: '20px', tick: '12px', gap: t.spacing(1) },
-  lg : { box: '24px', tick: '14px', gap: t.spacing(1) },
+  xs: { box: '0.75rem', tick: 'calc(0.75rem * 0.6)', gap: t.spacing(1) },
+  sm: { box: '1rem',   tick: 'calc(1rem * 0.6)',   gap: t.spacing(1) },
+  md: { box: '1.25rem',tick: 'calc(1.25rem * 0.6)',gap: t.spacing(1) },
+  lg: { box: '1.5rem', tick: 'calc(1.5rem * 0.6)', gap: t.spacing(1) },
+  xl: { box: '1.75rem',tick: 'calc(1.75rem * 0.6)',gap: t.spacing(1) },
 } as const);
 
 /*───────────────────────────────────────────────────────────────────────────*/
@@ -158,7 +160,18 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   ) => {
     /* Theme & sizing ---------------------------------------------------- */
     const { theme, mode } = useTheme();
-    const SZ              = createSizeMap(theme)[size];
+    const map = createSizeMap(theme);
+
+    let SZ: { box: string; tick: string; gap: string };
+
+    if (typeof size === 'number') {
+      const box = `${size}px`;
+      SZ = { box, tick: `calc(${box} * 0.6)`, gap: theme.spacing(1) };
+    } else if (map[size as CheckboxSize]) {
+      SZ = map[size as CheckboxSize];
+    } else {
+      SZ = { box: size, tick: `calc(${size} * 0.6)`, gap: theme.spacing(1) };
+    }
 
     /* Disabled colour (same recipe as Accordion) ------------------------ */
     const disabledColor = toHex(

--- a/src/components/fields/IconButton.tsx
+++ b/src/components/fields/IconButton.tsx
@@ -13,13 +13,13 @@ import { Icon }                from '../primitives/Icon';
 /*───────────────────────────────────────────────────────────*/
 /* Public API                                                */
 export type IconButtonVariant = 'contained' | 'outlined';
-export type IconButtonSize    = 'sm' | 'md' | 'lg' | 'xl';
+export type IconButtonSize    = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 export interface IconButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     Presettable {
   variant?: IconButtonVariant;
-  size?: IconButtonSize;
+  size?: IconButtonSize | number | string;
   icon?: string;
   svg?: string | ReactElement<SVGSVGElement>;
   /** Colour override for the glyph */
@@ -30,6 +30,7 @@ export interface IconButtonProps
 /* Geometry map                                              */
 type Geometry = { d: string; icon: string };
 const geom: (t: Theme) => Record<IconButtonSize, Geometry> = () => ({
+  xs: { d: '1.75rem', icon: '0.75rem' },
   sm: { d: '2.25rem', icon: '1rem'   },
   md: { d: '2.75rem', icon: '1.25rem'},
   lg: { d: '3.25rem', icon: '1.5rem' },
@@ -112,7 +113,20 @@ export const IconButton: React.FC<IconButtonProps> = ({
   ...rest
 }) => {
   const { theme } = useTheme();
-  const { d: diam, icon: iconSz } = geom(theme)[size];
+  const sizes = geom(theme);
+
+  let diam: string;
+  let iconSz: string;
+
+  if (typeof size === 'number') {
+    diam = `${size}px`;
+    iconSz = `calc(${diam} * 0.45)`;
+  } else if (sizes[size as IconButtonSize]) {
+    ({ d: diam, icon: iconSz } = sizes[size as IconButtonSize]);
+  } else {
+    diam = size;
+    iconSz = `calc(${diam} * 0.45)`;
+  }
 
   const ripple =
     variant === 'contained'

--- a/src/components/primitives/Icon.tsx
+++ b/src/components/primitives/Icon.tsx
@@ -12,7 +12,7 @@ import { styled }              from '../../css/createStyled';
 import { preset }              from '../../css/stylePresets';
 import type { Presettable }    from '../../types';
 
-export type IconSize = 'sm' | 'md' | 'lg' | 'xl';
+export type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 /*───────────────────────────────────────────────────────────*/
 /* Public props                                              */
@@ -49,6 +49,7 @@ const Wrapper = styled('span')<{ $size: string }>`
 `;
 
 const sizeMap: Record<IconSize, string> = {
+  xs: '0.75rem',
   sm: '1rem',
   md: '1.25rem',
   lg: '1.5rem',


### PR DESCRIPTION
## Summary
- extend IconButton and Icon tokens with `xs`
- default to `md` and compute geometry for numbers
- document the new size options and showcase xs examples
- add custom size support for Checkbox with `xs` through `xl` tokens

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876c2113a5c8320a33c9490e357e5e2