### PR TITLE
Disable page scroll on Iterator wheel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 - Added `DateSelector` widget – compact calendar component
+- Added `Iterator` widget – numeric stepper input
+- Fixed `Iterator` to hide native number spinners in Firefox
+- Iterator responds to mouse wheel scrolling when hovered
+- Iterator prevents page scroll while hovered
+- Improved Iterator's wheel handler to stop scrolling the page on Firefox
+- Shrunk Iterator buttons and width; increased spacing for a lighter layout
 
 ## [0.13.0]
 - Renamed `Chat` to `OAIChat`

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -30,6 +30,7 @@ const OAIChatDemoPage          = page(() => import('./pages/OAIChatDemo'));
 const PanelDemoPage         = page(() => import('./pages/PanelDemo'));
 const CheckboxDemoPage      = page(() => import('./pages/CheckBoxDemo'));
 const TooltipDemoPage       = page(() => import('./pages/TooltipDemo'));
+const IteratorDemoPage      = page(() => import('./pages/IteratorDemo'));
 const ModalDemoPage         = page(() => import('./pages/ModalDemo'));
 const SwitchDemoPage        = page(() => import('./pages/SwitchDemo'));
 const AccordionDemoPage     = page(() => import('./pages/AccordionDemo'));
@@ -124,6 +125,7 @@ export function App() {
         <Route path="/chat-demo"       element={<OAIChatDemoPage />} />
         <Route path="/snackbar-demo"   element={<SnackbarDemoPage />} />
         <Route path="/tree-demo"      element={<TreeDemoPage />} />
+        <Route path="/iterator-demo"  element={<IteratorDemoPage />} />
         <Route path="/datetime-demo"  element={<DateTimeDemoPage />} />
         <Route path="/dateselector-demo" element={<DateSelectorDemoPage />} />
         <Route path="/prop-patterns"  element={<PropPatternsPage />} />

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -42,6 +42,7 @@ const fields: [string, string][] = [
   ['Icon Button', '/icon-button-demo'],
   ['Radio Group', '/radio-demo'],
   ['Select', '/select-demo'],
+  ['Iterator', '/iterator-demo'],
   ['Slider', '/slider-demo'],
   ['Switch', '/switch-demo'],
   ['TextField', '/text-form-demo'],

--- a/docs/src/pages/IteratorDemo.tsx
+++ b/docs/src/pages/IteratorDemo.tsx
@@ -1,0 +1,178 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/IteratorDemo.tsx | valet
+// Showcase of Iterator component
+// ─────────────────────────────────────────────────────────────
+import { useState } from 'react';
+import {
+  Surface,
+  Stack,
+  Typography,
+  Button,
+  Iterator,
+  FormControl,
+  createFormStore,
+  useTheme,
+  Tabs,
+  Table,
+} from '@archway/valet';
+import type { TableColumn } from '@archway/valet';
+import type { ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
+
+/*───────────────────────────────────────────────────────────*/
+interface FormVals { amount: number; }
+const useFormStore = createFormStore<FormVals>({ amount: 1 });
+
+export default function IteratorDemoPage() {
+  const { theme, toggleMode } = useTheme();
+  const navigate = useNavigate();
+  const [count, setCount] = useState(2);
+
+  interface Row {
+    prop: ReactNode;
+    type: ReactNode;
+    default: ReactNode;
+    description: ReactNode;
+  }
+
+  const columns: TableColumn<Row>[] = [
+    { header: 'Prop', accessor: 'prop' },
+    { header: 'Type', accessor: 'type' },
+    { header: 'Default', accessor: 'default' },
+    { header: 'Description', accessor: 'description' },
+  ];
+
+  const data: Row[] = [
+    {
+      prop: <code>value</code>,
+      type: <code>number</code>,
+      default: <code>-</code>,
+      description: 'Controlled value',
+    },
+    {
+      prop: <code>defaultValue</code>,
+      type: <code>number</code>,
+      default: <code>0</code>,
+      description: 'Uncontrolled initial value',
+    },
+    {
+      prop: <code>onChange</code>,
+      type: <code>(value: number) =&gt; void</code>,
+      default: <code>-</code>,
+      description: 'Change handler',
+    },
+    {
+      prop: <code>name</code>,
+      type: <code>string</code>,
+      default: <code>-</code>,
+      description: 'Form field name',
+    },
+    {
+      prop: <code>min</code>,
+      type: <code>number</code>,
+      default: <code>-</code>,
+      description: 'Minimum value',
+    },
+    {
+      prop: <code>max</code>,
+      type: <code>number</code>,
+      default: <code>-</code>,
+      description: 'Maximum value',
+    },
+    {
+      prop: <code>step</code>,
+      type: <code>number</code>,
+      default: <code>1</code>,
+      description: 'Increment step',
+    },
+    {
+      prop: <code>width</code>,
+      type: <code>number | string</code>,
+      default: <code>'3.5rem'</code>,
+      description: 'Field width',
+    },
+    {
+      prop: <code>disabled</code>,
+      type: <code>boolean</code>,
+      default: <code>false</code>,
+      description: 'Disable interaction',
+    },
+    {
+      prop: <code>preset</code>,
+      type: <code>string | string[]</code>,
+      default: <code>-</code>,
+      description: 'Apply style presets',
+    },
+  ];
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack preset="showcaseStack">
+        <Typography variant="h2" bold>
+          Iterator Playground
+        </Typography>
+        <Typography variant="subtitle">
+          Compact numeric stepper with plus/minus controls. Scroll while
+          hovering to change the value without moving the page.
+        </Typography>
+        <Typography>
+          The field will increment when scrolling up and decrement when
+          scrolling down. Page scrolling is suppressed while hovering,
+          including on Firefox.
+        </Typography>
+
+        <Tabs>
+          <Tabs.Tab label="Usage" />
+          <Tabs.Panel>
+            <Stack>
+              <Typography variant="h3">1. Uncontrolled</Typography>
+              <Iterator defaultValue={3} />
+
+              <Typography variant="h3">2. Controlled</Typography>
+              <Stack direction="row" style={{ alignItems: 'center' }}>
+                <Iterator value={count} onChange={setCount} />
+                <Typography>Value: {count}</Typography>
+              </Stack>
+
+              <Typography variant="h3">3. Min, max &amp; step</Typography>
+              <Iterator min={0} max={10} step={2} defaultValue={4} />
+
+              <Typography variant="h3">4. Disabled</Typography>
+              <Iterator defaultValue={5} disabled />
+
+              <Typography variant="h3">5. FormControl</Typography>
+              <FormControl
+                useStore={useFormStore}
+                onSubmitValues={(vals) => alert(JSON.stringify(vals))}
+              >
+                <Iterator name="amount" />
+                <Button type="submit">Submit</Button>
+              </FormControl>
+
+              <Typography variant="h3">6. Theme toggle</Typography>
+              <Button variant="outlined" onClick={toggleMode}>
+                Toggle light / dark
+              </Button>
+            </Stack>
+          </Tabs.Panel>
+
+          <Tabs.Tab label="Reference" />
+          <Tabs.Panel>
+            <Typography variant="h3">Prop reference</Typography>
+            <Table data={data} columns={columns} constrainHeight={false} />
+          </Tabs.Panel>
+        </Tabs>
+
+        <Button
+          size="lg"
+          onClick={() => navigate(-1)}
+          style={{ marginTop: theme.spacing(1) }}
+        >
+          ← Back
+        </Button>
+      </Stack>
+    </Surface>
+  );
+}

--- a/docs/src/pages/IteratorDemo.tsx
+++ b/docs/src/pages/IteratorDemo.tsx
@@ -117,16 +117,16 @@ export default function IteratorDemoPage() {
           Compact numeric stepper with plus/minus controls. Scroll while
           hovering to change the value without moving the page.
         </Typography>
-        <Typography>
-          The field will increment when scrolling up and decrement when
-          scrolling down. Page scrolling is suppressed while hovering,
-          including on Firefox.
-        </Typography>
 
         <Tabs>
           <Tabs.Tab label="Usage" />
           <Tabs.Panel>
             <Stack>
+              <Typography>
+                The field will increment when scrolling up and decrement when
+                scrolling down. Page scrolling is suppressed while hovering,
+                including on Firefox.
+              </Typography>
               <Typography variant="h3">1. Uncontrolled</Typography>
               <Iterator defaultValue={3} />
 
@@ -147,8 +147,10 @@ export default function IteratorDemoPage() {
                 useStore={useFormStore}
                 onSubmitValues={(vals) => alert(JSON.stringify(vals))}
               >
-                <Iterator name="amount" />
-                <Button type="submit">Submit</Button>
+                <Stack direction="row" compact>
+                  <Iterator name="amount" />
+                  <Button type="submit">Submit</Button>
+                </Stack>
               </FormControl>
 
               <Typography variant="h3">6. Theme toggle</Typography>

--- a/src/components/fields/Iterator.tsx
+++ b/src/components/fields/Iterator.tsx
@@ -1,0 +1,181 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/fields/Iterator.tsx | valet
+// numeric stepper with plus/minus buttons and scroll wheel support
+// ─────────────────────────────────────────────────────────────
+import React, { forwardRef, useState, useEffect, useRef, useCallback } from 'react';
+import { styled } from '../../css/createStyled';
+import { useTheme } from '../../system/themeStore';
+import { preset } from '../../css/stylePresets';
+import { IconButton } from './IconButton';
+import { useForm } from './FormControl';
+import type { Presettable } from '../../types';
+import type { Theme } from '../../system/themeStore';
+
+/*───────────────────────────────────────────────────────────*/
+export interface IteratorProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'>, Presettable {
+  value?: number;
+  defaultValue?: number;
+  onChange?: (value: number) => void;
+  name?: string;
+  min?: number;
+  max?: number;
+  step?: number;
+  width?: number | string;
+}
+
+/*───────────────────────────────────────────────────────────*/
+const Wrapper = styled('div')<{ theme: Theme }>`
+  display: inline-flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.spacing(0.75)};
+`;
+
+const Field = styled('input')<{ theme: Theme; $w: string }>`
+  padding: ${({ theme }) => theme.spacing(0.5)};
+  border: 1px solid ${({ theme }) => theme.colors.text + '44'};
+  border-radius: 4px;
+  background: ${({ theme }) => theme.colors.background};
+  color: ${({ theme }) => theme.colors.text};
+  font-size: 0.875rem;
+  text-align: center;
+  width: ${({ $w }) => $w};
+  overscroll-behavior: contain;
+  -moz-appearance: textfield;
+  &::-webkit-inner-spin-button,
+  &::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+  &:focus {
+    outline: 2px solid ${({ theme }) => theme.colors.primary};
+    outline-offset: 1px;
+  }
+`;
+
+/*───────────────────────────────────────────────────────────*/
+export const Iterator = forwardRef<HTMLInputElement, IteratorProps>(
+  (
+    {
+      value: valueProp,
+      defaultValue,
+      onChange,
+      name,
+      min,
+      max,
+      step = 1,
+      width = '3.5rem',
+      disabled = false,
+      preset: p,
+      className,
+      style,
+      ...rest
+    },
+    ref,
+  ) => {
+    const { theme } = useTheme();
+
+    const localRef = useRef<HTMLInputElement | null>(null);
+    const setRef = useCallback(
+      (node: HTMLInputElement | null) => {
+        localRef.current = node;
+        if (typeof ref === 'function') ref(node);
+        else if (ref) (ref as any).current = node;
+      },
+      [ref],
+    );
+
+    let form: ReturnType<typeof useForm<any>> | null = null;
+    try { form = useForm<any>(); } catch {}
+
+    const formVal = form && name ? (form.values[name] as number | undefined) : undefined;
+    const controlled = valueProp !== undefined || formVal !== undefined;
+    const [internal, setInternal] = useState(defaultValue ?? 0);
+    const current = controlled ? (formVal ?? valueProp!) : internal;
+    const [text, setText] = useState(String(current));
+
+    useEffect(() => {
+      setText(String(current));
+    }, [current]);
+
+    const commit = (next: number) => {
+      if (min !== undefined && next < min) next = min;
+      if (max !== undefined && next > max) next = max;
+      if (!controlled) setInternal(next);
+      form?.setField(name as any, next);
+      onChange?.(next);
+      setText(String(next));
+    };
+
+    const handleInput: React.ChangeEventHandler<HTMLInputElement> = (e) => {
+      const val = e.target.value;
+      setText(val);
+      const num = parseFloat(val);
+      if (!Number.isNaN(num)) commit(num);
+    };
+
+    const handleBlur: React.FocusEventHandler<HTMLInputElement> = () => {
+      const num = parseFloat(text);
+      if (Number.isNaN(num)) setText(String(current));
+      else commit(num);
+    };
+
+    const stepBy = useCallback((dir: number) => {
+      commit(current + dir * step);
+    }, [current, step]);
+
+    const handleWheel = useCallback((e: WheelEvent) => {
+      if (disabled) return;
+      e.preventDefault();
+      e.stopPropagation();
+      stepBy(e.deltaY < 0 ? 1 : -1);
+    }, [disabled, stepBy]);
+
+    useEffect(() => {
+      const node = localRef.current;
+      if (!node) return;
+      node.addEventListener('wheel', handleWheel, { passive: false });
+      return () => node.removeEventListener('wheel', handleWheel);
+    }, [handleWheel]);
+
+    const cls = [p ? preset(p) : '', className].filter(Boolean).join(' ') || undefined;
+
+    const w = typeof width === 'number' ? `${width}px` : width;
+
+    return (
+      <Wrapper theme={theme} className={cls} style={style}>
+        <IconButton
+          size="xs"
+          variant="outlined"
+          icon="mdi:minus"
+          onClick={() => stepBy(-1)}
+          disabled={disabled}
+          aria-label="decrement"
+        />
+        <Field
+          {...rest}
+          ref={setRef}
+          type="number"
+          inputMode="numeric"
+          theme={theme}
+          $w={w}
+          value={text}
+          onChange={handleInput}
+          onBlur={handleBlur}
+          disabled={disabled}
+        />
+        <IconButton
+          size="xs"
+          variant="outlined"
+          icon="mdi:plus"
+          onClick={() => stepBy(1)}
+          disabled={disabled}
+          aria-label="increment"
+        />
+      </Wrapper>
+    );
+  },
+);
+
+Iterator.displayName = 'Iterator';
+
+export default Iterator;

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export type {
 export * from './components/fields/Slider';
 export * from './components/fields/Switch';
 export * from './components/fields/TextField';
+export * from './components/fields/Iterator';
 
 // ─── Widgets ─────────────────────────────────────────────────
 export * from './components/widgets/Accordion';


### PR DESCRIPTION
## Summary
- prevent scroll wheel from scrolling page on Iterator input
- contain overscroll in Iterator input so the page doesn't move
- mention suppressed scroll behavior in docs and changelog
- shrink Iterator buttons and field width

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687808dcf0388320a0b99ef83fa2339a