### PR TITLE
Add Iterator widget and demo

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -53,6 +53,7 @@ const SnackbarDemoPage      = page(() => import('./pages/SnackbarDemo'));
 const TreeDemoPage          = page(() => import('./pages/TreeDemo'));
 const DateTimeDemoPage      = page(() => import('./pages/DateTimeDemo'));
 const DateSelectorDemoPage  = page(() => import('./pages/DateSelectorDemo'));
+const IteratorDemoPage      = page(() => import('./pages/IteratorDemo'));
 const OverviewPage          = page(() => import('./pages/Overview'));
 const InstallationPage      = page(() => import('./pages/Installation'));
 const UsagePage             = page(() => import('./pages/Usage'));
@@ -126,6 +127,7 @@ export function App() {
         <Route path="/tree-demo"      element={<TreeDemoPage />} />
         <Route path="/datetime-demo"  element={<DateTimeDemoPage />} />
         <Route path="/dateselector-demo" element={<DateSelectorDemoPage />} />
+        <Route path="/iterator-demo"  element={<IteratorDemoPage />} />
         <Route path="/prop-patterns"  element={<PropPatternsPage />} />
       </Routes>
     </Suspense>

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -45,6 +45,7 @@ const fields: [string, string][] = [
   ['Slider', '/slider-demo'],
   ['Switch', '/switch-demo'],
   ['TextField', '/text-form-demo'],
+  ['Iterator', '/iterator-demo'],
 ];
 
 const widgets: [string, string][] = [

--- a/docs/src/pages/IteratorDemo.tsx
+++ b/docs/src/pages/IteratorDemo.tsx
@@ -1,0 +1,102 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/IteratorDemo.tsx | valet
+// Demo page for <Iterator /> widget
+// ─────────────────────────────────────────────────────────────
+import { useState } from 'react';
+import {
+  Surface,
+  Stack,
+  Typography,
+  Button,
+  Iterator,
+  FormControl,
+  createFormStore,
+  useTheme,
+  Tabs,
+  Table,
+} from '@archway/valet';
+import type { TableColumn } from '@archway/valet';
+import type { ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
+
+/*───────────────────────────────────────────────────────────*/
+/* Form demo store                                            */
+const useForm = createFormStore({ qty: 2 });
+
+export default function IteratorDemoPage() {
+  const { theme, toggleMode } = useTheme();
+  const navigate = useNavigate();
+
+  const [value, setValue] = useState(1);
+
+  interface Row { prop: ReactNode; type: ReactNode; default: ReactNode; description: ReactNode; }
+  const columns: TableColumn<Row>[] = [
+    { header: 'Prop', accessor: 'prop' },
+    { header: 'Type', accessor: 'type' },
+    { header: 'Default', accessor: 'default' },
+    { header: 'Description', accessor: 'description' },
+  ];
+
+  const data: Row[] = [
+    { prop: <code>value</code>, type: <code>number</code>, default: <code>-</code>, description: 'Controlled value' },
+    { prop: <code>defaultValue</code>, type: <code>number</code>, default: <code>0</code>, description: 'Uncontrolled initial value' },
+    { prop: <code>step</code>, type: <code>number</code>, default: <code>1</code>, description: 'Increment amount' },
+    { prop: <code>width</code>, type: <code>number | string</code>, default: <code>'3.5rem'</code>, description: 'Input width' },
+    { prop: <code>name</code>, type: <code>string</code>, default: <code>-</code>, description: 'Form field name' },
+    { prop: <code>onChange</code>, type: <code>(n: number) =&gt; void</code>, default: <code>-</code>, description: 'Change handler' },
+    { prop: <code>preset</code>, type: <code>string | string[]</code>, default: <code>-</code>, description: 'Apply style presets' },
+  ];
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack preset="showcaseStack">
+        <Typography variant="h2" bold>
+          Iterator Widget
+        </Typography>
+        <Typography variant="subtitle">
+          Compact numeric input with quick ± controls
+        </Typography>
+
+        <Tabs>
+          <Tabs.Tab label="Usage" />
+          <Tabs.Panel>
+            <Typography variant="h3">1. Uncontrolled</Typography>
+            <Iterator defaultValue={3} />
+
+            <Typography variant="h3">2. Controlled</Typography>
+            <Stack direction="row" style={{ alignItems: 'center' }}>
+              <Iterator value={value} onChange={setValue} />
+              <Typography>&nbsp;Value: {value}</Typography>
+            </Stack>
+
+            <Typography variant="h3">3. Custom width</Typography>
+            <Iterator defaultValue={5} width="5rem" />
+
+            <Typography variant="h3">4. FormControl</Typography>
+            <FormControl useStore={useForm} onSubmitValues={(v) => alert(JSON.stringify(v))}>
+              <Iterator name="qty" width="4rem" />
+              <Button type="submit">Submit</Button>
+            </FormControl>
+
+            <Typography variant="h3">5. Theme toggle</Typography>
+            <Button variant="outlined" onClick={toggleMode}>
+              Toggle light / dark
+            </Button>
+          </Tabs.Panel>
+
+          <Tabs.Tab label="Reference" />
+          <Tabs.Panel>
+            <Typography variant="h3">Prop reference</Typography>
+            <Table data={data} columns={columns} constrainHeight={false} />
+          </Tabs.Panel>
+        </Tabs>
+
+        <Button size="lg" onClick={() => navigate(-1)} style={{ marginTop: theme.spacing(1) }}>
+          ← Back
+        </Button>
+      </Stack>
+    </Surface>
+  );
+}

--- a/src/components/widgets/Iterator.tsx
+++ b/src/components/widgets/Iterator.tsx
@@ -1,0 +1,137 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/widgets/Iterator.tsx  | valet
+// numeric stepper widget – small text field with ± buttons
+// ─────────────────────────────────────────────────────────────
+import React, { forwardRef, useState, useId, ChangeEvent } from 'react';
+import { styled } from '../../css/createStyled';
+import { useTheme } from '../../system/themeStore';
+import { preset } from '../../css/stylePresets';
+import { IconButton } from '../fields/IconButton';
+import { useForm } from '../fields/FormControl';
+import type { Presettable } from '../../types';
+
+/*───────────────────────────────────────────────────────────*/
+/* Public props                                              */
+export interface IteratorProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'size'>,
+    Presettable {
+  /** Current numeric value (controlled) */
+  value?: number;
+  /** Initial value for uncontrolled usage */
+  defaultValue?: number;
+  /** Step increment/decrement amount */
+  step?: number;
+  /** Width of the text field */
+  width?: number | string;
+  /** FormControl field name */
+  name?: string;
+  /** Fires with next value on change */
+  onChange?: (val: number) => void;
+}
+
+/*───────────────────────────────────────────────────────────*/
+/* Layout wrappers                                            */
+const Wrapper = styled('div')`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+`;
+
+const Field = styled('input')<{ $w: string; $bg: string; $text: string }>`
+  width: ${({ $w }) => $w};
+  min-width: ${({ $w }) => $w};
+  text-align: center;
+  padding: 0.25rem;
+  border: 1px solid ${({ $text }) => $text + '55'};
+  border-radius: 4px;
+  background: ${({ $bg }) => $bg};
+  color: ${({ $text }) => $text};
+  font: inherit;
+`;
+
+/*───────────────────────────────────────────────────────────*/
+/* Component                                                  */
+export const Iterator = forwardRef<HTMLInputElement, IteratorProps>(
+  (
+    {
+      value,
+      defaultValue = 0,
+      step = 1,
+      width = '3.5rem',
+      name,
+      onChange,
+      preset: p,
+      className,
+      style,
+      ...rest
+    },
+    ref,
+  ) => {
+    const { theme } = useTheme();
+
+    /* Optional FormControl wiring ------------------------------------- */
+    let form: ReturnType<typeof useForm<any>> | null = null;
+    try { form = useForm<any>(); } catch {}
+
+    const formVal = form && name ? Number(form.values[name]) : undefined;
+    const controlled = value !== undefined || formVal !== undefined;
+    const [selfVal, setSelfVal] = useState(defaultValue);
+    const current = controlled
+      ? (formVal !== undefined ? formVal : value ?? 0)
+      : selfVal;
+
+    const commit = (next: number) => {
+      if (!controlled) setSelfVal(next);
+      form?.setField?.(name as any, next);
+      onChange?.(next);
+    };
+
+    const adjust = (delta: number) => {
+      const next = current + delta;
+      commit(next);
+    };
+
+    const handleInput = (e: ChangeEvent<HTMLInputElement>) => {
+      const parsed = Number(e.target.value);
+      if (!Number.isNaN(parsed)) commit(parsed);
+    };
+
+    const presetCls = p ? preset(p) : '';
+    const mergedCls = [presetCls, className].filter(Boolean).join(' ') || undefined;
+    const w = typeof width === 'number' ? `${width}px` : width;
+
+    return (
+      <Wrapper className={mergedCls} style={style}>
+        <IconButton
+          size="sm"
+          variant="outlined"
+          icon="mdi:minus"
+          aria-label="Decrease"
+          onClick={() => adjust(-step)}
+        />
+        <Field
+          {...rest}
+          ref={ref}
+          type="number"
+          name={name}
+          value={current}
+          onChange={handleInput}
+          $w={w}
+          $bg={theme.colors.background}
+          $text={theme.colors.text}
+        />
+        <IconButton
+          size="sm"
+          variant="outlined"
+          icon="mdi:plus"
+          aria-label="Increase"
+          onClick={() => adjust(step)}
+        />
+      </Wrapper>
+    );
+  },
+);
+
+Iterator.displayName = 'Iterator';
+
+export default Iterator;

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ export * from './components/widgets/Pagination';
 export * from './components/widgets/Parallax';
 export * from './components/widgets/Snackbar';
 export * from './components/widgets/SpeedDial';
+export * from './components/widgets/Iterator';
 export * from './components/widgets/Stepper';
 export * from './components/widgets/Table';
 export * from './components/widgets/Tabs';


### PR DESCRIPTION
## Summary
- create `Iterator` widget with ± buttons and small number field
- export `Iterator` from library
- add Iterator demo page with usage and reference
- register route and nav item for demo

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687808dcf0388320a0b99ef83fa2339a