### PR TITLE
Adjust chat bubble width

### DIFF
--- a/docs/src/pages/OAIChatDemo.tsx
+++ b/docs/src/pages/OAIChatDemo.tsx
@@ -23,9 +23,19 @@ export default function OAIChatDemoPage() {
   const [messages, setMessages] = useState<ChatMessage[]>([
     { role: 'assistant', content: 'Hello! How can I help you?' },
     { role: 'user', content: 'Tell me about valet.' },
-    { role: 'assistant', content: 'It\'s a tiny React UI kit focused on AI driven interfaces.' },
+    { role: 'assistant', content: "It's a tiny React UI kit focused on AI driven interfaces." },
     { role: 'user', content: 'Nice, how can I contribute?' },
     { role: 'assistant', content: 'Check the repository README for guidelines.' },
+    {
+      role: 'user',
+      content:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
+    },
+    {
+      role: 'assistant',
+      content:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+    },
   ]);
 
   const handleSend = (m: ChatMessage) => {

--- a/src/components/widgets/OAIChat.tsx
+++ b/src/components/widgets/OAIChat.tsx
@@ -95,12 +95,14 @@ export const OAIChat: React.FC<ChatProps> = ({
   const surface = useSurface(
     s => ({
       element: s.element,
+      width: s.width,
       height: s.height,
       registerChild: s.registerChild,
       unregisterChild: s.unregisterChild,
     }),
     shallow,
   );
+  const portrait = surface.height > surface.width;
   const wrapRef = useRef<HTMLDivElement>(null);
   const uniqueId = useId();
   const [maxHeight, setMaxHeight] = useState<number>();
@@ -200,22 +202,28 @@ export const OAIChat: React.FC<ChatProps> = ({
           $gap={theme.spacing(1.5)}
           style={shouldConstrain ? { overflowY: 'auto', maxHeight } : undefined}
         >
-          {messages.map((m, i) => (
-            <Row
-              key={i}
-              $from={m.role}
-              $left={m.role === 'user' ? theme.spacing(24) : theme.spacing(3)}
-              $right={m.role === 'user' ? theme.spacing(3) : theme.spacing(24)}
-            >
+          {messages.map((m, i) => {
+            const sidePad = portrait ? theme.spacing(8) : theme.spacing(24);
+            const avatarPad = theme.spacing(1);
+            return (
+              <Row
+                key={i}
+                $from={m.role}
+                $left={m.role === 'user' ? sidePad : avatarPad}
+                $right={m.role === 'user' ? avatarPad : sidePad}
+              >
               {m.role !== 'user' && systemAvatar && (
-                <Avatar src={systemAvatar} size="s" style={{ marginRight: theme.spacing(1) }} />
+                <Avatar
+                  src={systemAvatar}
+                  size="s"
+                  style={{ marginRight: theme.spacing(1) }}
+                />
               )}
               <Panel
-                fullWidth
                 compact
                 variant="main"
                 background={m.role === 'user' ? theme.colors.primary : undefined}
-                style={{ borderRadius: theme.spacing(0.5) }}
+                style={{ maxWidth: '100%', width: 'fit-content', borderRadius: theme.spacing(0.5) }}
               >
                 {m.name && (
                   <Typography variant="subtitle" bold>
@@ -225,10 +233,15 @@ export const OAIChat: React.FC<ChatProps> = ({
                 <Typography>{m.content}</Typography>
               </Panel>
               {m.role === 'user' && userAvatar && (
-                <Avatar src={userAvatar} size="s" style={{ marginLeft: theme.spacing(1) }} />
+                <Avatar
+                  src={userAvatar}
+                  size="s"
+                  style={{ marginLeft: theme.spacing(1) }}
+                />
               )}
-            </Row>
-          ))}
+              </Row>
+            );
+          })}
         </Messages>
 
         {!disableInput && (


### PR DESCRIPTION
## Summary
- shrink chat bubbles to fit the content
- extend chat demo with long lorem ipsum text
- limit chat bubble width based on orientation
- reduce outer padding around avatars

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879f698354c832098469e018c65ad10