### PR TITLE
Fix tabs panel width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Fixed mobile horizontal overflow caused by full-width `Panel` margin and
+  `Tabs` container
+- Prevented `Stack` child margins from causing overflow by switching to
+  internal padding
+- Ensured `Tabs` width stays within the viewport by sizing its tab list with
+  `box-sizing: border-box`
 
 ## [0.15.1]
 - Adjusted size mappings for `IconButonn` and `Icon` 

--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -44,7 +44,8 @@ const Base = styled('div')<{
     $center ? 'flex' : $full ? 'block' : 'inline-block'};
   width        : ${({ $full }) => ($full ? '100%'  : 'auto')};
   align-self   : ${({ $full }) => ($full ? 'stretch' : 'flex-start')};
-  margin       : ${({ $margin }) => $margin};
+  margin       :
+    ${({ $margin, $full }) => ($full ? `${$margin} 0` : $margin)};
   & > * {
     padding: ${({ $pad }) => $pad};
   }

--- a/src/components/layout/Stack.tsx
+++ b/src/components/layout/Stack.tsx
@@ -37,10 +37,8 @@ const StackContainer = styled('div')<{
   align-items: ${({ $dir }) => ($dir === 'row' ? 'center' : 'stretch')};
   gap: ${({ $gap }) => $gap};
   ${({ $wrap }) => ($wrap ? 'flex-wrap: wrap;' : '')}
-  margin: ${({ $margin }) => $margin};
-  & > * {
-    margin: ${({ $pad }) => $pad};
-  }
+  margin : ${({ $margin }) => $margin};
+  padding: ${({ $pad }) => $pad};
 `;
 
 /*───────────────────────────────────────────────────────────*/

--- a/src/components/layout/Tabs.tsx
+++ b/src/components/layout/Tabs.tsx
@@ -42,9 +42,10 @@ const Root = styled('div')<{
   $placement : 'top' | 'bottom' | 'left' | 'right';
   $gap: string;
 }>`
+  box-sizing: border-box;
   width: 100%;
   display: grid;
-  margin: ${({ $gap }) => $gap};
+  margin: ${({ $gap }) => `${$gap} 0`};
   & > * {
     padding: ${({ $gap }) => $gap};
   }
@@ -74,6 +75,7 @@ const Root = styled('div')<{
 const TabList = styled('div')<{
   $orientation: 'horizontal' | 'vertical';
 }>`
+  box-sizing: border-box;
   display: flex;
   flex-direction: ${({ $orientation }) =>
     $orientation === 'vertical' ? 'column' : 'row'};


### PR DESCRIPTION
## Summary
- size `Tabs` children with border-box to prevent overflow
- document the tab list sizing fix

## Testing
- `npm run build`
- `npm --prefix docs run build`


------
https://chatgpt.com/codex/tasks/task_e_68796c0fef088320961ba73d60dd28e9