### PR TITLE
Update Button size options

### DIFF
--- a/docs/src/pages/ButtonDemoPage.tsx
+++ b/docs/src/pages/ButtonDemoPage.tsx
@@ -57,9 +57,9 @@ export default function ButtonDemoPage() {
     },
     {
       prop: <code>size</code>,
-      type: <code>'sm' | 'md' | 'lg'</code>,
+      type: <code>'xs' | 'sm' | 'md' | 'lg' | 'xl' | number | string</code>,
       default: <code>'md'</code>,
-      description: 'Overall button scale',
+      description: 'Overall button size or custom CSS length',
     },
     {
       prop: <code>fullWidth</code>,
@@ -101,9 +101,15 @@ export default function ButtonDemoPage() {
         {/* 2 ▸ Sizes ----------------------------------------------------- */}
         <Typography variant="h3">2. Sizes</Typography>
         <Stack direction="row">
+          <Button size="xs">xs</Button>
           <Button size="sm">sm</Button>
           <Button>md (default)</Button>
           <Button size="lg">lg</Button>
+          <Button size="xl">xl</Button>
+        </Stack>
+        <Stack direction="row">
+          <Button size="2rem">2rem</Button>
+          <Button size="32px">32px</Button>
         </Stack>
 
         {/* 3 ▸ Full-width ---------------------------------------------- */}

--- a/src/components/fields/Button.tsx
+++ b/src/components/fields/Button.tsx
@@ -12,7 +12,7 @@ import type { Presettable } from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
 export type ButtonVariant = 'contained' | 'outlined';
-export type ButtonSize    = 'sm' | 'md' | 'lg';
+export type ButtonSize    = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 export type ButtonToken   = 'primary' | 'secondary' | 'tertiary';
 
 export interface ButtonProps
@@ -21,15 +21,17 @@ export interface ButtonProps
   color?     : ButtonToken | string;
   textColor? : ButtonToken | string;
   variant?   : ButtonVariant;
-  size?      : ButtonSize;
+  size?      : ButtonSize | number | string;
   fullWidth? : boolean;
 }
 
 /*───────────────────────────────────────────────────────────*/
 const createSizeMap = (t: Theme) => ({
-  sm: { padV: t.spacing(1), padH: t.spacing(1), font: '1rem',  height: '2rem'  },
-  md: { padV: t.spacing(1), padH: t.spacing(1), font: '1rem', height: '2.5rem'},
-  lg: { padV: t.spacing(1), padH: t.spacing(1), font: '1rem',     height: '3rem'  },
+  xs: { padV: t.spacing(1), padH: t.spacing(1), font: '1rem', height: '1.5rem' },
+  sm: { padV: t.spacing(1), padH: t.spacing(1), font: '1rem', height: '2rem'   },
+  md: { padV: t.spacing(1), padH: t.spacing(1), font: '1rem', height: '2.5rem' },
+  lg: { padV: t.spacing(1), padH: t.spacing(1), font: '1rem', height: '3rem'   },
+  xl: { padV: t.spacing(1), padH: t.spacing(1), font: '1rem', height: '3.5rem' },
 } as const);
 
 /*───────────────────────────────────────────────────────────*/
@@ -129,7 +131,19 @@ export const Button: React.FC<ButtonProps> = ({
   ...rest
 }) => {
   const { theme, mode } = useTheme();
-  const { padV, padH, font, height } = createSizeMap(theme)[size];
+  const map = createSizeMap(theme);
+  let geom: { padV: string; padH: string; font: string; height: string };
+
+  if (typeof size === 'number') {
+    const h = `${size}px`;
+    geom = { padV: theme.spacing(1), padH: theme.spacing(1), font: '1rem', height: h };
+  } else if (map[size as ButtonSize]) {
+    geom = map[size as ButtonSize];
+  } else {
+    geom = { padV: theme.spacing(1), padH: theme.spacing(1), font: '1rem', height: size as string };
+  }
+
+  const { padV, padH, font, height } = geom;
 
   const padRule =
     variant === 'outlined'


### PR DESCRIPTION
## Summary
- allow more button size tokens and custom CSS lengths
- document new size options in the Button demo

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6876ebc522a08320bacba238f0f371a8