### PR TITLE
Fix panel background with presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Default Panel background ignored when preset present
 
 ## [0.16.0]
 - Adjust sizing and spacing for:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file. The format 
 - Default Panel background ignored when a preset was present
 - Panel now checks presets for a custom background before falling back
 
+## [0.16.1]
+- Bugfix on `Panel` default background
+
 ## [0.16.0]
 - Adjust sizing and spacing for:
   - Box

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 ### Fixed
-- Default Panel background ignored when preset present
+- Default Panel background ignored when a preset was present
+- Panel now checks presets for a custom background before falling back
 
 ## [0.16.0]
 - Adjust sizing and spacing for:

--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -102,13 +102,12 @@ export const Panel: React.FC<PanelProps> = ({
   ...rest
 }) => {
   const { theme } = useTheme();
-  const hasPreset = Boolean(p);
   const hasBgProp = typeof background === 'string';
 
   /* Resolve background */
   const bg: string | undefined = hasBgProp
     ? background!
-    : !hasPreset && variant === 'main'
+    : variant === 'main'
     ? theme.colors.backgroundAlt
     : undefined;
 

--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { styled } from '../../css/createStyled';
 import { useTheme } from '../../system/themeStore';
-import { preset } from '../../css/stylePresets';
+import { preset, presetHas } from '../../css/stylePresets';
 import type { Presettable } from '../../types';
 
 export type PanelVariant = 'main' | 'alt';
@@ -103,11 +103,12 @@ export const Panel: React.FC<PanelProps> = ({
 }) => {
   const { theme } = useTheme();
   const hasBgProp = typeof background === 'string';
+  const hasPresetBg = p ? presetHas(p, 'background') : false;
 
   /* Resolve background */
   const bg: string | undefined = hasBgProp
     ? background!
-    : variant === 'main'
+    : !hasPresetBg && variant === 'main'
     ? theme.colors.backgroundAlt
     : undefined;
 

--- a/src/css/stylePresets.ts
+++ b/src/css/stylePresets.ts
@@ -68,3 +68,17 @@ export function preset(names: string | string[]) {
     })
     .join(' ');
 }
+
+export function presetHas(
+  names: string | string[],
+  property: string,
+): boolean {
+  const list = Array.isArray(names) ? names : [names];
+  for (const name of list) {
+    const entry = registry.get(name);
+    if (entry && entry.rule.style.getPropertyValue(property)) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
- fix fallback background logic for `Panel`
- note change in changelog

## Testing
- `npm run build`
- `npm run build` in docs

------
https://chatgpt.com/codex/tasks/task_e_6879d7186f608320ac0641ee43c93f52