### PR TITLE
Add OpenAI chat connection header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Changed
 - `OAIChat` starts disconnected with a built-in AppBar to manage the OpenAI key
+- Chat AppBar uses the secondary color scheme
 
 ### Improved
 - `KeyModal` now shows an error when an incorrect passphrase is entered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- `KeyModal` component and secure `openaiKeyStore` for browser-stored keys
+- `sendChat` helper for direct OpenAI conversations
+- `KeyModal` now allows deleting the stored key
+
+### Changed
+- `OAIChat` starts disconnected with a built-in AppBar to manage the OpenAI key
+
+### Improved
+- `KeyModal` now shows an error when an incorrect passphrase is entered
 
 ## [0.16.3]
 - Improved `OAIChat` styling, especially on mobile / portrait. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ### Improved
 - `KeyModal` now shows an error when an incorrect passphrase is entered
+- Chat demo no longer records attempts when the API key is missing
 
 ## [0.16.3]
 - Improved `OAIChat` styling, especially on mobile / portrait. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Changed
 - `OAIChat` starts disconnected with a built-in AppBar to manage the OpenAI key
 - Chat AppBar uses the secondary color scheme
+- Chat text field now fills available width
 
 ### Fixed
 - `OAIChat` no longer displays system prompt messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file. The format 
 - `OAIChat` starts disconnected with a built-in AppBar to manage the OpenAI key
 - Chat AppBar uses the secondary color scheme
 
+### Fixed
+- `OAIChat` no longer displays system prompt messages
+
 ### Improved
 - `KeyModal` now shows an error when an incorrect passphrase is entered
 - Chat demo no longer records attempts when the API key is missing

