### PR TITLE
Fix panel overflow on mobile

### DIFF
--- a/src/components/layout/Surface.tsx
+++ b/src/components/layout/Surface.tsx
@@ -151,7 +151,16 @@ export const Surface: React.FC<SurfaceProps> = ({
         {showBackdrop && (
           <LoadingBackdrop fading={fade} showSpinner={showSpinner} />
         )}
-        <div style={{ visibility: fontsReady ? 'visible' : 'hidden', padding: gap }}>{children}</div>
+        <div
+          style={{
+            visibility: fontsReady ? 'visible' : 'hidden',
+            padding: gap,
+            boxSizing: 'border-box',
+            width: '100%',
+          }}
+        >
+          {children}
+        </div>
       </div>
     </SurfaceCtx.Provider>
   );


### PR DESCRIPTION
## Summary
- ensure Surface inner container uses `box-sizing: border-box`
- give Surface inner container full width to prevent horizontal scrollbars

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68796c0fef088320961ba73d60dd28e9