### PR TITLE
Rename Chat widget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ component rather than the page. Pass `constrainHeight={false}` to opt out.
 - **Box** – baseline container that handles background, text colour and centring.
 - **Button** – theme-aware button with variants and sizes.
 - **Checkbox** – controlled/uncontrolled checkbox adhering to accessibility.
-- **Chat** – conversation UI with OpenAI message format and optional height constraint.
+- **OAIChat** – conversation UI with OpenAI message format and optional height constraint.
 - **Drawer** – sliding overlay panel with escape handling and backdrop.
 - **FormControl** – context provider wiring labels, errors and disabled state.
 - **Grid** – CSS grid layout helper with gaps and spans.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ These have been mostly tested in the [valet Docs](https://github.com/off-court-c
 | Box           |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
 | Button        |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
 | Checkbox      |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
-| Chat          |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
+| OAIChat          |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
 | DateTimePicker|  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
 | Drawer        |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
 | FormControl   |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -26,7 +26,7 @@ const IconDemoPage          = page(() => import('./pages/IconDemoPage'));
 const IconButtonDemoPage    = page(() => import('./pages/IconButtonDemoPage'));
 const ImageDemoPage         = page(() => import('./pages/ImageDemo'));
 const AvatarDemoPage        = page(() => import('./pages/AvatarDemo'));
-const ChatDemoPage          = page(() => import('./pages/ChatDemo'));
+const OAIChatDemoPage          = page(() => import('./pages/OAIChatDemo'));
 const PanelDemoPage         = page(() => import('./pages/PanelDemo'));
 const CheckboxDemoPage      = page(() => import('./pages/CheckBoxDemo'));
 const TooltipDemoPage       = page(() => import('./pages/TooltipDemo'));
@@ -120,7 +120,7 @@ export function App() {
         <Route path="/stepper-demo"    element={<StepperDemoPage />} />
         <Route path="/radio-demo"      element={<RadioGroupDemoPage />} />
         <Route path="/video-demo"      element={<VideoDemoPage />} />
-        <Route path="/chat-demo"       element={<ChatDemoPage />} />
+        <Route path="/chat-demo"       element={<OAIChatDemoPage />} />
         <Route path="/snackbar-demo"   element={<SnackbarDemoPage />} />
         <Route path="/tree-demo"      element={<TreeDemoPage />} />
         <Route path="/datetime-demo"  element={<DateTimeDemoPage />} />

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -49,7 +49,7 @@ const fields: [string, string][] = [
 const widgets: [string, string][] = [
   ['Accordion', '/accordion-demo'],
   ['AppBar', '/appbar-demo'],
-  ['Chat', '/chat-demo'],
+  ['OAIChat', '/chat-demo'],
   ['Drawer', '/drawer-demo'],
   ['List', '/list-demo'],
   ['Pagination', '/pagination-demo'],

--- a/docs/src/pages/OAIChatDemo.tsx
+++ b/docs/src/pages/OAIChatDemo.tsx
@@ -1,6 +1,6 @@
 // ─────────────────────────────────────────────────────────────────────────────
-// src/pages/ChatDemo.tsx
-// Simple showcase for <Chat /> component
+// src/pages/OAIChatDemo.tsx | valet
+// Simple showcase for <OAIChat /> component
 // ─────────────────────────────────────────────────────────────────────────────
 import { useState } from 'react';
 import {
@@ -8,7 +8,7 @@ import {
   Stack,
   Typography,
   Button,
-  Chat,
+  OAIChat,
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
@@ -17,7 +17,7 @@ import type { ChatMessage } from '@archway/valet';
 import monkey from '../assets/monkey.jpg';
 import present from '../assets/present.jpg';
 
-export default function ChatDemoPage() {
+export default function OAIChatDemoPage() {
   const navigate = useNavigate();
   const { theme, toggleMode } = useTheme();
   const [messages, setMessages] = useState<ChatMessage[]>([
@@ -40,10 +40,10 @@ export default function ChatDemoPage() {
           Chat Showcase
         </Typography>
         <Typography variant="subtitle">
-          Chat component with OpenAI style messages
+          OAIChat component with OpenAI style messages
         </Typography>
 
-        <Chat
+        <OAIChat
           messages={messages}
           onSend={handleSend}
           constrainHeight

--- a/docs/src/pages/PropPatterns.tsx
+++ b/docs/src/pages/PropPatterns.tsx
@@ -73,7 +73,7 @@ export default function UsagePage() {
     {
       prop: <code>constrainHeight</code>,
       purpose: 'Clamp height using Surface metrics',
-      components: 'Accordion, Chat, Table',
+      components: 'Accordion, OAIChat, Table',
     },
     {
       prop: <code>value</code>,

--- a/src/components/widgets/OAIChat.tsx
+++ b/src/components/widgets/OAIChat.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/widgets/Chat.tsx  | valet
+// src/components/widgets/OAIChat.tsx  | valet
 // OpenAI style chat component with height constraint
 // ─────────────────────────────────────────────────────────────
 import React, {
@@ -78,7 +78,7 @@ const InputRow = styled('form') <{ $gap: string }>`
 
 /*───────────────────────────────────────────────────────────*/
 /* Component                                                  */
-export const Chat: React.FC<ChatProps> = ({
+export const OAIChat: React.FC<ChatProps> = ({
   messages,
   onSend,
   userAvatar,
@@ -249,4 +249,4 @@ export const Chat: React.FC<ChatProps> = ({
   );
 };
 
-export default Chat;
+export default OAIChat;

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export * from './components/fields/TextField';
 // ─── Widgets ─────────────────────────────────────────────────
 export * from './components/widgets/Accordion';
 export * from './components/widgets/AppBar';
-export * from './components/widgets/Chat';
+export * from './components/widgets/OAIChat';
 export * from './components/widgets/Drawer';
 export * from './components/widgets/List';
 export * from './components/widgets/LoadingBackdrop';


### PR DESCRIPTION
## Summary
- rename Chat widget to OAIChat
- adjust exports and demo imports
- update component lists and docs
- rename ChatDemo to OAIChatDemo

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877f601280c8320b43c50700a9e486d