### PR TITLE
Adjust toggle button transparency

### DIFF
--- a/src/components/widgets/Drawer.tsx
+++ b/src/components/widgets/Drawer.tsx
@@ -13,6 +13,7 @@ import { shallow } from 'zustand/shallow';
 import { preset } from '../../css/stylePresets';
 import type { Presettable } from '../../types';
 import { IconButton } from '../fields/IconButton';
+import { withAlpha } from '../../helpers/color';
 
 /*───────────────────────────────────────────────────────────*/
 export type DrawerAnchor = 'left' | 'right' | 'top' | 'bottom';
@@ -139,6 +140,7 @@ export const Drawer: React.FC<DrawerProps> = ({
     ? parseFloat(window.getComputedStyle(element).marginTop || '0')
     : 0;
   const presetClasses = presetKey ? preset(presetKey) : '';
+  const toggleBg = withAlpha(theme.colors.primary, 0.7);
   const portrait = height > width;
   const adaptiveMode = adaptive && (anchor === 'left' || anchor === 'right');
   const orientationPersistent = adaptiveMode && !portrait;
@@ -214,6 +216,7 @@ export const Drawer: React.FC<DrawerProps> = ({
             top: `calc(${theme.spacing(1)} + ${surfOffset}px)`,
             [anchor]: theme.spacing(1),
             zIndex: 9999,
+            background: toggleBg,
           }}
           aria-label="Open drawer"
         />

--- a/src/helpers/color.ts
+++ b/src/helpers/color.ts
@@ -44,6 +44,13 @@ export function toHex({ r, g, b }: RGB): string {
   return '#' + (((1 << 24) | (r << 16) | (g << 8) | b).toString(16).slice(1));
 }
 
+/*──────────── Hex → RGBA string ────────────*/
+export function withAlpha(hex: string, alpha: number): string {
+  const { r, g, b } = toRgb(hex);
+  const a = alpha <= 0 ? 0 : alpha >= 1 ? 1 : alpha;
+  return `rgba(${r}, ${g}, ${b}, ${a})`;
+}
+
 /*──────────── Cached zebra-stripe colour ────────────*/
 const stripeCache = new Map<string, string>();
 


### PR DESCRIPTION
## Summary
- expose `withAlpha` color helper
- give adaptive drawer toggle a semi-transparent background

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6876ec86a2a8832093a362e17223f473