### PR TITLE
Fix tabs overflow and panel width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Fixed mobile horizontal overflow caused by full-width `Panel` margin and
+  `Tabs` container
+- Panels now emit a `data-valet-fullwidth` flag so parent Stacks can remove
+  side margins, preventing overflow inside Tabs
 
 ## [0.15.1]
 - Adjusted size mappings for `IconButonn` and `Icon` 

--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -44,7 +44,8 @@ const Base = styled('div')<{
     $center ? 'flex' : $full ? 'block' : 'inline-block'};
   width        : ${({ $full }) => ($full ? '100%'  : 'auto')};
   align-self   : ${({ $full }) => ($full ? 'stretch' : 'flex-start')};
-  margin       : ${({ $margin }) => $margin};
+  margin       :
+    ${({ $margin, $full }) => ($full ? `${$margin} 0` : $margin)};
   & > * {
     padding: ${({ $pad }) => $pad};
   }
@@ -128,6 +129,7 @@ export const Panel: React.FC<PanelProps> = ({
   return (
     <Base
       {...rest}
+      data-valet-fullwidth={fullWidth || undefined}
       $variant={variant}
       $full={fullWidth}
       $center={centered}

--- a/src/components/layout/Stack.tsx
+++ b/src/components/layout/Stack.tsx
@@ -41,6 +41,10 @@ const StackContainer = styled('div')<{
   & > * {
     margin: ${({ $pad }) => $pad};
   }
+  & > [data-valet-fullwidth] {
+    margin-left: 0;
+    margin-right: 0;
+  }
 `;
 
 /*───────────────────────────────────────────────────────────*/

--- a/src/components/layout/Tabs.tsx
+++ b/src/components/layout/Tabs.tsx
@@ -44,7 +44,8 @@ const Root = styled('div')<{
 }>`
   width: 100%;
   display: grid;
-  margin: ${({ $gap }) => $gap};
+  margin: ${({ $gap }) => `${$gap} 0`};
+  overflow-x: hidden;
   & > * {
     padding: ${({ $gap }) => $gap};
   }


### PR DESCRIPTION
## Summary
- avoid horizontal margin when Stacks contain full-width Panels
- mark full-width Panels so Stacks can detect them
- hide horizontal overflow in Tabs
- document the fix

## Testing
- `npm run build`
- `npm run build` in docs

------
https://chatgpt.com/codex/tasks/task_e_68796c0fef088320961ba73d60dd28e9