### PR TITLE
Add DateSelector widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Added `DateSelector` widget – compact calendar component
 
 ## [0.13.0]
 - Renamed `Chat` to `OAIChat`

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -52,6 +52,7 @@ const VideoDemoPage         = page(() => import('./pages/VideoDemo'));
 const SnackbarDemoPage      = page(() => import('./pages/SnackbarDemo'));
 const TreeDemoPage          = page(() => import('./pages/TreeDemo'));
 const DateTimeDemoPage      = page(() => import('./pages/DateTimeDemo'));
+const DateSelectorDemoPage  = page(() => import('./pages/DateSelectorDemo'));
 const OverviewPage          = page(() => import('./pages/Overview'));
 const InstallationPage      = page(() => import('./pages/Installation'));
 const UsagePage             = page(() => import('./pages/Usage'));
@@ -124,6 +125,7 @@ export function App() {
         <Route path="/snackbar-demo"   element={<SnackbarDemoPage />} />
         <Route path="/tree-demo"      element={<TreeDemoPage />} />
         <Route path="/datetime-demo"  element={<DateTimeDemoPage />} />
+        <Route path="/dateselector-demo" element={<DateSelectorDemoPage />} />
         <Route path="/prop-patterns"  element={<PropPatternsPage />} />
       </Routes>
     </Suspense>

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -37,6 +37,7 @@ const layoutPrimitives: [string, string][] = [
 const fields: [string, string][] = [
   ['Button', '/button-demo'],
   ['Checkbox', '/checkbox-demo'],
+  ['Date Selector', '/dateselector-demo'],
   ['DateTime Picker', '/datetime-demo'],
   ['Icon Button', '/icon-button-demo'],
   ['Radio Group', '/radio-demo'],
@@ -56,7 +57,6 @@ const widgets: [string, string][] = [
   ['Parallax', '/parallax'],
   ['Snackbar', '/snackbar-demo'],
   ['Speed Dial', '/speeddial-demo'],
-  ['Date Selector', '/dateselector-demo'],
   ['Stepper', '/stepper-demo'],
   ['Table', '/table-demo'],
   ['Tabs', '/tabs-demo'],

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -56,6 +56,7 @@ const widgets: [string, string][] = [
   ['Parallax', '/parallax'],
   ['Snackbar', '/snackbar-demo'],
   ['Speed Dial', '/speeddial-demo'],
+  ['Date Selector', '/dateselector-demo'],
   ['Stepper', '/stepper-demo'],
   ['Table', '/table-demo'],
   ['Tabs', '/tabs-demo'],

--- a/docs/src/pages/DateSelectorDemo.tsx
+++ b/docs/src/pages/DateSelectorDemo.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   DateSelector,
   useTheme,
+  Grid,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
 import NavDrawer from '../components/NavDrawer';
@@ -29,6 +30,14 @@ export default function DateSelectorDemoPage() {
 
         <DateSelector value={selected} onChange={setSelected} />
         <Typography variant="body">Current: {selected}</Typography>
+
+        <Grid columns={3} adaptive>
+          <DateSelector value={selected} onChange={setSelected} />
+        </Grid>
+
+        <Grid columns={5} adaptive>
+          <DateSelector value={selected} onChange={setSelected} />
+        </Grid>
 
         <Stack direction="row">
           <Button variant="outlined" onClick={toggleMode}>

--- a/docs/src/pages/DateSelectorDemo.tsx
+++ b/docs/src/pages/DateSelectorDemo.tsx
@@ -1,0 +1,42 @@
+// src/pages/DateSelectorDemo.tsx
+import { useState } from 'react';
+import {
+  Surface,
+  Stack,
+  Typography,
+  Button,
+  DateSelector,
+  useTheme,
+} from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
+
+export default function DateSelectorDemoPage() {
+  const { theme, toggleMode } = useTheme();
+  const navigate = useNavigate();
+  const [selected, setSelected] = useState('2025-01-01');
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack preset="showcaseStack">
+        <Typography variant="h2" bold>
+          DateSelector Showcase
+        </Typography>
+        <Typography variant="subtitle">
+          Compact calendar with month and year navigation
+        </Typography>
+
+        <DateSelector value={selected} onChange={setSelected} />
+        <Typography variant="body">Current: {selected}</Typography>
+
+        <Stack direction="row">
+          <Button variant="outlined" onClick={toggleMode}>
+            Toggle light / dark
+          </Button>
+          <Button onClick={() => navigate(-1)}>← Back</Button>
+        </Stack>
+      </Stack>
+    </Surface>
+  );
+}

--- a/src/components/widgets/DateSelector.tsx
+++ b/src/components/widgets/DateSelector.tsx
@@ -1,0 +1,210 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/widgets/DateSelector.tsx | valet
+// interactive month calendar for picking dates
+// ─────────────────────────────────────────────────────────────
+import React, { useState } from 'react';
+import { styled } from '../../css/createStyled';
+import { useTheme } from '../../system/themeStore';
+import { preset } from '../../css/stylePresets';
+import { IconButton } from '../fields/IconButton';
+import { Typography } from '../primitives/Typography';
+import { useForm } from '../fields/FormControl';
+import type { Presettable } from '../../types';
+
+/*───────────────────────────────────────────────────────────*/
+export interface DateSelectorProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'>,
+    Presettable {
+  /** Controlled ISO date value (YYYY-MM-DD). */
+  value?: string;
+  /** Default value for uncontrolled usage. */
+  defaultValue?: string;
+  /** Fires with ISO value when selection changes. */
+  onChange?: (value: string) => void;
+  /** FormControl field name. */
+  name?: string;
+}
+
+/*───────────────────────────────────────────────────────────*/
+const Wrapper = styled('div')<{ $bg: string; $text: string }>`
+  display: inline-block;
+  padding: 0.5rem;
+  background: ${({ $bg }) => $bg};
+  color: ${({ $text }) => $text};
+  border-radius: 4px;
+  user-select: none;
+`;
+
+const Header = styled('div')`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+`;
+
+const Grid = styled('div')`
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.25rem;
+`;
+
+const DayLabel = styled('div')`
+  font-size: 0.75rem;
+  text-align: center;
+  opacity: 0.8;
+`;
+
+const Cell = styled('button')<{ $selected: boolean; $primary: string }>`
+  padding: 0.25rem 0;
+  border: none;
+  background: ${({ $selected, $primary }) =>
+    $selected ? $primary : 'transparent'};
+  color: inherit;
+  border-radius: 4px;
+  cursor: pointer;
+  font: inherit;
+  height: 2rem;
+  &:hover:not(:disabled) { filter: brightness(1.2); }
+`;
+
+/*───────────────────────────────────────────────────────────*/
+const monthNames = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+const days = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+
+/*───────────────────────────────────────────────────────────*/
+export const DateSelector: React.FC<DateSelectorProps> = ({
+  value,
+  defaultValue,
+  onChange,
+  name,
+  preset: p,
+  className,
+  style,
+  ...rest
+}) => {
+  const { theme } = useTheme();
+  let form: ReturnType<typeof useForm<any>> | null = null;
+  try { form = useForm<any>(); } catch {}
+
+  const formVal = form && name ? (form.values[name] as string | undefined) : undefined;
+  const controlled = value !== undefined || formVal !== undefined;
+  const initial = value ?? formVal ?? defaultValue;
+  const parseDate = (v?: string) => v ? new Date(v + 'T00:00') : new Date();
+  const [internal, setInternal] = useState(parseDate(initial));
+
+  const selected = controlled ? parseDate(value ?? formVal) : internal;
+  const [viewYear, setViewYear] = useState(selected.getFullYear());
+  const [viewMonth, setViewMonth] = useState(selected.getMonth());
+
+  const startDay = new Date(viewYear, viewMonth, 1).getDay();
+  const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+
+  const commit = (d: number) => {
+    const iso = new Date(viewYear, viewMonth, d).toISOString().slice(0, 10);
+    if (!controlled) setInternal(new Date(viewYear, viewMonth, d));
+    if (form && name) form.setField(name as any, iso);
+    onChange?.(iso);
+  };
+
+  const changeMonth = (delta: number) => {
+    setViewMonth((m) => {
+      let next = m + delta;
+      let yr = viewYear;
+      while (next < 0) { next += 12; yr--; }
+      while (next > 11) { next -= 12; yr++; }
+      setViewYear(yr);
+      return next;
+    });
+  };
+
+  const presetCls = p ? preset(p) : '';
+  const cls = [presetCls, className].filter(Boolean).join(' ') || undefined;
+
+  return (
+    <Wrapper
+      {...rest}
+      $bg={theme.colors.backgroundAlt}
+      $text={theme.colors.text}
+      className={cls}
+      style={style}
+    >
+      <Header>
+        <div style={{ display: 'flex', gap: '0.25rem' }}>
+          <IconButton
+            size="sm"
+            variant="outlined"
+            icon="mdi:chevron-double-left"
+            aria-label="Previous year"
+            onClick={() => setViewYear((y) => y - 1)}
+          />
+          <IconButton
+            size="sm"
+            variant="outlined"
+            icon="mdi:chevron-left"
+            aria-label="Previous month"
+            onClick={() => changeMonth(-1)}
+          />
+        </div>
+        <Typography variant="body" bold>
+          {monthNames[viewMonth]} {viewYear}
+        </Typography>
+        <div style={{ display: 'flex', gap: '0.25rem' }}>
+          <IconButton
+            size="sm"
+            variant="outlined"
+            icon="mdi:chevron-right"
+            aria-label="Next month"
+            onClick={() => changeMonth(1)}
+          />
+          <IconButton
+            size="sm"
+            variant="outlined"
+            icon="mdi:chevron-double-right"
+            aria-label="Next year"
+            onClick={() => setViewYear((y) => y + 1)}
+          />
+        </div>
+      </Header>
+      <Grid>
+        {days.map((d) => (
+          <DayLabel key={d}>{d}</DayLabel>
+        ))}
+        {Array.from({ length: startDay }).map((_, i) => (
+          <span key={`blank-${i}`} />
+        ))}
+        {Array.from({ length: daysInMonth }).map((_, i) => {
+          const day = i + 1;
+          const selectedDay =
+            selected.getFullYear() === viewYear &&
+            selected.getMonth() === viewMonth &&
+            selected.getDate() === day;
+          return (
+            <Cell
+              key={day}
+              $selected={selectedDay}
+              $primary={theme.colors.primary}
+              onClick={() => commit(day)}
+            >
+              {day}
+            </Cell>
+          );
+        })}
+      </Grid>
+    </Wrapper>
+  );
+};
+
+export default DateSelector;

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ export * from './components/widgets/Accordion';
 export * from './components/widgets/AppBar';
 export * from './components/widgets/OAIChat';
 export * from './components/widgets/Drawer';
+export * from './components/widgets/DateSelector';
 export * from './components/widgets/List';
 export * from './components/widgets/LoadingBackdrop';
 export * from './components/widgets/Pagination';


### PR DESCRIPTION
## Summary
- introduce `DateSelector` widget
- wire exports
- document DateSelector in docs nav and routes
- add DateSelector demo page
- update changelog

## Testing
- `npm run build`
- `npm run build` in docs

------
https://chatgpt.com/codex/tasks/task_e_6877fdfe1f5c83208f3af84edf09b2a5