### PR TITLE
Add DateSelector widget

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -52,6 +52,7 @@ const VideoDemoPage         = page(() => import('./pages/VideoDemo'));
 const SnackbarDemoPage      = page(() => import('./pages/SnackbarDemo'));
 const TreeDemoPage          = page(() => import('./pages/TreeDemo'));
 const DateTimeDemoPage      = page(() => import('./pages/DateTimeDemo'));
+const DateSelectorDemoPage  = page(() => import('./pages/DateSelectorDemo'));
 const OverviewPage          = page(() => import('./pages/Overview'));
 const InstallationPage      = page(() => import('./pages/Installation'));
 const UsagePage             = page(() => import('./pages/Usage'));
@@ -124,6 +125,7 @@ export function App() {
         <Route path="/snackbar-demo"   element={<SnackbarDemoPage />} />
         <Route path="/tree-demo"      element={<TreeDemoPage />} />
         <Route path="/datetime-demo"  element={<DateTimeDemoPage />} />
+        <Route path="/date-selector-demo" element={<DateSelectorDemoPage />} />
         <Route path="/prop-patterns"  element={<PropPatternsPage />} />
       </Routes>
     </Suspense>

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -57,6 +57,7 @@ const widgets: [string, string][] = [
   ['Snackbar', '/snackbar-demo'],
   ['Speed Dial', '/speeddial-demo'],
   ['Stepper', '/stepper-demo'],
+  ['Date Selector', '/date-selector-demo'],
   ['Table', '/table-demo'],
   ['Tabs', '/tabs-demo'],
   ['Tooltip', '/tooltip-demo'],

--- a/docs/src/pages/DateSelectorDemo.tsx
+++ b/docs/src/pages/DateSelectorDemo.tsx
@@ -1,0 +1,40 @@
+// src/pages/DateSelectorDemo.tsx
+import { useState } from 'react';
+import {
+  Surface,
+  Stack,
+  Typography,
+  Button,
+  DateSelector,
+  useTheme,
+} from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
+
+export default function DateSelectorDemoPage() {
+  const { theme, toggleMode } = useTheme();
+  const navigate = useNavigate();
+  const [date, setDate] = useState('2025-01-01');
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack preset="showcaseStack">
+        <Typography variant="h2" bold>DateSelector Showcase</Typography>
+        <Typography variant="subtitle">Interactive calendar</Typography>
+
+        <Typography variant="h3">Controlled</Typography>
+        <DateSelector value={date} onChange={setDate} />
+        <Typography>Selected date: <code>{date}</code></Typography>
+
+        <Typography variant="h3">Uncontrolled</Typography>
+        <DateSelector />
+
+        <Stack direction="row">
+          <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
+          <Button onClick={() => navigate(-1)}>← Back</Button>
+        </Stack>
+      </Stack>
+    </Surface>
+  );
+}

--- a/src/components/widgets/DateSelector.tsx
+++ b/src/components/widgets/DateSelector.tsx
@@ -1,0 +1,191 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/widgets/DateSelector.tsx  | valet
+// simple month calendar picker
+// ─────────────────────────────────────────────────────────────
+import React, { useState } from 'react';
+import { styled } from '../../css/createStyled';
+import { useTheme } from '../../system/themeStore';
+import { preset } from '../../css/stylePresets';
+import type { Presettable } from '../../types';
+import { IconButton } from '../fields/IconButton';
+import Icon from '../primitives/Icon';
+
+/*───────────────────────────────────────────────────────────*/
+export interface DateSelectorProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'>,
+    Presettable {
+  value?: string;         // ISO date YYYY-MM-DD
+  defaultValue?: string;  // initial uncontrolled value
+  onChange?: (date: string) => void;
+  firstDayOfWeek?: 0 | 1 | 2 | 3 | 4 | 5 | 6; // 0=Sunday
+}
+
+/*───────────────────────────────────────────────────────────*/
+const Root = styled('div')<{ $pad: string }>`
+  display: inline-flex;
+  flex-direction: column;
+  gap: ${({ $pad }) => $pad};
+  padding: ${({ $pad }) => $pad};
+`;
+
+const Header = styled('div')<{ $gap: string }>`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: ${({ $gap }) => $gap};
+`;
+
+const Grid = styled('div')<{ $gap: string }>`
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: ${({ $gap }) => $gap};
+`;
+
+const DayLabel = styled('div')<{ $text: string }>`
+  text-align: center;
+  font-size: 0.75rem;
+  color: ${({ $text }) => $text};
+`;
+
+const DayButton = styled('button')<{
+  $selected: boolean;
+  $primary: string;
+  $text: string;
+}>`
+  width: 2rem;
+  height: 2rem;
+  border: none;
+  border-radius: 4px;
+  background: ${({ $selected, $primary }) =>
+    $selected ? $primary : 'transparent'};
+  color: ${({ $selected, $text }) =>
+    $selected ? '#fff' : $text};
+  cursor: pointer;
+  font: inherit;
+  padding: 0;
+  &:hover {
+    filter: brightness(1.1);
+  }
+`;
+
+/*───────────────────────────────────────────────────────────*/
+function parseDate(v?: string) {
+  if (!v) return null;
+  const [y, m, d] = v.split('-').map((n) => parseInt(n, 10));
+  if (!y || !m || !d) return null;
+  return new Date(y, m - 1, d);
+}
+
+function fmtDate(d: Date) {
+  const y = d.getFullYear();
+  const m = `${d.getMonth() + 1}`.padStart(2, '0');
+  const day = `${d.getDate()}`.padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+const monthNames = [
+  'January','February','March','April','May','June',
+  'July','August','September','October','November','December',
+];
+const weekday = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+
+/*───────────────────────────────────────────────────────────*/
+export const DateSelector: React.FC<DateSelectorProps> = ({
+  value,
+  defaultValue,
+  onChange,
+  firstDayOfWeek = 0,
+  preset: p,
+  className,
+  style,
+  ...rest
+}) => {
+  const { theme } = useTheme();
+  const controlled = value !== undefined;
+  const [internal, setInternal] = useState(defaultValue || '');
+  const sel = controlled ? value || '' : internal;
+  const selDate = parseDate(sel);
+  const today = new Date();
+  const initial = selDate || today;
+  const [viewYear, setViewYear] = useState(initial.getFullYear());
+  const [viewMonth, setViewMonth] = useState(initial.getMonth());
+
+  const changeMonth = (delta: number) => {
+    let m = viewMonth + delta;
+    let y = viewYear;
+    if (m < 0) { m = 11; y--; }
+    if (m > 11) { m = 0; y++; }
+    setViewMonth(m); setViewYear(y);
+  };
+
+  const handleSelect = (day: number) => {
+    const d = new Date(viewYear, viewMonth, day);
+    const iso = fmtDate(d);
+    if (!controlled) setInternal(iso);
+    onChange?.(iso);
+  };
+
+  const pad = theme.spacing(1);
+  const gap = theme.spacing(0.5);
+  const presetClass = p ? preset(p) : '';
+
+  const first = new Date(viewYear, viewMonth, 1);
+  const offset = (first.getDay() - firstDayOfWeek + 7) % 7;
+  const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+  const cells = Array.from({ length: offset + daysInMonth }, (_, i) => i - offset + 1);
+
+  return (
+    <Root
+      {...rest}
+      $pad={pad}
+      className={[presetClass, className].filter(Boolean).join(' ')}
+      style={style}
+    >
+      <Header $gap={gap}>
+        <IconButton
+          variant="outlined"
+          size="sm"
+          onClick={() => changeMonth(-1)}
+          aria-label="Previous month"
+        >
+          <Icon icon="mdi:chevron-left" />
+        </IconButton>
+        <DayLabel $text={theme.colors.text}>
+          {monthNames[viewMonth]} {viewYear}
+        </DayLabel>
+        <IconButton
+          variant="outlined"
+          size="sm"
+          onClick={() => changeMonth(1)}
+          aria-label="Next month"
+        >
+          <Icon icon="mdi:chevron-right" />
+        </IconButton>
+      </Header>
+      <Grid $gap={gap}>
+        {weekday.map((d, i) => (
+          <DayLabel key={i} $text={theme.colors.text}>
+            {weekday[(i + firstDayOfWeek) % 7]}
+          </DayLabel>
+        ))}
+        {cells.map((day, idx) =>
+          day < 1 ? (
+            <span key={idx} />
+          ) : (
+            <DayButton
+              key={idx}
+              onClick={() => handleSelect(day)}
+              $selected={selDate?.getFullYear() === viewYear && selDate.getMonth() === viewMonth && selDate.getDate() === day}
+              $primary={theme.colors.primary}
+              $text={theme.colors.text}
+            >
+              {day}
+            </DayButton>
+          )
+        )}
+      </Grid>
+    </Root>
+  );
+};
+
+export default DateSelector;

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ export * from './components/widgets/Parallax';
 export * from './components/widgets/Snackbar';
 export * from './components/widgets/SpeedDial';
 export * from './components/widgets/Stepper';
+export * from './components/widgets/DateSelector';
 export * from './components/widgets/Table';
 export * from './components/widgets/Tabs';
 export * from './components/widgets/Tooltip';


### PR DESCRIPTION
## Summary
- add `DateSelector` widget
- export widget and document in docs
- add demo page and navigation links

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6877fdfe1f5c83208f3af84edf09b2a5