### PR TITLE
Allow numeric IconButton sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- `RadioGroup` now supports `xs` through `xl` size tokens and accepts numeric or
+  string values for custom radio dimensions
 
 ## [0.11.3]
 - Adjusted IconButton and Button to have consistent sizing under the hood

--- a/docs/src/pages/CheckBoxDemo.tsx
+++ b/docs/src/pages/CheckBoxDemo.tsx
@@ -78,7 +78,7 @@ export default function CheckboxDemoPage() {
     },
     {
       prop: <code>size</code>,
-      type: <code>'sm' | 'md' | 'lg'</code>,
+      type: <code>'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | string</code>,
       default: <code>'md'</code>,
       description: 'Checkbox dimensions',
     },
@@ -153,13 +153,22 @@ export default function CheckboxDemoPage() {
         {/* 3. Sizes --------------------------------------------------------- */}
         <Typography variant="h3">3. Sizes</Typography>
         <Stack>
+          <Checkbox name="xs" size="xs" defaultChecked label="size='xs'" />
           <Checkbox name="sm" size="sm" defaultChecked label="size='sm'" />
           <Checkbox name="md" size="md" defaultChecked label="size='md'" />
           <Checkbox name="lg" size="lg" defaultChecked label="size='lg'" />
+          <Checkbox name="xl" size="xl" defaultChecked label="size='xl'" />
         </Stack>
 
-        {/* 4. Disabled ------------------------------------------------------ */}
-        <Typography variant="h3">4. Disabled</Typography>
+        {/* 4. Custom sizes ------------------------------------------------- */}
+        <Typography variant="h3">4. Custom sizes</Typography>
+        <Stack>
+          <Checkbox name="c1" size="3rem" defaultChecked label="size='3rem'" />
+          <Checkbox name="c2" size={28} defaultChecked label="size={28}" />
+        </Stack>
+
+        {/* 5. Disabled ------------------------------------------------------ */}
+        <Typography variant="h3">5. Disabled</Typography>
         <Stack>
           <Checkbox
             name="d1"
@@ -170,8 +179,8 @@ export default function CheckboxDemoPage() {
           <Checkbox name="d2" disabled label="disabled & unchecked" />
         </Stack>
 
-        {/* 5. FormControl integration -------------------------------------- */}
-        <Typography variant="h3">5. FormControl Binding</Typography>
+        {/* 6. FormControl integration -------------------------------------- */}
+        <Typography variant="h3">6. FormControl Binding</Typography>
         <FormControl
           useStore={useSignupForm}
           onSubmitValues={handleSubmit}
@@ -191,8 +200,8 @@ export default function CheckboxDemoPage() {
           </Button>
         </FormControl>
 
-          {/* 6. Live theme validation ---------------------------------------- */}
-          <Typography variant="h3">6. Theme coupling</Typography>
+          {/* 7. Live theme validation ---------------------------------------- */}
+          <Typography variant="h3">7. Theme coupling</Typography>
           <Button variant="outlined" onClick={toggleMode}>
             Toggle light / dark mode
           </Button>

--- a/docs/src/pages/IconButtonDemoPage.tsx
+++ b/docs/src/pages/IconButtonDemoPage.tsx
@@ -71,7 +71,7 @@ export default function IconButtonDemoPage() {
     },
     {
       prop: <code>size</code>,
-      type: <code>'sm' | 'md' | 'lg' | 'xl'</code>,
+      type: <code>'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | string</code>,
       default: <code>'md'</code>,
       description: 'Overall button dimensions',
     },
@@ -122,6 +122,7 @@ export default function IconButtonDemoPage() {
         {/* 1. Contained sizes --------------------------------------------- */}
         <Typography variant="h3">1. Contained sizes</Typography>
         <Stack direction="row">
+          <IconButton icon="mdi:play" size="xs" aria-label="Play xs" />
           <IconButton icon="mdi:play" size="sm" aria-label="Play small" />
           <IconButton icon="mdi:play" size="md" aria-label="Play medium" />
           <IconButton icon="mdi:play" size="lg" aria-label="Play large" />
@@ -131,6 +132,12 @@ export default function IconButtonDemoPage() {
         {/* 2. Outlined sizes ---------------------------------------------- */}
         <Typography variant="h3">2. Outlined sizes</Typography>
         <Stack direction="row">
+          <IconButton
+            variant="outlined"
+            icon="mdi:pause"
+            size="xs"
+            aria-label="Pause xs"
+          />
           <IconButton
             variant="outlined"
             icon="mdi:pause"
@@ -179,8 +186,15 @@ export default function IconButtonDemoPage() {
           <IconButton svg={HeartSvg} aria-label="Heart" />
         </Stack>
 
-        {/* 5. Disabled & active states ------------------------------------ */}
-        <Typography variant="h3">5. Disabled state</Typography>
+        {/* 5. Custom sizes ------------------------------------------------- */}
+        <Typography variant="h3">5. Custom sizes</Typography>
+        <Stack direction="row">
+          <IconButton icon="mdi:play" size="3rem" aria-label="Play 3rem" />
+          <IconButton icon="mdi:star" size={56} aria-label="Star 56px" />
+        </Stack>
+
+        {/* 6. Disabled & active states ------------------------------------ */}
+        <Typography variant="h3">6. Disabled state</Typography>
         <IconButton
           icon="mdi:delete"
           size="md"
@@ -188,8 +202,8 @@ export default function IconButtonDemoPage() {
           aria-label="Delete disabled"
         />
 
-        {/* 6. Preset usage ------------------------------------------------- */}
-        <Typography variant="h3">6. Preset integration</Typography>
+        {/* 7. Preset usage ------------------------------------------------- */}
+        <Typography variant="h3">7. Preset integration</Typography>
         <Box preset="actionCard">
           <IconButton
             icon="mdi:credit-card"
@@ -199,8 +213,8 @@ export default function IconButtonDemoPage() {
           <Typography>Pay now</Typography>
         </Box>
 
-        {/* 7. Theme coupling ---------------------------------------------- */}
-            <Typography variant="h3">7. Theme demonstration</Typography>
+        {/* 8. Theme coupling ---------------------------------------------- */}
+            <Typography variant="h3">8. Theme demonstration</Typography>
             <Button variant="outlined" onClick={toggleMode}>
               Toggle light / dark mode&nbsp;
               <Icon icon="mdi:theme-light-dark" size="1.2rem" />

--- a/docs/src/pages/IconDemoPage.tsx
+++ b/docs/src/pages/IconDemoPage.tsx
@@ -78,7 +78,7 @@ export default function IconDemoPage() {
     },
     {
       prop: <code>size</code>,
-      type: <code>'sm' | 'md' | 'lg' | 'xl' | number | string</code>,
+      type: <code>'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | string</code>,
       default: <code>'md'</code>,
       description: 'Icon dimensions',
     },
@@ -125,6 +125,7 @@ export default function IconDemoPage() {
         {/* 2. Sizing -------------------------------------------------------- */}
         <Typography variant="h3">2. Size prop</Typography>
         <Stack direction="row">
+          <Icon icon="mdi:home" size="xs" aria-label="home-xs" />
           <Icon icon="mdi:home" size="sm" aria-label="home-sm" />
           <Icon icon="mdi:home" size="md" aria-label="home-md" />
           <Icon icon="mdi:home" size="lg" aria-label="home-lg" />

--- a/docs/src/pages/RadioGroupDemo.tsx
+++ b/docs/src/pages/RadioGroupDemo.tsx
@@ -104,9 +104,9 @@ export default function RadioGroupDemoPage() {
     },
     {
       prop: <code>size</code>,
-      type: <code>'sm' | 'md' | 'lg'</code>,
+      type: <code>'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | string</code>,
       default: <code>'md'</code>,
-      description: 'Radio size token',
+      description: 'Radio size token or custom CSS measurement',
     },
     {
       prop: <code>spacing</code>,
@@ -172,6 +172,11 @@ export default function RadioGroupDemoPage() {
         {/* 3. Sizes --------------------------------------------------------- */}
         <Typography variant="h3">3. Sizes</Typography>
         <Stack direction="row">
+          <RadioGroup defaultValue="xs" size="xs">
+            <Radio value="xs" label="size='xs'" />
+            <Radio value="xs2" label="size='xs'" />
+            <Radio value="xs3" label="size='xs'" />
+          </RadioGroup>
           <RadioGroup defaultValue="sm" size="sm">
             <Radio value="sm" label="size='sm'" />
             <Radio value="sm2" label="size='sm'" />
@@ -186,6 +191,23 @@ export default function RadioGroupDemoPage() {
             <Radio value="lg" label="size='lg'" />
             <Radio value="lg2" label="size='lg'" />
             <Radio value="lg3" label="size='lg'" />
+          </RadioGroup>
+          <RadioGroup defaultValue="xl" size="xl">
+            <Radio value="xl" label="size='xl'" />
+            <Radio value="xl2" label="size='xl'" />
+            <Radio value="xl3" label="size='xl'" />
+          </RadioGroup>
+        </Stack>
+
+        <Typography variant="h4">Custom sizes</Typography>
+        <Stack direction="row">
+          <RadioGroup defaultValue="c1" size="3rem">
+            <Radio value="c1" label="size='3rem'" />
+            <Radio value="c2" label="size='3rem'" />
+          </RadioGroup>
+          <RadioGroup defaultValue="c3" size={28}>
+            <Radio value="c3" label="size={28}" />
+            <Radio value="c4" label="size={28}" />
           </RadioGroup>
         </Stack>
 

--- a/docs/src/pages/SelectDemo.tsx
+++ b/docs/src/pages/SelectDemo.tsx
@@ -90,7 +90,7 @@ export default function SelectDemoPage() {
     },
     {
       prop: <code>size</code>,
-      type: <code>'sm' | 'md' | 'lg'</code>,
+      type: <code>'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | string</code>,
       default: <code>'md'</code>,
       description: 'Control height',
     },
@@ -171,7 +171,7 @@ export default function SelectDemoPage() {
         {/* ————————————————— Sizes */}
         <Typography variant="h3">4. Size variants</Typography>
         <Stack direction="row">
-          {(['sm', 'md', 'lg'] as const).map((s) => (
+          {(['xs', 'sm', 'md', 'lg', 'xl'] as const).map((s) => (
             <Select key={s} size={s} placeholder={s.toUpperCase()}>
               <Select.Option value="a">A</Select.Option>
               <Select.Option value="b">B</Select.Option>
@@ -179,8 +179,19 @@ export default function SelectDemoPage() {
           ))}
         </Stack>
 
-        {/* ————————————————— Disabled / preset */}
-        <Typography variant="h3">5. Disabled & preset</Typography>
+        {/* ————————————————— Custom sizes */}
+        <Typography variant="h3">5. Custom sizes</Typography>
+        <Stack direction="row">
+          <Select size="3rem" placeholder="3rem">
+            <Select.Option value="x">X</Select.Option>
+          </Select>
+          <Select size={56} placeholder="56px">
+            <Select.Option value="y">Y</Select.Option>
+          </Select>
+        </Stack>
+
+        {/* ————————————————— Disabled & preset */}
+        <Typography variant="h3">6. Disabled & preset</Typography>
         <Stack direction="row">
           <Select disabled placeholder="Disabled">
             <Select.Option value="x">X</Select.Option>
@@ -193,7 +204,7 @@ export default function SelectDemoPage() {
         </Stack>
 
         {/* ————————————————— FormControl demo */}
-        <Typography variant="h3">6. FormControl integration</Typography>
+        <Typography variant="h3">7. FormControl integration</Typography>
         <FormControl
           useStore={useDemoForm}
           onSubmitValues={(vals) => setSubmitted(vals)}
@@ -241,7 +252,7 @@ export default function SelectDemoPage() {
         )}
 
         {/* ————————————————— Theme toggle */}
-        <Typography variant="h3">7. Theme toggle</Typography>
+        <Typography variant="h3">8. Theme toggle</Typography>
         <IconButton icon="mdi:weather-night" onClick={toggleMode} aria-label="toggle theme" />
           </Tabs.Panel>
 

--- a/src/components/fields/Checkbox.tsx
+++ b/src/components/fields/Checkbox.tsx
@@ -21,7 +21,7 @@ import type { Presettable } from '../../types';
 
 /*───────────────────────────────────────────────────────────────────────────*/
 /* Public prop contracts                                                    */
-export type CheckboxSize = 'sm' | 'md' | 'lg';
+export type CheckboxSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 export interface CheckboxProps
   extends Omit<
@@ -33,16 +33,18 @@ export interface CheckboxProps
   defaultChecked?: boolean;
   name: string;
   label?: ReactNode;
-  size?: CheckboxSize;
+  size?: CheckboxSize | number | string;
   onChange?: (checked: boolean, event: ChangeEvent<HTMLInputElement>) => void;
 }
 
 /*───────────────────────────────────────────────────────────────────────────*/
 /* Size map helper                                                          */
 const createSizeMap = (t: Theme) => ({
-  sm : { box: '16px', tick: '10px', gap: t.spacing(1) },
-  md : { box: '20px', tick: '12px', gap: t.spacing(1) },
-  lg : { box: '24px', tick: '14px', gap: t.spacing(1) },
+  xs: { box: '0.75rem', tick: 'calc(0.75rem * 0.6)', gap: t.spacing(1) },
+  sm: { box: '1rem',   tick: 'calc(1rem * 0.6)',   gap: t.spacing(1) },
+  md: { box: '1.25rem',tick: 'calc(1.25rem * 0.6)',gap: t.spacing(1) },
+  lg: { box: '1.5rem', tick: 'calc(1.5rem * 0.6)', gap: t.spacing(1) },
+  xl: { box: '1.75rem',tick: 'calc(1.75rem * 0.6)',gap: t.spacing(1) },
 } as const);
 
 /*───────────────────────────────────────────────────────────────────────────*/
@@ -158,7 +160,18 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
   ) => {
     /* Theme & sizing ---------------------------------------------------- */
     const { theme, mode } = useTheme();
-    const SZ              = createSizeMap(theme)[size];
+    const map = createSizeMap(theme);
+
+    let SZ: { box: string; tick: string; gap: string };
+
+    if (typeof size === 'number') {
+      const box = `${size}px`;
+      SZ = { box, tick: `calc(${box} * 0.6)`, gap: theme.spacing(1) };
+    } else if (map[size as CheckboxSize]) {
+      SZ = map[size as CheckboxSize];
+    } else {
+      SZ = { box: size, tick: `calc(${size} * 0.6)`, gap: theme.spacing(1) };
+    }
 
     /* Disabled colour (same recipe as Accordion) ------------------------ */
     const disabledColor = toHex(

--- a/src/components/fields/IconButton.tsx
+++ b/src/components/fields/IconButton.tsx
@@ -13,13 +13,13 @@ import { Icon }                from '../primitives/Icon';
 /*───────────────────────────────────────────────────────────*/
 /* Public API                                                */
 export type IconButtonVariant = 'contained' | 'outlined';
-export type IconButtonSize    = 'sm' | 'md' | 'lg' | 'xl';
+export type IconButtonSize    = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 export interface IconButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     Presettable {
   variant?: IconButtonVariant;
-  size?: IconButtonSize;
+  size?: IconButtonSize | number | string;
   icon?: string;
   svg?: string | ReactElement<SVGSVGElement>;
   /** Colour override for the glyph */
@@ -30,6 +30,7 @@ export interface IconButtonProps
 /* Geometry map                                              */
 type Geometry = { d: string; icon: string };
 const geom: (t: Theme) => Record<IconButtonSize, Geometry> = () => ({
+  xs: { d: '1.75rem', icon: '0.75rem' },
   sm: { d: '2.25rem', icon: '1rem'   },
   md: { d: '2.75rem', icon: '1.25rem'},
   lg: { d: '3.25rem', icon: '1.5rem' },
@@ -112,7 +113,20 @@ export const IconButton: React.FC<IconButtonProps> = ({
   ...rest
 }) => {
   const { theme } = useTheme();
-  const { d: diam, icon: iconSz } = geom(theme)[size];
+  const sizes = geom(theme);
+
+  let diam: string;
+  let iconSz: string;
+
+  if (typeof size === 'number') {
+    diam = `${size}px`;
+    iconSz = `calc(${diam} * 0.45)`;
+  } else if (sizes[size as IconButtonSize]) {
+    ({ d: diam, icon: iconSz } = sizes[size as IconButtonSize]);
+  } else {
+    diam = size;
+    iconSz = `calc(${diam} * 0.45)`;
+  }
 
   const ripple =
     variant === 'contained'

--- a/src/components/fields/RadioGroup.tsx
+++ b/src/components/fields/RadioGroup.tsx
@@ -25,13 +25,13 @@ import type { Presettable } from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
 /* Context                                                   */
-type RadioSize = 'sm' | 'md' | 'lg';
+export type RadioSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 interface RadioCtx {
   value   : string | null;
   setValue: (v: string) => void;
   name    : string;
-  size    : RadioSize;
+  size    : RadioSize | number | string;
 }
 
 const RadioGroupCtx = createContext<RadioCtx | null>(null);
@@ -44,9 +44,11 @@ const useRadioGroup = () => {
 /*───────────────────────────────────────────────────────────*/
 /* Size map helper                                           */
 const createSizeMap = (t: Theme) => ({
-  sm: { indicator: '16px', dot: '10px', gapInner: t.spacing(0.75) },
-  md: { indicator: '20px', dot: '12px', gapInner: t.spacing(0.75) },
-  lg: { indicator: '24px', dot: '14px', gapInner: t.spacing(1) },
+  xs: { indicator: '0.75rem', dot: 'calc(0.75rem * 0.6)', gapInner: t.spacing(0.75) },
+  sm: { indicator: '1rem',    dot: 'calc(1rem * 0.6)',    gapInner: t.spacing(0.75) },
+  md: { indicator: '1.25rem', dot: 'calc(1.25rem * 0.6)', gapInner: t.spacing(0.75) },
+  lg: { indicator: '1.5rem',  dot: 'calc(1.5rem * 0.6)',  gapInner: t.spacing(1)    },
+  xl: { indicator: '1.75rem', dot: 'calc(1.75rem * 0.6)', gapInner: t.spacing(1)    },
 });
 
 /*───────────────────────────────────────────────────────────*/
@@ -88,7 +90,7 @@ export interface RadioGroupProps
   defaultValue? : string;
   name?         : string;
   row?          : boolean;
-  size?         : RadioSize;
+  size?         : RadioSize | number | string;
   /** Gap between options */
   spacing?      : number | string;
   onChange?     : (val: string) => void;
@@ -103,7 +105,7 @@ export interface RadioProps
     Presettable {
   value   : string;
   label?  : string;
-  size?   : RadioSize;
+  size?   : RadioSize | number | string;
   children?: ReactNode;
 }
 
@@ -281,7 +283,27 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(
     const { value: sel, setValue, name, size: groupSize } = useRadioGroup();
 
     const token   = sizeProp ?? groupSize;
-    const SZ      = createSizeMap(theme)[token];
+    const map     = createSizeMap(theme);
+
+    let SZ: { indicator: string; dot: string; gapInner: string };
+
+    if (typeof token === 'number') {
+      const ind = `${token}px`;
+      SZ = {
+        indicator: ind,
+        dot      : `calc(${ind} * 0.6)`,
+        gapInner : theme.spacing(0.75),
+      };
+    } else if (map[token as RadioSize]) {
+      SZ = map[token as RadioSize];
+    } else {
+      const ind = token as string;
+      SZ = {
+        indicator: ind,
+        dot      : `calc(${ind} * 0.6)`,
+        gapInner : theme.spacing(0.75),
+      };
+    }
     const checked = sel === value;
 
     /* Disabled colour (Accordion recipe) ------------------------------- */

--- a/src/components/fields/Select.tsx
+++ b/src/components/fields/Select.tsx
@@ -23,6 +23,8 @@ import React, {
   
   /*───────────────────────────────────────────────────────────*/
   /* Public props                                              */
+  export type SelectSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+
   export interface SelectProps
     extends Omit<
         React.HTMLAttributes<HTMLDivElement>,
@@ -39,8 +41,8 @@ import React, {
     multiple?: boolean;
     /** Placeholder when nothing selected. */
     placeholder?: string;
-    /** Size token */
-    size?: 'sm' | 'md' | 'lg';
+    /** Size token or custom measurement */
+    size?: SelectSize | number | string;
     disabled?: boolean;
     /** Field name for FormControl binding. */
     name?: string;
@@ -57,16 +59,18 @@ import React, {
   /*───────────────────────────────────────────────────────────*/
   /* Size tokens                                               */
   const geom = (t: Theme) => ({
-    sm: { h: 30, pad: 8,  font: '0.75rem'  },
-    md: { h: 38, pad: 10, font: '0.875rem' },
-    lg: { h: 46, pad: 12, font: '1rem'     },
+    xs: { h: '1.5rem',  pad: t.spacing(0.75), font: '0.625rem'  },
+    sm: { h: '1.875rem', pad: t.spacing(1),    font: '0.75rem'   },
+    md: { h: '2.375rem', pad: t.spacing(1.25), font: '0.875rem'  },
+    lg: { h: '2.875rem', pad: t.spacing(1.5),  font: '1rem'      },
+    xl: { h: '3.375rem', pad: t.spacing(1.75), font: '1.125rem'  },
   }) as const;
   
   /*───────────────────────────────────────────────────────────*/
   /* Styled primitives                                         */
   const Trigger = styled('button')<{
-    $h: number;
-    $pad: number;
+    $h: string;
+    $pad: string;
     $bg: string;
     $text: string;
     $primary: string;
@@ -74,8 +78,8 @@ import React, {
     all: unset;
     box-sizing: border-box;
     width: 100%;
-    height: ${({ $h }) => $h}px;
-    padding: 0 ${({ $pad }) => $pad}px;
+    height: ${({ $h }) => $h};
+    padding: 0 ${({ $pad }) => $pad};
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -125,9 +129,9 @@ import React, {
   `;
   
   const Item = styled('li')<{
-    $pad: number; $active?: boolean; $disabled?: boolean; $primary: string;
+    $pad: string; $active?: boolean; $disabled?: boolean; $primary: string;
   }>`
-    padding: 6px ${({ $pad }) => $pad}px;
+    padding: 6px ${({ $pad }) => $pad};
     cursor: ${({ $disabled }) => ($disabled ? 'not-allowed' : 'pointer')};
     opacity:${({ $disabled }) => ($disabled ? .45 : 1)};
     background:${({ $active,$primary }) => $active ? $primary+'22' : 'transparent'};
@@ -167,8 +171,21 @@ import React, {
     } = props;
   
     /* theme + geometry --------------------------------------- */
-    const { theme }       = useTheme();
-    const g               = geom(theme)[size];
+    const { theme } = useTheme();
+    const map = geom(theme);
+
+    let g: { h: string; pad: string; font: string };
+
+    if (typeof size === 'number') {
+      const h = `${size}px`;
+      g = { h, pad: `${size * 0.26}px`, font: `calc(${h} * 0.35)` };
+    } else if (map[size as SelectSize]) {
+      g = map[size as SelectSize];
+    } else {
+      const h = size;
+      g = { h, pad: `calc(${size} * 0.26)`, font: `calc(${size} * 0.35)` };
+    }
+
     const textCol         = theme.colors.text;
     const bg              = theme.colors.surface;
     const bgElev          = theme.colors.surfaceElevated ?? theme.colors.backgroundAlt ?? bg;

--- a/src/components/primitives/Icon.tsx
+++ b/src/components/primitives/Icon.tsx
@@ -12,7 +12,7 @@ import { styled }              from '../../css/createStyled';
 import { preset }              from '../../css/stylePresets';
 import type { Presettable }    from '../../types';
 
-export type IconSize = 'sm' | 'md' | 'lg' | 'xl';
+export type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
 /*───────────────────────────────────────────────────────────*/
 /* Public props                                              */
@@ -49,6 +49,7 @@ const Wrapper = styled('span')<{ $size: string }>`
 `;
 
 const sizeMap: Record<IconSize, string> = {
+  xs: '0.75rem',
   sm: '1rem',
   md: '1.25rem',
   lg: '1.5rem',


### PR DESCRIPTION
## Summary
- extend IconButton and Icon tokens with `xs`
- default to `md` and compute geometry for numbers
- document the new size options and showcase xs examples
- add custom size support for Checkbox with `xs` through `xl` tokens
- allow custom units for Select size prop
- enable custom numeric sizes for RadioGroup

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6876c2113a5c8320a33c9490e357e5e2