### PR TITLE
Fix overflow in tabs and panel

### DIFF
--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -44,7 +44,7 @@ const Base = styled('div')<{
     $center ? 'flex' : $full ? 'block' : 'inline-block'};
   width        : ${({ $full }) => ($full ? '100%'  : 'auto')};
   align-self   : ${({ $full }) => ($full ? 'stretch' : 'flex-start')};
-  margin       : ${({ $margin }) => $margin};
+  margin       : ${({ $margin, $full }) => ($full ? `${$margin} 0` : $margin)};
   & > * {
     padding: ${({ $pad }) => $pad};
   }

--- a/src/components/layout/Tabs.tsx
+++ b/src/components/layout/Tabs.tsx
@@ -42,9 +42,10 @@ const Root = styled('div')<{
   $placement : 'top' | 'bottom' | 'left' | 'right';
   $gap: string;
 }>`
+  box-sizing: border-box;
   width: 100%;
   display: grid;
-  margin: ${({ $gap }) => $gap};
+  margin: ${({ $gap }) => `${$gap} 0`};
   & > * {
     padding: ${({ $gap }) => $gap};
   }


### PR DESCRIPTION
## Summary
- clamp horizontal margin for Tabs to avoid page overflow
- adjust Panel margin when `fullWidth` is used

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68796c0fef088320961ba73d60dd28e9