### PR TITLE
Add range mode to DateSelector

### DIFF
--- a/docs/src/pages/DateSelectorDemo.tsx
+++ b/docs/src/pages/DateSelectorDemo.tsx
@@ -24,6 +24,10 @@ export default function DateSelectorDemoPage() {
   const navigate = useNavigate();
   const [selected, setSelected] = useState('2025-01-01');
   const [limited, setLimited] = useState('2025-07-15');
+  const [rangeDates, setRangeDates] = useState<[string, string]>([
+    '2025-07-01',
+    '2025-07-10',
+  ]);
 
   interface Row {
     prop: ReactNode;
@@ -82,6 +86,30 @@ export default function DateSelectorDemoPage() {
       default: <code>'120y ahead'</code>,
       description: 'Latest selectable date',
     },
+    {
+      prop: <code>range</code>,
+      type: <code>boolean</code>,
+      default: <code>false</code>,
+      description: 'Enable dual start/end selection',
+    },
+    {
+      prop: <code>endValue</code>,
+      type: <code>string</code>,
+      default: <code>-</code>,
+      description: 'Controlled end date when range is true',
+    },
+    {
+      prop: <code>defaultEndValue</code>,
+      type: <code>string</code>,
+      default: <code>-</code>,
+      description: 'Uncontrolled end date default',
+    },
+    {
+      prop: <code>onRangeChange</code>,
+      type: <code>(start: string, end: string) =&gt; void</code>,
+      default: <code>-</code>,
+      description: 'Fires when range selection changes',
+    },
   ];
 
   return (
@@ -112,6 +140,14 @@ export default function DateSelectorDemoPage() {
               onChange={setLimited}
               minDate="2025-06-01"
               maxDate="2025-09-15"
+            />
+
+            <Typography variant="h3">4. Range mode</Typography>
+            <DateSelector
+              range
+              value={rangeDates[0]}
+              endValue={rangeDates[1]}
+              onRangeChange={(s, e) => setRangeDates([s, e])}
             />
 
             <Stack direction="row">

--- a/src/components/fields/DateSelector.tsx
+++ b/src/components/fields/DateSelector.tsx
@@ -9,6 +9,7 @@ import { preset } from '../../css/stylePresets';
 import { IconButton } from './IconButton';
 import { Select } from './Select';
 import { useForm } from './FormControl';
+import { toRgb, mix, toHex } from '../../helpers/color';
 import type { Presettable } from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
@@ -27,6 +28,14 @@ export interface DateSelectorProps
   minDate?: string;
   /** Latest selectable ISO date (YYYY-MM-DD). */
   maxDate?: string;
+  /** Enable dual start/end selection mode. */
+  range?: boolean;
+  /** Controlled end date when `range` is true. */
+  endValue?: string;
+  /** Default end date for uncontrolled range mode. */
+  defaultEndValue?: string;
+  /** Fires with start and end ISO values when range changes. */
+  onRangeChange?: (start: string, end: string) => void;
 }
 
 /*───────────────────────────────────────────────────────────*/
@@ -58,12 +67,20 @@ const DayLabel = styled('div')`
   opacity: 0.8;
 `;
 
-const Cell = styled('button')<{ $selected: boolean; $primary: string }>`
+const Cell = styled('button')<{
+  $selected: boolean;
+  $outline: boolean;
+  $inRange: boolean;
+  $primary: string;
+  $rangeBg: string;
+}>`
   padding: 0.25rem 0;
-  border: none;
-  background: ${({ $selected, $primary }) =>
-    $selected ? $primary : 'transparent'};
-  color: inherit;
+  border: ${({ $outline, $primary }) =>
+    $outline ? `1px solid ${$primary}` : 'none'};
+  background: ${({ $selected, $inRange, $primary, $rangeBg }) =>
+    $selected ? $primary : $inRange ? $rangeBg : 'transparent'};
+  color: ${({ $outline, $primary }) =>
+    $outline ? $primary : 'inherit'};
   border-radius: 4px;
   cursor: pointer;
   font: inherit;
@@ -94,6 +111,10 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
   value,
   defaultValue,
   onChange,
+  range = false,
+  endValue,
+  defaultEndValue,
+  onRangeChange,
   name,
   minDate: minDateProp,
   maxDate: maxDateProp,
@@ -108,9 +129,13 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
 
   const formVal = form && name ? (form.values[name] as string | undefined) : undefined;
   const controlled = value !== undefined || formVal !== undefined;
-  const initial = value ?? formVal ?? defaultValue;
-  const parseDate = (v?: string) => v ? new Date(v + 'T00:00') : new Date();
-  const [internal, setInternal] = useState(parseDate(initial));
+  const parseDate = (v?: string) => (v ? new Date(v + 'T00:00') : new Date());
+
+  const initialStart = value ?? formVal ?? defaultValue;
+  const initialEnd = endValue ?? defaultEndValue ?? initialStart;
+
+  const [startInt, setStartInt] = useState(parseDate(initialStart));
+  const [endInt, setEndInt] = useState(parseDate(initialEnd));
 
   const today = new Date();
   const min = minDateProp ? parseDate(minDateProp) : new Date(today.getFullYear() - 120, 0, 1);
@@ -119,10 +144,13 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
   const minYear = min.getFullYear();
   const maxYear = max.getFullYear();
 
+  const startDate = controlled ? parseDate(value ?? formVal) : startInt;
+  const endDate = range
+    ? (endValue !== undefined ? parseDate(endValue) : endInt)
+    : startDate;
 
-  const selected = controlled ? parseDate(value ?? formVal) : internal;
-  const [viewYear, setViewYear] = useState(selected.getFullYear());
-  const [viewMonth, setViewMonth] = useState(selected.getMonth());
+  const [viewYear, setViewYear] = useState(startDate.getFullYear());
+  const [viewMonth, setViewMonth] = useState(startDate.getMonth());
 
   const years = Array.from({ length: maxYear - minYear + 1 }, (_, i) => minYear + i);
 
@@ -137,9 +165,35 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
 
   const commit = (d: number) => {
     const iso = new Date(viewYear, viewMonth, d).toISOString().slice(0, 10);
-    if (!controlled) setInternal(new Date(viewYear, viewMonth, d));
+    if (!controlled) setStartInt(new Date(viewYear, viewMonth, d));
     if (form && name) form.setField(name as any, iso);
     onChange?.(iso);
+  };
+
+  const commitRange = (d: number) => {
+    const clicked = new Date(viewYear, viewMonth, d);
+    let start = startDate;
+    let end = endDate;
+
+    if (start.getTime() !== end.getTime()) {
+      start = clicked;
+      end = clicked;
+    } else {
+      if (clicked < start) {
+        start = clicked;
+      } else {
+        end = clicked;
+      }
+      if (start > end) {
+        const tmp = start;
+        start = end;
+        end = tmp;
+      }
+    }
+
+    if (!controlled) setStartInt(start);
+    if (endValue === undefined) setEndInt(end);
+    onRangeChange?.(start.toISOString().slice(0, 10), end.toISOString().slice(0, 10));
   };
 
   const changeMonth = (delta: number) => {
@@ -158,6 +212,10 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
 
   const presetCls = p ? preset(p) : '';
   const cls = [presetCls, className].filter(Boolean).join(' ') || undefined;
+
+  const rangeBg = toHex(
+    mix(toRgb(theme.colors.secondary), toRgb(theme.colors.background), 0.25),
+  );
 
   return (
     <Wrapper
@@ -268,16 +326,30 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
           const day = i + 1;
           const date = new Date(viewYear, viewMonth, day);
           const disabled = date < min || date > max;
-          const selectedDay =
-            selected.getFullYear() === viewYear &&
-            selected.getMonth() === viewMonth &&
-            selected.getDate() === day;
+          const startSel =
+            startDate.getFullYear() === viewYear &&
+            startDate.getMonth() === viewMonth &&
+            startDate.getDate() === day;
+          const endSel =
+            range &&
+            endDate.getFullYear() === viewYear &&
+            endDate.getMonth() === viewMonth &&
+            endDate.getDate() === day;
+          const inRange =
+            range &&
+            date > startDate &&
+            date < endDate;
           return (
             <Cell
               key={day}
-              $selected={selectedDay}
+              $selected={startSel}
+              $outline={!!endSel && !startSel}
+              $inRange={!!inRange}
               $primary={theme.colors.primary}
-              onClick={() => !disabled && commit(day)}
+              $rangeBg={rangeBg}
+              onClick={() =>
+                !disabled && (range ? commitRange(day) : commit(day))
+              }
               disabled={disabled}
             >
               {day}


### PR DESCRIPTION
## Summary
- support dual date selection with a `range` prop
- style outlined end date and highlight days between
- demo new prop in docs

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6879e795f14c8320b5485c9c9a90c3f0