--- a/docs/src/pages/OAIChatDemo.tsx
+++ b/docs/src/pages/OAIChatDemo.tsx
@@ -9,6 +9,7 @@ import {
   Typography,
   Button,
   OAIChat,
+  sendChat,
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
@@ -21,25 +22,22 @@ export default function OAIChatDemoPage() {
   const navigate = useNavigate();
   const { theme, toggleMode } = useTheme();
   const [messages, setMessages] = useState<ChatMessage[]>([
-    { role: 'assistant', content: 'Hello! How can I help you?' },
-    { role: 'user', content: 'Tell me about valet.' },
-    { role: 'assistant', content: "It's a tiny React UI kit focused on AI driven interfaces." },
-    { role: 'user', content: 'Nice, how can I contribute?' },
-    { role: 'assistant', content: 'Check the repository README for guidelines.' },
-    {
-      role: 'user',
-      content:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.'
-    },
-    {
-      role: 'assistant',
-      content:
-        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
-    },
+    { role: 'system', content: 'You are a helpful assistant.' },
   ]);
 
-  const handleSend = (m: ChatMessage) => {
-    setMessages(prev => [...prev, m, { role: 'assistant', content: `Echo: ${m.content}` }]);
+  const handleSend = async (m: ChatMessage) => {
+    const history = [...messages, m];
+    setMessages(history);
+    try {
+      const res = await sendChat(history);
+      const reply = res.choices[0]?.message as ChatMessage | undefined;
+      if (reply) setMessages(prev => [...prev, reply]);
+    } catch (err: any) {
+      setMessages(prev => [
+        ...prev,
+        { role: 'assistant', content: String(err.message || err) },
+      ]);
+    }
   };
 
   return (

--- a/docs/src/pages/OAIChatDemo.tsx
+++ b/docs/src/pages/OAIChatDemo.tsx
@@ -10,6 +10,7 @@ import {
   Button,
   OAIChat,
   sendChat,
+  Snackbar,
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
@@ -24,6 +25,7 @@ export default function OAIChatDemoPage() {
   const [messages, setMessages] = useState<ChatMessage[]>([
     { role: 'system', content: 'You are a helpful assistant.' },
   ]);
+  const [noKey, setNoKey] = useState(false);
 
   const handleSend = async (m: ChatMessage) => {
     const history = [...messages, m];
@@ -33,10 +35,15 @@ export default function OAIChatDemoPage() {
       const reply = res.choices[0]?.message as ChatMessage | undefined;
       if (reply) setMessages(prev => [...prev, reply]);
     } catch (err: any) {
-      setMessages(prev => [
-        ...prev,
-        { role: 'assistant', content: String(err.message || err) },
-      ]);
+      const msg = String(err.message || err);
+      if (msg.includes('No OpenAI key set')) {
+        setNoKey(true);
+      } else {
+        setMessages(prev => [
+          ...prev,
+          { role: 'assistant', content: msg },
+        ]);
+      }
     }
   };
 
@@ -58,6 +65,12 @@ export default function OAIChatDemoPage() {
           userAvatar={present}
           systemAvatar={monkey}
         />
+        {noKey && (
+          <Snackbar
+            message="No OpenAI key set"
+            onClose={() => setNoKey(false)}
+          />
+        )}
 
         <Button variant="outlined" onClick={toggleMode}>
           Toggle light / dark mode

--- a/docs/src/pages/OAIChatDemo.tsx
+++ b/docs/src/pages/OAIChatDemo.tsx
@@ -11,6 +11,7 @@ import {
   OAIChat,
   sendChat,
   Snackbar,
+  useOpenAIKey,
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
@@ -28,6 +29,10 @@ export default function OAIChatDemoPage() {
   const [noKey, setNoKey] = useState(false);
 
   const handleSend = async (m: ChatMessage) => {
+    if (!useOpenAIKey.getState().apiKey) {
+      setNoKey(true);
+      return;
+    }
     const history = [...messages, m];
     setMessages(history);
     try {
@@ -36,7 +41,7 @@ export default function OAIChatDemoPage() {
       if (reply) setMessages(prev => [...prev, reply]);
     } catch (err: any) {
       const msg = String(err.message || err);
-      if (msg.includes('No OpenAI key set')) {
+      if (msg.includes('No OpenAI key set yet')) {
         setNoKey(true);
       } else {
         setMessages(prev => [
@@ -67,7 +72,7 @@ export default function OAIChatDemoPage() {
         />
         {noKey && (
           <Snackbar
-            message="No OpenAI key set"
+            message="No OpenAI key set yet"
             onClose={() => setNoKey(false)}
           />
         )}

--- a/src/components/KeyModal.tsx
+++ b/src/components/KeyModal.tsx
@@ -1,0 +1,108 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/KeyModal.tsx | valet
+// modal to capture an OpenAI API key
+// ─────────────────────────────────────────────────────────────
+import { useState } from 'react';
+import Modal from './layout/Modal';
+import Panel from './layout/Panel';
+import Stack from './layout/Stack';
+import Typography from './primitives/Typography';
+import Button from './fields/Button';
+import { useOpenAIKey } from '../system/openaiKeyStore';
+import { useTheme } from '../system/themeStore';
+
+export interface KeyModalProps {
+  open: boolean;
+  onClose?: () => void;
+}
+
+export default function KeyModal({ open, onClose }: KeyModalProps) {
+  const { apiKey, cipher, setKey, applyPassphrase, clearKey } = useOpenAIKey();
+  const [value, setValue] = useState('');
+  const [remember, setRemember] = useState(false);
+  const [passphrase, setPassphrase] = useState('');
+  const [error, setError] = useState('');
+  const { theme } = useTheme();
+
+  if (!open) return null;
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <Panel centered compact style={{ maxWidth: 480 }}>
+        <Stack spacing={1}>
+          <Typography variant="h3" bold>
+            {cipher ? 'Unlock OpenAI key' : 'Paste your OpenAI key'}
+          </Typography>
+
+          {!cipher && (
+            <input
+              style={{ fontFamily: 'monospace', width: '100%', padding: '0.5rem' }}
+              type="password"
+              placeholder="sk-..."
+              value={value}
+              onChange={(e) => {
+                setValue(e.target.value);
+                if (error) setError('');
+              }}
+            />
+          )}
+
+          {(remember || cipher) && (
+            <input
+              type="password"
+              placeholder="passphrase"
+              value={passphrase}
+              onChange={(e) => {
+                setPassphrase(e.target.value);
+                if (error) setError('');
+              }}
+              style={{ width: '100%', padding: '0.5rem' }}
+            />
+          )}
+
+          {error && (
+            <Typography color={theme.colors.secondary}>{error}</Typography>
+          )}
+
+          {!cipher && (
+            <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+              <input
+                type="checkbox"
+                checked={remember}
+                onChange={(e) => setRemember(e.target.checked)}
+              />
+              <Typography>remember this key (encrypted)</Typography>
+            </label>
+          )}
+
+          <Button
+            fullWidth
+            disabled={cipher ? !passphrase : (!value.trim() || (remember && !passphrase))}
+            onClick={async () => {
+              setError('');
+              if (cipher) {
+                const ok = await applyPassphrase(passphrase);
+                if (!ok) {
+                  setError('Incorrect passphrase');
+                  return;
+                }
+              } else {
+                await setKey(value.trim(), remember ? passphrase : undefined);
+              }
+              onClose?.();
+            }}
+          >
+            Save &amp; Continue
+          </Button>
+
+          {(cipher || apiKey) && (
+            <Button variant="outlined" fullWidth onClick={() => { clearKey(); onClose?.(); }}>
+              Delete stored key
+            </Button>
+          )}
+        </Stack>
+      </Panel>
+    </Modal>
+  );
+}
+

--- a/src/components/widgets/OAIChat.tsx
+++ b/src/components/widgets/OAIChat.tsx
@@ -213,7 +213,7 @@ export const OAIChat: React.FC<ChatProps> = ({
         style={style}
         className={cls}
       >
-        <Bar $bg={theme.colors.primary} $text={theme.colors.primaryText} $gap={theme.spacing(0.5)}>
+        <Bar $bg={theme.colors.secondary} $text={theme.colors.secondaryText} $gap={theme.spacing(0.5)}>
           <span />
           <span
             style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', gap: theme.spacing(0.5) }}

--- a/src/components/widgets/OAIChat.tsx
+++ b/src/components/widgets/OAIChat.tsx
@@ -73,7 +73,8 @@ const Row = styled('div') <{
 `;
 
 const InputRow = styled('form')`
-  align-self: center;
+  align-self: stretch;
+  width: 100%;
 `;
 
 const Bar = styled('div')<{ $bg: string; $text: string; $gap: string }>`
@@ -279,7 +280,7 @@ export const OAIChat: React.FC<ChatProps> = ({
 
         {!disableInput && (
           <InputRow onSubmit={handleSubmit}>
-            <Stack direction="row" spacing={1} compact>
+            <Stack direction="row" spacing={1} compact style={{ width: '100%' }}>
               <TextField
                 as="textarea"
                 name="chat-message"
@@ -287,6 +288,7 @@ export const OAIChat: React.FC<ChatProps> = ({
                 onChange={(e) => setText(e.target.value)}
                 rows={1}
                 placeholder={placeholder}
+                style={{ flex: 1 }}
               />
               <IconButton icon="carbon:send" type="submit" aria-label="Send" />
             </Stack>

--- a/src/components/widgets/OAIChat.tsx
+++ b/src/components/widgets/OAIChat.tsx
@@ -19,6 +19,8 @@ import TextField from '../fields/TextField';
 import Panel from '../layout/Panel';
 import Typography from '../primitives/Typography';
 import Avatar from '../primitives/Avatar';
+import KeyModal from '../KeyModal';
+import { useOpenAIKey } from '../../system/openaiKeyStore';
 import type { Presettable } from '../../types';
 import Stack from '../layout/Stack';
 
@@ -74,6 +76,18 @@ const InputRow = styled('form')`
   align-self: center;
 `;
 
+const Bar = styled('div')<{ $bg: string; $text: string; $gap: string }>`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background: ${({ $bg }) => $bg};
+  color: ${({ $text }) => $text};
+  & > * {
+    padding: ${({ $gap }) => $gap};
+  }
+`;
+
 /*───────────────────────────────────────────────────────────*/
 /* Component                                                  */
 export const OAIChat: React.FC<ChatProps> = ({
@@ -108,6 +122,8 @@ export const OAIChat: React.FC<ChatProps> = ({
   const constraintRef = useRef(false);
 
   const [text, setText] = useState('');
+  const { apiKey } = useOpenAIKey();
+  const [showKeyModal, setShowKeyModal] = useState(false);
 
   const calcCutoff = () => {
     if (typeof document === 'undefined') return 32;
@@ -187,15 +203,32 @@ export const OAIChat: React.FC<ChatProps> = ({
   const cls = [presetClasses, className].filter(Boolean).join(' ') || undefined;
 
   return (
-    <Panel
-      {...rest}
-      compact
-      fullWidth
-      variant="alt"
-      style={style}
-      className={cls}
-    >
-      <Wrapper ref={wrapRef} $gap={theme.spacing(3)} style={{ overflow: 'hidden' }}>
+    <>
+      <KeyModal open={showKeyModal} onClose={() => setShowKeyModal(false)} />
+      <Panel
+        {...rest}
+        compact
+        fullWidth
+        variant="alt"
+        style={style}
+        className={cls}
+      >
+        <Bar $bg={theme.colors.primary} $text={theme.colors.primaryText} $gap={theme.spacing(0.5)}>
+          <span />
+          <span
+            style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', gap: theme.spacing(0.5) }}
+            onClick={() => setShowKeyModal(true)}
+          >
+            <Typography variant="subtitle">
+              {apiKey ? 'Connected' : 'Disconnected'}
+            </Typography>
+            <IconButton
+              icon={apiKey ? 'carbon:checkmark' : 'carbon:circle-dash'}
+              aria-label="Set OpenAI key"
+            />
+          </span>
+        </Bar>
+        <Wrapper ref={wrapRef} $gap={theme.spacing(3)} style={{ overflow: 'hidden' }}>
         <Messages
           $gap={theme.spacing(1.5)}
           style={shouldConstrain ? { overflowY: 'auto', maxHeight } : undefined}
@@ -259,6 +292,7 @@ export const OAIChat: React.FC<ChatProps> = ({
         )}
       </Wrapper>
     </Panel>
+    </>
   );
 };
 

--- a/src/components/widgets/OAIChat.tsx
+++ b/src/components/widgets/OAIChat.tsx
@@ -22,7 +22,6 @@ import Avatar from '../primitives/Avatar';
 import KeyModal from '../KeyModal';
 import { useOpenAIKey } from '../../system/openaiKeyStore';
 import type { Presettable } from '../../types';
-import Stack from '../layout/Stack';
 
 /*───────────────────────────────────────────────────────────*/
 /* Types                                                      */
@@ -72,9 +71,11 @@ const Row = styled('div') <{
   padding-right: ${({ $right }) => $right};
 `;
 
-const InputRow = styled('form')`
+const InputRow = styled('form')<{ $gap: string }>`
   align-self: stretch;
   width: 100%;
+  display: flex;
+  gap: ${({ $gap }) => $gap};
 `;
 
 const Bar = styled('div')<{ $bg: string; $text: string; $gap: string }>`
@@ -279,19 +280,17 @@ export const OAIChat: React.FC<ChatProps> = ({
         </Messages>
 
         {!disableInput && (
-          <InputRow onSubmit={handleSubmit}>
-            <Stack direction="row" spacing={1} compact style={{ width: '100%' }}>
-              <TextField
-                as="textarea"
-                name="chat-message"
-                value={text}
-                onChange={(e) => setText(e.target.value)}
-                rows={1}
-                placeholder={placeholder}
-                style={{ flex: 1 }}
-              />
-              <IconButton icon="carbon:send" type="submit" aria-label="Send" />
-            </Stack>
+          <InputRow onSubmit={handleSubmit} $gap={theme.spacing(1)}>
+            <TextField
+              as="textarea"
+              name="chat-message"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              rows={1}
+              placeholder={placeholder}
+              style={{ flex: 1 }}
+            />
+            <IconButton icon="carbon:send" type="submit" aria-label="Send" />
           </InputRow>
         )}
       </Wrapper>

--- a/src/components/widgets/OAIChat.tsx
+++ b/src/components/widgets/OAIChat.tsx
@@ -233,7 +233,9 @@ export const OAIChat: React.FC<ChatProps> = ({
           $gap={theme.spacing(1.5)}
           style={shouldConstrain ? { overflowY: 'auto', maxHeight } : undefined}
         >
-          {messages.map((m, i) => {
+          {messages
+            .filter(m => m.role !== 'system')
+            .map((m, i) => {
             const sidePad = portrait ? theme.spacing(8) : theme.spacing(24);
             const avatarPad = theme.spacing(1);
             return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,10 @@ export * from './components/widgets/Table';
 export * from './components/layout/Tabs';
 export * from './components/widgets/Tooltip';
 export * from './components/widgets/Tree';
+export { default as KeyModal } from './components/KeyModal';
+
+// ─── OpenAI Helpers ──────────────────────────────────────────
+export * from './system/openaiKeyStore';
 
 // ─── Core ────────────────────────────────────────────────────
 export * from './css/createStyled';

--- a/src/system/openaiKeyStore.ts
+++ b/src/system/openaiKeyStore.ts
@@ -1,0 +1,127 @@
+// ─────────────────────────────────────────────────────────────
+// src/system/openaiKeyStore.ts | valet
+// secure in-browser store for OpenAI keys
+// ─────────────────────────────────────────────────────────────
+import { create } from 'zustand';
+import { persist, StateStorage, createJSONStorage } from 'zustand/middleware';
+
+/* ---- 1. simple AES-GCM helpers ---------------------------------- */
+const algo = { name: 'AES-GCM', length: 256 } as const;
+
+async function deriveKey(passphrase: string, salt: Uint8Array) {
+  const enc = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw', enc.encode(passphrase), { name: 'PBKDF2' }, false, ['deriveKey'],
+  );
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations: 120_000, hash: 'SHA-256' },
+    keyMaterial, algo, false, ['encrypt', 'decrypt'],
+  );
+}
+
+export async function encrypt(plaintext: string, passphrase: string) {
+  const enc   = new TextEncoder();
+  const salt  = crypto.getRandomValues(new Uint8Array(16));
+  const iv    = crypto.getRandomValues(new Uint8Array(12));
+  const key   = await deriveKey(passphrase, salt);
+  const data  = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv }, key, enc.encode(plaintext),
+  );
+  return btoa(
+    JSON.stringify({ iv: [...iv], salt: [...salt], data: [...new Uint8Array(data)] }),
+  );
+}
+
+export async function decrypt(cipherB64: string, passphrase: string) {
+  const { iv, salt, data } = JSON.parse(atob(cipherB64));
+  const key  = await deriveKey(passphrase, new Uint8Array(salt));
+  const dec  = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: new Uint8Array(iv) }, key, new Uint8Array(data),
+  );
+  return new TextDecoder().decode(dec);
+}
+
+/* ---- 2. custom storage routing ---------------------------------- */
+const dynamicStorage: StateStorage = {
+  getItem: (name) => localStorage.getItem(name) ?? sessionStorage.getItem(name),
+  setItem: (name, value) => {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed.state?.cipher) {
+        localStorage.setItem(name, value);
+        sessionStorage.removeItem(name);
+        return;
+      }
+    } catch {}
+    sessionStorage.setItem(name, value);
+  },
+  removeItem: (name) => {
+    localStorage.removeItem(name);
+    sessionStorage.removeItem(name);
+  },
+};
+
+/* ---- 3. Zustand secure store ------------------------------------ */
+type KeyState = {
+  apiKey: string | null;     // decrypted key in memory
+  cipher: string | null;     // encrypted key persisted
+  passphrase: string | null; // transient
+  setKey: (k: string, pass?: string) => Promise<void>;
+  applyPassphrase: (pass: string) => Promise<boolean>;
+  clearKey: () => void;
+};
+
+export const useOpenAIKey = create<KeyState>()(
+  persist(
+    (set, get) => {
+      return {
+        apiKey: null,
+        cipher: null,
+        passphrase: null,
+        setKey: async (k, pass) => {
+          if (pass) {
+            const cipher = await encrypt(k, pass);
+            set({ apiKey: k, cipher, passphrase: pass });
+          } else {
+            set({ apiKey: k, cipher: null, passphrase: null });
+          }
+        },
+        applyPassphrase: async (pass) => {
+          const { cipher } = get();
+          if (!cipher) return false;
+          try {
+            const key = await decrypt(cipher, pass);
+            set({ apiKey: key, passphrase: pass });
+            return true;
+          } catch {
+            return false;
+          }
+        },
+        clearKey: () => set({ apiKey: null, cipher: null, passphrase: null }),
+      };
+    },
+    {
+      name: 'valet-openai-key',
+      storage: createJSONStorage(() => dynamicStorage),
+      partialize: (state) => ({ cipher: state.cipher }),
+    },
+  ),
+);
+
+/* ---- 4. helper for OpenAI chat ---------------------------------- */
+export async function sendChat(messages: any[], model = 'gpt-4o') {
+  const apiKey = useOpenAIKey.getState().apiKey;
+  if (!apiKey) throw new Error('No OpenAI key set');
+
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method : 'POST',
+    headers: {
+      'Content-Type' : 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ model, messages }),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+


### PR DESCRIPTION
## Summary
- show connection status in a new chat AppBar
- trigger KeyModal via the status button and allow key deletion
- update demo for manual key entry

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a2a3878e48320b10d2cc311abfbb5