### PR TITLE
Fix tabs and panel margin overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Fixed mobile horizontal overflow caused by full-width `Panel` margin and
+  `Tabs` container
+- Prevented `Stack` child margins from causing overflow by switching to
+  internal padding
 
 ## [0.15.1]
 - Adjusted size mappings for `IconButonn` and `Icon` 

--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -44,7 +44,8 @@ const Base = styled('div')<{
     $center ? 'flex' : $full ? 'block' : 'inline-block'};
   width        : ${({ $full }) => ($full ? '100%'  : 'auto')};
   align-self   : ${({ $full }) => ($full ? 'stretch' : 'flex-start')};
-  margin       : ${({ $margin }) => $margin};
+  margin       :
+    ${({ $margin, $full }) => ($full ? `${$margin} 0` : $margin)};
   & > * {
     padding: ${({ $pad }) => $pad};
   }

--- a/src/components/layout/Stack.tsx
+++ b/src/components/layout/Stack.tsx
@@ -37,10 +37,8 @@ const StackContainer = styled('div')<{
   align-items: ${({ $dir }) => ($dir === 'row' ? 'center' : 'stretch')};
   gap: ${({ $gap }) => $gap};
   ${({ $wrap }) => ($wrap ? 'flex-wrap: wrap;' : '')}
-  margin: ${({ $margin }) => $margin};
-  & > * {
-    margin: ${({ $pad }) => $pad};
-  }
+  margin : ${({ $margin }) => $margin};
+  padding: ${({ $pad }) => $pad};
 `;
 
 /*───────────────────────────────────────────────────────────*/

--- a/src/components/layout/Tabs.tsx
+++ b/src/components/layout/Tabs.tsx
@@ -44,7 +44,7 @@ const Root = styled('div')<{
 }>`
   width: 100%;
   display: grid;
-  margin: ${({ $gap }) => $gap};
+  margin: ${({ $gap }) => `${$gap} 0`};
   & > * {
     padding: ${({ $gap }) => $gap};
   }


### PR DESCRIPTION
## Summary
- avoid horizontal margin when a Panel is `fullWidth`
- remove horizontal margin from Tabs root
- use padding in Stack to prevent overflow
- document the fix in the changelog

## Testing
- `npm run build`
- `npm --prefix docs run build`

------
https://chatgpt.com/codex/tasks/task_e_68796c0fef088320961ba73d60dd28e9