### PR TITLE
Add Iterator widget with docs

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -26,6 +26,7 @@ const IconDemoPage          = page(() => import('./pages/IconDemoPage'));
 const IconButtonDemoPage    = page(() => import('./pages/IconButtonDemoPage'));
 const ImageDemoPage         = page(() => import('./pages/ImageDemo'));
 const AvatarDemoPage        = page(() => import('./pages/AvatarDemo'));
+const IteratorDemoPage      = page(() => import('./pages/IteratorDemo'));
 const OAIChatDemoPage          = page(() => import('./pages/OAIChatDemo'));
 const PanelDemoPage         = page(() => import('./pages/PanelDemo'));
 const CheckboxDemoPage      = page(() => import('./pages/CheckBoxDemo'));
@@ -95,6 +96,7 @@ export function App() {
         <Route path="/icon-demo"       element={<IconDemoPage />} />
         <Route path="/image-demo"      element={<ImageDemoPage />} />
         <Route path="/icon-button-demo"element={<IconButtonDemoPage />} />
+        <Route path="/iterator-demo"  element={<IteratorDemoPage />} />
         <Route path="/avatar-demo"    element={<AvatarDemoPage />} />
         <Route path="/panel-demo"      element={<PanelDemoPage />} />
         <Route path="/checkbox-demo"   element={<CheckboxDemoPage />} />

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -40,6 +40,7 @@ const fields: [string, string][] = [
   ['Date Selector', '/dateselector-demo'],
   ['DateTime Picker', '/datetime-demo'],
   ['Icon Button', '/icon-button-demo'],
+  ['Iterator', '/iterator-demo'],
   ['Radio Group', '/radio-demo'],
   ['Select', '/select-demo'],
   ['Slider', '/slider-demo'],

--- a/docs/src/pages/IteratorDemo.tsx
+++ b/docs/src/pages/IteratorDemo.tsx
@@ -1,0 +1,129 @@
+// src/pages/IteratorDemo.tsx
+import { useState } from 'react';
+import {
+  Surface,
+  Stack,
+  Typography,
+  Button,
+  Iterator,
+  Tabs,
+  Table,
+  useTheme,
+} from '@archway/valet';
+import type { TableColumn } from '@archway/valet';
+import type { ReactNode } from 'react';
+import NavDrawer from '../components/NavDrawer';
+
+export default function IteratorDemoPage() {
+  const { theme, toggleMode } = useTheme();
+  const [count, setCount] = useState(3);
+
+  interface Row {
+    prop: ReactNode;
+    type: ReactNode;
+    default: ReactNode;
+    description: ReactNode;
+  }
+
+  const columns: TableColumn<Row>[] = [
+    { header: 'Prop', accessor: 'prop' },
+    { header: 'Type', accessor: 'type' },
+    { header: 'Default', accessor: 'default' },
+    { header: 'Description', accessor: 'description' },
+  ];
+
+  const data: Row[] = [
+    {
+      prop: <code>value</code>,
+      type: <code>number</code>,
+      default: <code>-</code>,
+      description: 'Controlled value',
+    },
+    {
+      prop: <code>defaultValue</code>,
+      type: <code>number</code>,
+      default: <code>0</code>,
+      description: 'Uncontrolled initial value',
+    },
+    {
+      prop: <code>onChange</code>,
+      type: <code>(n: number) =&gt; void</code>,
+      default: <code>-</code>,
+      description: 'Change handler',
+    },
+    {
+      prop: <code>step</code>,
+      type: <code>number</code>,
+      default: <code>1</code>,
+      description: 'Increment amount',
+    },
+    {
+      prop: <code>min</code>,
+      type: <code>number</code>,
+      default: <code>-</code>,
+      description: 'Minimum value',
+    },
+    {
+      prop: <code>max</code>,
+      type: <code>number</code>,
+      default: <code>-</code>,
+      description: 'Maximum value',
+    },
+    {
+      prop: <code>width</code>,
+      type: <code>number | string</code>,
+      default: <code>'4rem'</code>,
+      description: 'Input width',
+    },
+    {
+      prop: <code>preset</code>,
+      type: <code>string | string[]</code>,
+      default: <code>-</code>,
+      description: 'Apply style presets',
+    },
+  ];
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack preset="showcaseStack">
+        <Typography variant="h2" bold>
+          Iterator
+        </Typography>
+        <Typography variant="subtitle">
+          Compact numeric input with plus/minus controls
+        </Typography>
+
+        <Tabs>
+          <Tabs.Tab label="Usage" />
+          <Tabs.Panel>
+            <Typography variant="h3">1. Uncontrolled</Typography>
+            <Iterator defaultValue={2} />
+
+            <Typography variant="h3">2. Controlled</Typography>
+            <Stack direction="row" style={{ alignItems: 'center' }}>
+              <Iterator value={count} onChange={setCount} />
+              <Typography variant="body" style={{ marginLeft: theme.spacing(1) }}>
+                Count: {count}
+              </Typography>
+            </Stack>
+
+            <Typography variant="h3">3. Custom width &amp; step</Typography>
+            <Iterator defaultValue={10} width="5rem" step={5} />
+
+            <Typography variant="h3">4. Theme toggle</Typography>
+            <Button variant="outlined" onClick={toggleMode}>
+              Toggle light / dark
+            </Button>
+          </Tabs.Panel>
+
+          <Tabs.Tab label="Reference" />
+          <Tabs.Panel>
+            <Typography variant="h3">Prop reference</Typography>
+            <Table data={data} columns={columns} constrainHeight={false} />
+          </Tabs.Panel>
+        </Tabs>
+      </Stack>
+    </Surface>
+  );
+}

--- a/src/components/fields/Iterator.tsx
+++ b/src/components/fields/Iterator.tsx
@@ -1,0 +1,112 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/fields/Iterator.tsx | valet
+// compact number input with +/- controls
+// ─────────────────────────────────────────────────────────────
+import React, { forwardRef, useId, useState } from 'react';
+import { styled } from '../../css/createStyled';
+import { useTheme } from '../../system/themeStore';
+import { preset } from '../../css/stylePresets';
+import IconButton from './IconButton';
+import type { Theme } from '../../system/themeStore';
+import type { Presettable } from '../../types';
+
+/*───────────────────────────────────────────────────────────*/
+export interface IteratorProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'size' | 'value' | 'defaultValue'>,
+    Presettable {
+  value?: number;
+  defaultValue?: number;
+  onChange?: (n: number) => void;
+  min?: number;
+  max?: number;
+  step?: number;
+  width?: number | string;
+}
+
+/*───────────────────────────────────────────────────────────*/
+const Wrapper = styled('div')<{ $width: string }>`
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+`;
+
+const Field = styled('input')<{ theme: Theme; $width: string }>`
+  width: ${({ $width }) => $width};
+  text-align: center;
+  padding: ${({ theme }) => theme.spacing(0.5)};
+  border: 1px solid ${({ theme }) => theme.colors.text}44;
+  border-radius: 4px;
+  background: ${({ theme }) => theme.colors.background};
+  color: ${({ theme }) => theme.colors.text};
+  font-size: 0.875rem;
+`;
+
+/*───────────────────────────────────────────────────────────*/
+export const Iterator = forwardRef<HTMLInputElement, IteratorProps>(
+  (
+    {
+      value,
+      defaultValue,
+      onChange,
+      min,
+      max,
+      step = 1,
+      width = '4rem',
+      preset: presetKey,
+      className,
+      style,
+      ...rest
+    },
+    ref,
+  ) => {
+    const { theme } = useTheme();
+    const id = useId();
+
+    const presetCls = presetKey ? preset(presetKey) : '';
+    const mergedCls = [presetCls, className].filter(Boolean).join(' ') || undefined;
+
+    const [internal, setInternal] = useState(defaultValue ?? 0);
+    const current = value ?? internal;
+
+    const clamp = (n: number) => {
+      if (min !== undefined && n < min) n = min;
+      if (max !== undefined && n > max) n = max;
+      return n;
+    };
+
+    const update = (n: number) => {
+      n = clamp(n);
+      if (value === undefined) setInternal(n);
+      onChange?.(n);
+    };
+
+    const handleChange: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+      const next = Number(e.target.value);
+      if (!Number.isNaN(next)) update(next);
+    };
+
+    return (
+      <Wrapper $width={typeof width === 'number' ? `${width}px` : width} className={mergedCls} style={style}>
+        <IconButton icon="mdi:minus" size="sm" onClick={() => update(current - step)} aria-label="decrement" />
+        <Field
+          {...rest}
+          ref={ref}
+          id={id}
+          theme={theme}
+          type="number"
+          value={current}
+          onChange={handleChange}
+          min={min}
+          max={max}
+          step={step}
+          $width={typeof width === 'number' ? `${width}px` : width}
+        />
+        <IconButton icon="mdi:plus" size="sm" onClick={() => update(current + step)} aria-label="increment" />
+      </Wrapper>
+    );
+  },
+);
+
+Iterator.displayName = 'Iterator';
+
+export default Iterator;

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export type {
 export * from './components/fields/Slider';
 export * from './components/fields/Switch';
 export * from './components/fields/TextField';
+export * from './components/fields/Iterator';
 
 // ─── Widgets ─────────────────────────────────────────────────
 export * from './components/widgets/Accordion';


### PR DESCRIPTION
## Summary
- add compact `Iterator` field widget
- document `Iterator` usage and props
- include the widget in navbar
- wire up route for iterator demo

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687808dcf0388320a0b99ef83fa2339a