### PR TITLE
Fix persistent mobile overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Fixed persistent mobile overflow in the Panel demo by ensuring `Tabs` and
+  `Stack` account for internal padding via `box-sizing`
 
 ## [0.15.1]
 - Adjusted size mappings for `IconButonn` and `Icon` 

--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -44,7 +44,8 @@ const Base = styled('div')<{
     $center ? 'flex' : $full ? 'block' : 'inline-block'};
   width        : ${({ $full }) => ($full ? '100%'  : 'auto')};
   align-self   : ${({ $full }) => ($full ? 'stretch' : 'flex-start')};
-  margin       : ${({ $margin }) => $margin};
+  margin       :
+    ${({ $margin, $full }) => ($full ? `${$margin} 0` : $margin)};
   & > * {
     padding: ${({ $pad }) => $pad};
   }

--- a/src/components/layout/Stack.tsx
+++ b/src/components/layout/Stack.tsx
@@ -32,15 +32,15 @@ const StackContainer = styled('div')<{
   $margin: string;
   $pad: string;
 }>`
+  box-sizing: border-box;
+  width: 100%;
   display: flex;
   flex-direction: ${({ $dir }) => $dir};
   align-items: ${({ $dir }) => ($dir === 'row' ? 'center' : 'stretch')};
   gap: ${({ $gap }) => $gap};
   ${({ $wrap }) => ($wrap ? 'flex-wrap: wrap;' : '')}
-  margin: ${({ $margin }) => $margin};
-  & > * {
-    margin: ${({ $pad }) => $pad};
-  }
+  margin : ${({ $margin }) => $margin};
+  padding: ${({ $pad }) => $pad};
 `;
 
 /*───────────────────────────────────────────────────────────*/

--- a/src/components/layout/Tabs.tsx
+++ b/src/components/layout/Tabs.tsx
@@ -43,8 +43,9 @@ const Root = styled('div')<{
   $gap: string;
 }>`
   width: 100%;
+  box-sizing: border-box;
   display: grid;
-  margin: ${({ $gap }) => $gap};
+  margin: ${({ $gap }) => `${$gap} 0`};
   & > * {
     padding: ${({ $gap }) => $gap};
   }
@@ -79,8 +80,9 @@ const TabList = styled('div')<{
     $orientation === 'vertical' ? 'column' : 'row'};
   gap: 0;
 
-  ${({ $orientation }) =>
-    $orientation === 'vertical' && 'width: max-content;'}
+  box-sizing: border-box;
+  width: ${({ $orientation }) =>
+    $orientation === 'vertical' ? 'max-content' : '100%'};
 `;
 
 /*───────────────────────────────────────────────────────────*/
@@ -128,6 +130,7 @@ const Panel = styled('div')`
   padding: 1rem 0;
   overflow: visible;
   box-sizing: border-box;
+  width: 100%;
   min-height: 0;
 `;
 


### PR DESCRIPTION
## Summary
- enforce border-box and width constraints in `Stack` and `Tabs`
- document the mobile overflow fix in the changelog

## Testing
- `npm run build`
- `npm --prefix docs run build`


------
https://chatgpt.com/codex/tasks/task_e_68796c0fef088320961ba73d60dd28e9