### PR TITLE
Add Iterator component and documentation

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -38,6 +38,7 @@ const TabsDemoPage          = page(() => import('./pages/TabsDemo'));
 const SliderDemoPage        = page(() => import('./pages/SliderDemo'));
 const ProgressDemoPage      = page(() => import('./pages/ProgressDemo'));
 const SelectDemoPage        = page(() => import('./pages/SelectDemo'));
+const IteratorDemoPage      = page(() => import('./pages/IteratorDemo'));
 const TablePlaygroundPage   = page(() => import('./pages/TableDemo'));
 const ListDemoPage          = page(() => import('./pages/ListDemoPage'));
 const DrawerDemoPage        = page(() => import('./pages/DrawerDemo'));
@@ -108,6 +109,7 @@ export function App() {
         />
         <Route path="/tabs-demo"       element={<TabsDemoPage />} />
         <Route path="/slider-demo"     element={<SliderDemoPage />} />
+        <Route path="/iterator-demo"  element={<IteratorDemoPage />} />
         <Route path="/progress-demo"   element={<ProgressDemoPage />} />
         <Route path="/select-demo"     element={<SelectDemoPage />} />
         <Route path="/table-demo"      element={<TablePlaygroundPage />} />

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -43,6 +43,7 @@ const fields: [string, string][] = [
   ['Radio Group', '/radio-demo'],
   ['Select', '/select-demo'],
   ['Slider', '/slider-demo'],
+  ['Iterator', '/iterator-demo'],
   ['Switch', '/switch-demo'],
   ['TextField', '/text-form-demo'],
 ];

--- a/docs/src/pages/IteratorDemo.tsx
+++ b/docs/src/pages/IteratorDemo.tsx
@@ -1,0 +1,146 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/IteratorDemo.tsx | valet docs
+// Showcase of Iterator component
+// ─────────────────────────────────────────────────────────────
+import { useState } from 'react';
+import {
+  Surface,
+  Stack,
+  Typography,
+  Button,
+  Tabs,
+  Table,
+  useTheme,
+  Iterator,
+} from '@archway/valet';
+import type { TableColumn } from '@archway/valet';
+import type { ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
+
+export default function IteratorDemoPage() {
+  const { theme, toggleMode } = useTheme();
+  const navigate = useNavigate();
+  const [count, setCount] = useState(5);
+
+  interface Row {
+    prop: ReactNode;
+    type: ReactNode;
+    default: ReactNode;
+    description: ReactNode;
+  }
+
+  const columns: TableColumn<Row>[] = [
+    { header: 'Prop', accessor: 'prop' },
+    { header: 'Type', accessor: 'type' },
+    { header: 'Default', accessor: 'default' },
+    { header: 'Description', accessor: 'description' },
+  ];
+
+  const data: Row[] = [
+    {
+      prop: <code>value</code>,
+      type: <code>number</code>,
+      default: <code>-</code>,
+      description: 'Controlled value',
+    },
+    {
+      prop: <code>defaultValue</code>,
+      type: <code>number</code>,
+      default: <code>0</code>,
+      description: 'Uncontrolled start value',
+    },
+    {
+      prop: <code>onChange</code>,
+      type: <code>(v: number) =&gt; void</code>,
+      default: <code>-</code>,
+      description: 'Change handler',
+    },
+    {
+      prop: <code>step</code>,
+      type: <code>number</code>,
+      default: <code>1</code>,
+      description: 'Increment value',
+    },
+    {
+      prop: <code>min</code>,
+      type: <code>number</code>,
+      default: <code>-Infinity</code>,
+      description: 'Minimum allowed value',
+    },
+    {
+      prop: <code>max</code>,
+      type: <code>number</code>,
+      default: <code>Infinity</code>,
+      description: 'Maximum allowed value',
+    },
+    {
+      prop: <code>size</code>,
+      type: <code>number | string</code>,
+      default: <code>'4rem'</code>,
+      description: 'Input width',
+    },
+    {
+      prop: <code>disabled</code>,
+      type: <code>boolean</code>,
+      default: <code>false</code>,
+      description: 'Disable interaction',
+    },
+    {
+      prop: <code>preset</code>,
+      type: <code>string | string[]</code>,
+      default: <code>-</code>,
+      description: 'Apply style presets',
+    },
+  ];
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack preset="showcaseStack">
+        <Typography variant="h2" bold>
+          Iterator Showcase
+        </Typography>
+        <Typography variant="subtitle">
+          Compact numeric input with plus/minus controls
+        </Typography>
+
+        <Tabs>
+          <Tabs.Tab label="Usage" />
+          <Tabs.Panel>
+            <Stack>
+              <Typography variant="h3">1. Uncontrolled</Typography>
+              <Iterator />
+
+              <Typography variant="h3">2. Controlled</Typography>
+              <Iterator value={count} onChange={setCount} />
+              <Typography>Value: {count}</Typography>
+
+              <Typography variant="h3">3. Disabled</Typography>
+              <Iterator defaultValue={3} disabled />
+
+              <Typography variant="h3">4. Theme toggle</Typography>
+              <Button variant="outlined" onClick={toggleMode}>
+                Toggle light / dark
+              </Button>
+            </Stack>
+          </Tabs.Panel>
+
+          <Tabs.Tab label="Reference" />
+          <Tabs.Panel>
+            <Typography variant="h3">Prop reference</Typography>
+            <Table data={data} columns={columns} constrainHeight={false} />
+          </Tabs.Panel>
+        </Tabs>
+
+        <Button
+          size="lg"
+          onClick={() => navigate(-1)}
+          style={{ marginTop: theme.spacing(1) }}
+        >
+          ← Back
+        </Button>
+      </Stack>
+    </Surface>
+  );
+}

--- a/src/components/widgets/Iterator.tsx
+++ b/src/components/widgets/Iterator.tsx
@@ -1,0 +1,121 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/widgets/Iterator.tsx  | valet
+// numeric stepper with +/- buttons
+// ─────────────────────────────────────────────────────────────
+import React, { useState } from 'react';
+import { styled } from '../../css/createStyled';
+import { useTheme } from '../../system/themeStore';
+import { preset } from '../../css/stylePresets';
+import type { Presettable } from '../../types';
+import IconButton from '../fields/IconButton';
+
+/*───────────────────────────────────────────────────────────*/
+export interface IteratorProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size' | 'value' | 'defaultValue' | 'onChange'>,
+    Presettable {
+  value?: number;
+  defaultValue?: number;
+  step?: number;
+  min?: number;
+  max?: number;
+  size?: number | string;
+  onChange?: (value: number) => void;
+}
+
+/*───────────────────────────────────────────────────────────*/
+const Root = styled('div')<{ $disabled: boolean; $gap: string }>`
+  display: inline-flex;
+  align-items: center;
+  gap: ${({ $gap }) => $gap};
+  opacity: ${({ $disabled }) => ($disabled ? 0.5 : 1)};
+`;
+
+const Field = styled('input')<{ theme: any; $width: string }>`
+  width: ${({ $width }) => $width};
+  padding: ${({ theme }) => theme.spacing(0.5)};
+  border: 1px solid ${({ theme }) => theme.colors.text + '44'};
+  border-radius: 4px;
+  background: ${({ theme }) => theme.colors.background};
+  color: ${({ theme }) => theme.colors.text};
+  font-size: 0.875rem;
+  text-align: center;
+  &:focus {
+    outline: 2px solid ${({ theme }) => theme.colors.primary};
+    outline-offset: 1px;
+  }
+`;
+
+/*───────────────────────────────────────────────────────────*/
+export const Iterator: React.FC<IteratorProps> = ({
+  value: valueProp,
+  defaultValue = 0,
+  step = 1,
+  min = Number.NEGATIVE_INFINITY,
+  max = Number.POSITIVE_INFINITY,
+  size = '4rem',
+  disabled = false,
+  onChange,
+  preset: p,
+  className,
+  style,
+  ...rest
+}) => {
+  const { theme } = useTheme();
+  const [self, setSelf] = useState(defaultValue);
+  const controlled = valueProp !== undefined;
+  const current = controlled ? valueProp! : self;
+  const width = typeof size === 'number' ? `${size}px` : size;
+  const presetClass = p ? preset(p) : '';
+
+  const commit = (next: number) => {
+    const clamped = Math.min(max, Math.max(min, next));
+    if (!controlled) setSelf(clamped);
+    onChange?.(clamped);
+  };
+
+  const inc = () => !disabled && commit(current + step);
+  const dec = () => !disabled && commit(current - step);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const num = Number(e.target.value);
+    if (!Number.isNaN(num)) commit(num);
+  };
+
+  return (
+    <Root
+      $disabled={disabled}
+      $gap={theme.spacing(0.5)}
+      className={[presetClass, className].filter(Boolean).join(' ')}
+      style={style}
+    >
+      <IconButton
+        icon="mdi:minus"
+        size="sm"
+        onClick={dec}
+        aria-label="decrease"
+        disabled={disabled}
+      />
+      <Field
+        {...rest}
+        type="number"
+        value={current}
+        onChange={handleChange}
+        min={min}
+        max={max}
+        step={step}
+        disabled={disabled}
+        theme={theme}
+        $width={width}
+      />
+      <IconButton
+        icon="mdi:plus"
+        size="sm"
+        onClick={inc}
+        aria-label="increase"
+        disabled={disabled}
+      />
+    </Root>
+  );
+};
+
+export default Iterator;

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ export * from './components/widgets/Pagination';
 export * from './components/widgets/Parallax';
 export * from './components/widgets/Snackbar';
 export * from './components/widgets/SpeedDial';
+export * from './components/widgets/Iterator';
 export * from './components/widgets/Stepper';
 export * from './components/widgets/Table';
 export * from './components/widgets/Tabs';


### PR DESCRIPTION
## Summary
- add `Iterator` numeric stepper widget
- export `Iterator` from the library
- create example docs page with usage and reference
- register the page in the docs nav and routing

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687808dcf0388320a0b99ef83fa2339a