### PR TITLE
Add centered prop to Panel

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -2,4 +2,3 @@
 
 - Table has visual artificats on iOS
 - Chat bubble width could be better on tall / mobile
-- panel needs a centered prop like box and typography

--- a/docs/src/pages/PanelDemo.tsx
+++ b/docs/src/pages/PanelDemo.tsx
@@ -116,6 +116,14 @@ export default function PanelDemoPage() {
           </Panel>
         </Stack>
 
+        {/* 8. centered prop ----------------------------------------------- */}
+        <Typography variant="h3">8. centered&nbsp;prop</Typography>
+        <Panel centered style={{ padding: theme.spacing(1), minHeight: 80 }}>
+          <Typography>
+            Contents centered with <code>centered</code>
+          </Typography>
+        </Panel>
+
         {/* 9. Live theme validation ---------------------------------------- */}
         <Typography variant="h3">9. Theme coupling</Typography>
         <Button variant="outlined" onClick={toggleMode}>

--- a/docs/src/pages/PanelDemo.tsx
+++ b/docs/src/pages/PanelDemo.tsx
@@ -61,10 +61,6 @@ export default function PanelDemoPage() {
         <Typography variant="h3">4. fullWidth&nbsp;prop</Typography>
         <Panel
           fullWidth
-          style={{
-            padding: theme.spacing(1),
-            textAlign: 'center',
-          }}
         >
           <Typography>Stretch me edge-to-edge with <code>fullWidth</code></Typography>
         </Panel>
@@ -118,7 +114,7 @@ export default function PanelDemoPage() {
 
         {/* 8. centered prop ----------------------------------------------- */}
         <Typography variant="h3">8. centered&nbsp;prop</Typography>
-        <Panel centered style={{ padding: theme.spacing(1), minHeight: 80 }}>
+        <Panel centered fullWidth>
           <Typography>
             Contents centered with <code>centered</code>
           </Typography>

--- a/docs/src/pages/PropPatterns.tsx
+++ b/docs/src/pages/PropPatterns.tsx
@@ -63,7 +63,7 @@ export default function UsagePage() {
     {
       prop: <code>centered</code>,
       purpose: 'Center content or text',
-      components: 'Box, Typography',
+      components: 'Box, Typography, Panel',
     },
     {
       prop: <code>open</code>,

--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -19,6 +19,8 @@ export interface PanelProps
   fullWidth?: boolean;
   /** Explicit background override */
   background?: string | undefined;
+  /** Centre contents & propagate intent via CSS var */
+  centered?: boolean;
   /** Remove built-in margin and padding */
   compact?: boolean;
 }
@@ -28,6 +30,7 @@ export interface PanelProps
 const Base = styled('div')<{
   $variant: PanelVariant;
   $full?: boolean;
+  $center?: boolean;
   $outline?: string;
   $bg?: string;
   $text?: string;
@@ -37,13 +40,21 @@ const Base = styled('div')<{
   box-sizing: border-box;
   vertical-align: top;
 
-  display      : ${({ $full }) => ($full ? 'block' : 'inline-block')};
+  display      : ${({ $center, $full }) =>
+    $center ? 'flex' : $full ? 'block' : 'inline-block'};
   width        : ${({ $full }) => ($full ? '100%'  : 'auto')};
   align-self   : ${({ $full }) => ($full ? 'stretch' : 'flex-start')};
   margin       : ${({ $margin }) => $margin};
   & > * {
     padding: ${({ $pad }) => $pad};
   }
+
+  ${({ $center }) =>
+    $center &&
+    `
+      justify-content: center;
+      align-items: center;
+    `}
 
   /* Only emit a background when we’ve actually been given one */
   ${({ $variant, $bg }) =>
@@ -63,6 +74,9 @@ const Base = styled('div')<{
       color: ${$text};
       --valet-text-color: ${$text};
     `}
+
+  ${({ $center }) =>
+    $center !== undefined && `--valet-centered: ${$center ? '1' : '0'};`}
 `;
 
 /*───────────────────────────────────────────────────────────*/
@@ -70,6 +84,7 @@ const Base = styled('div')<{
 export const Panel: React.FC<PanelProps> = ({
   variant   = 'main',
   fullWidth = false,
+  centered,
   preset: p,
   className,
   style,
@@ -115,6 +130,7 @@ export const Panel: React.FC<PanelProps> = ({
       {...rest}
       $variant={variant}
       $full={fullWidth}
+      $center={centered}
       $outline={theme.colors.backgroundAlt}
       $bg={bg}
       $text={textColour}


### PR DESCRIPTION
## Summary
- enable `centered` on `<Panel>`
- show usage of the new prop in the Panel demo

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6876efd36ccc83209ae5b3668f73d532