### PR TITLE
Fix Panel fullWidth margin causing overflow

### DIFF
--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -123,7 +123,7 @@ export const Panel: React.FC<PanelProps> = ({
 
   const presetClasses = p ? preset(p) : '';
   const pad = theme.spacing(1);
-  const margin = compact ? '0' : pad;
+  const margin = compact ? '0' : fullWidth ? `${pad} 0` : pad;
 
   return (
     <Base


### PR DESCRIPTION
## Summary
- adjust Panel margin logic so `fullWidth` panels don't extend past screen edges

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68796c0fef088320961ba73d60dd28e9