### PR TITLE
Refine chat input handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- `KeyModal` component and secure `openaiKeyStore` for browser-stored keys
+- `sendChat` helper for direct OpenAI conversations
+- `KeyModal` now allows deleting the stored key
+
+### Changed
+- `OAIChat` starts disconnected with a built-in AppBar to manage the OpenAI key
+- Chat AppBar uses the secondary color scheme
+- Chat text field now fills available width
+- Chat input uses `Stack`; Enter sends the message while Shift+Enter newlines
+- `TextField` accepts `fullWidth` to stretch inside flex rows
+
+### Fixed
+- `OAIChat` no longer displays system prompt messages
+
+### Improved
+- `KeyModal` now shows an error when an incorrect passphrase is entered
+- Chat demo no longer records attempts when the API key is missing
 
 ## [0.16.3]
 - Improved `OAIChat` styling, especially on mobile / portrait. 

--- a/src/components/KeyModal.tsx
+++ b/src/components/KeyModal.tsx
@@ -1,0 +1,108 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/KeyModal.tsx | valet
+// modal to capture an OpenAI API key
+// ─────────────────────────────────────────────────────────────
+import { useState } from 'react';
+import Modal from './layout/Modal';
+import Panel from './layout/Panel';
+import Stack from './layout/Stack';
+import Typography from './primitives/Typography';
+import Button from './fields/Button';
+import { useOpenAIKey } from '../system/openaiKeyStore';
+import { useTheme } from '../system/themeStore';
+
+export interface KeyModalProps {
+  open: boolean;
+  onClose?: () => void;
+}
+
+export default function KeyModal({ open, onClose }: KeyModalProps) {
+  const { apiKey, cipher, setKey, applyPassphrase, clearKey } = useOpenAIKey();
+  const [value, setValue] = useState('');
+  const [remember, setRemember] = useState(false);
+  const [passphrase, setPassphrase] = useState('');
+  const [error, setError] = useState('');
+  const { theme } = useTheme();
+
+  if (!open) return null;
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <Panel centered compact style={{ maxWidth: 480 }}>
+        <Stack spacing={1}>
+          <Typography variant="h3" bold>
+            {cipher ? 'Unlock OpenAI key' : 'Paste your OpenAI key'}
+          </Typography>
+
+          {!cipher && (
+            <input
+              style={{ fontFamily: 'monospace', width: '100%', padding: '0.5rem' }}
+              type="password"
+              placeholder="sk-..."
+              value={value}
+              onChange={(e) => {
+                setValue(e.target.value);
+                if (error) setError('');
+              }}
+            />
+          )}
+
+          {(remember || cipher) && (
+            <input
+              type="password"
+              placeholder="passphrase"
+              value={passphrase}
+              onChange={(e) => {
+                setPassphrase(e.target.value);
+                if (error) setError('');
+              }}
+              style={{ width: '100%', padding: '0.5rem' }}
+            />
+          )}
+
+          {error && (
+            <Typography color={theme.colors.secondary}>{error}</Typography>
+          )}
+
+          {!cipher && (
+            <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+              <input
+                type="checkbox"
+                checked={remember}
+                onChange={(e) => setRemember(e.target.checked)}
+              />
+              <Typography>remember this key (encrypted)</Typography>
+            </label>
+          )}
+
+          <Button
+            fullWidth
+            disabled={cipher ? !passphrase : (!value.trim() || (remember && !passphrase))}
+            onClick={async () => {
+              setError('');
+              if (cipher) {
+                const ok = await applyPassphrase(passphrase);
+                if (!ok) {
+                  setError('Incorrect passphrase');
+                  return;
+                }
+              } else {
+                await setKey(value.trim(), remember ? passphrase : undefined);
+              }
+              onClose?.();
+            }}
+          >
+            Save &amp; Continue
+          </Button>
+
+          {(cipher || apiKey) && (
+            <Button variant="outlined" fullWidth onClick={() => { clearKey(); onClose?.(); }}>
+              Delete stored key
+            </Button>
+          )}
+        </Stack>
+      </Panel>
+    </Modal>
+  );
+}
+

--- a/src/components/fields/TextField.tsx
+++ b/src/components/fields/TextField.tsx
@@ -27,6 +27,8 @@ interface FieldCommon extends Presettable {
   label?: string;
   helperText?: string;
   error?: boolean;
+  /** Stretch the wrapper to fill available width */
+  fullWidth?: boolean;
 }
 
 export type TextFieldProps =
@@ -94,9 +96,11 @@ export const TextField = forwardRef<
     label,
     helperText,
     error = false,
+    fullWidth = false,
     preset: presetName,
     className,
     rows,
+    style: styleProp,
     ...rawRest
   } = props;
 
@@ -142,6 +146,7 @@ export const TextField = forwardRef<
     <Wrapper
       theme={theme}
       className={[presetClasses, className].filter(Boolean).join(' ')}
+      style={fullWidth ? { flex: 1, width: '100%', ...styleProp } : styleProp}
     >
       {label && (
         <Label theme={theme} htmlFor={id}>

--- a/src/components/widgets/OAIChat.tsx
+++ b/src/components/widgets/OAIChat.tsx
@@ -16,11 +16,13 @@ import { shallow } from 'zustand/shallow';
 import { preset } from '../../css/stylePresets';
 import IconButton from '../fields/IconButton';
 import TextField from '../fields/TextField';
+import Stack from '../layout/Stack';
 import Panel from '../layout/Panel';
 import Typography from '../primitives/Typography';
 import Avatar from '../primitives/Avatar';
+import KeyModal from '../KeyModal';
+import { useOpenAIKey } from '../../system/openaiKeyStore';
 import type { Presettable } from '../../types';
-import Stack from '../layout/Stack';
 
 /*───────────────────────────────────────────────────────────*/
 /* Types                                                      */
@@ -70,8 +72,17 @@ const Row = styled('div') <{
   padding-right: ${({ $right }) => $right};
 `;
 
-const InputRow = styled('form')`
-  align-self: center;
+
+const Bar = styled('div')<{ $bg: string; $text: string; $gap: string }>`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 1rem;
+  background: ${({ $bg }) => $bg};
+  color: ${({ $text }) => $text};
+  & > * {
+    padding: ${({ $gap }) => $gap};
+  }
 `;
 
 /*───────────────────────────────────────────────────────────*/
@@ -108,6 +119,8 @@ export const OAIChat: React.FC<ChatProps> = ({
   const constraintRef = useRef(false);
 
   const [text, setText] = useState('');
+  const { apiKey } = useOpenAIKey();
+  const [showKeyModal, setShowKeyModal] = useState(false);
 
   const calcCutoff = () => {
     if (typeof document === 'undefined') return 32;
@@ -187,20 +200,39 @@ export const OAIChat: React.FC<ChatProps> = ({
   const cls = [presetClasses, className].filter(Boolean).join(' ') || undefined;
 
   return (
-    <Panel
-      {...rest}
-      compact
-      fullWidth
-      variant="alt"
-      style={style}
-      className={cls}
-    >
-      <Wrapper ref={wrapRef} $gap={theme.spacing(3)} style={{ overflow: 'hidden' }}>
+    <>
+      <KeyModal open={showKeyModal} onClose={() => setShowKeyModal(false)} />
+      <Panel
+        {...rest}
+        compact
+        fullWidth
+        variant="alt"
+        style={style}
+        className={cls}
+      >
+        <Bar $bg={theme.colors.secondary} $text={theme.colors.secondaryText} $gap={theme.spacing(0.5)}>
+          <span />
+          <span
+            style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', gap: theme.spacing(0.5) }}
+            onClick={() => setShowKeyModal(true)}
+          >
+            <Typography variant="subtitle">
+              {apiKey ? 'Connected' : 'Disconnected'}
+            </Typography>
+            <IconButton
+              icon={apiKey ? 'carbon:checkmark' : 'carbon:circle-dash'}
+              aria-label="Set OpenAI key"
+            />
+          </span>
+        </Bar>
+        <Wrapper ref={wrapRef} $gap={theme.spacing(3)} style={{ overflow: 'hidden' }}>
         <Messages
           $gap={theme.spacing(1.5)}
           style={shouldConstrain ? { overflowY: 'auto', maxHeight } : undefined}
         >
-          {messages.map((m, i) => {
+          {messages
+            .filter(m => m.role !== 'system')
+            .map((m, i) => {
             const sidePad = portrait ? theme.spacing(8) : theme.spacing(24);
             const avatarPad = theme.spacing(1);
             return (
@@ -243,22 +275,30 @@ export const OAIChat: React.FC<ChatProps> = ({
         </Messages>
 
         {!disableInput && (
-          <InputRow onSubmit={handleSubmit}>
+          <form onSubmit={handleSubmit} style={{ width: '100%' }}>
             <Stack direction="row" spacing={1} compact>
               <TextField
                 as="textarea"
                 name="chat-message"
                 value={text}
                 onChange={(e) => setText(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault();
+                    handleSubmit(e as any);
+                  }
+                }}
                 rows={1}
                 placeholder={placeholder}
+                fullWidth
               />
               <IconButton icon="carbon:send" type="submit" aria-label="Send" />
             </Stack>
-          </InputRow>
+          </form>
         )}
       </Wrapper>
     </Panel>
+    </>
   );
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,10 @@ export * from './components/widgets/Table';
 export * from './components/layout/Tabs';
 export * from './components/widgets/Tooltip';
 export * from './components/widgets/Tree';
+export { default as KeyModal } from './components/KeyModal';
+
+// ─── OpenAI Helpers ──────────────────────────────────────────
+export * from './system/openaiKeyStore';
 
 // ─── Core ────────────────────────────────────────────────────
 export * from './css/createStyled';

--- a/src/system/openaiKeyStore.ts
+++ b/src/system/openaiKeyStore.ts
@@ -1,0 +1,127 @@
+// ─────────────────────────────────────────────────────────────
+// src/system/openaiKeyStore.ts | valet
+// secure in-browser store for OpenAI keys
+// ─────────────────────────────────────────────────────────────
+import { create } from 'zustand';
+import { persist, StateStorage, createJSONStorage } from 'zustand/middleware';
+
+/* ---- 1. simple AES-GCM helpers ---------------------------------- */
+const algo = { name: 'AES-GCM', length: 256 } as const;
+
+async function deriveKey(passphrase: string, salt: Uint8Array) {
+  const enc = new TextEncoder();
+  const keyMaterial = await crypto.subtle.importKey(
+    'raw', enc.encode(passphrase), { name: 'PBKDF2' }, false, ['deriveKey'],
+  );
+  return crypto.subtle.deriveKey(
+    { name: 'PBKDF2', salt, iterations: 120_000, hash: 'SHA-256' },
+    keyMaterial, algo, false, ['encrypt', 'decrypt'],
+  );
+}
+
+export async function encrypt(plaintext: string, passphrase: string) {
+  const enc   = new TextEncoder();
+  const salt  = crypto.getRandomValues(new Uint8Array(16));
+  const iv    = crypto.getRandomValues(new Uint8Array(12));
+  const key   = await deriveKey(passphrase, salt);
+  const data  = await crypto.subtle.encrypt(
+    { name: 'AES-GCM', iv }, key, enc.encode(plaintext),
+  );
+  return btoa(
+    JSON.stringify({ iv: [...iv], salt: [...salt], data: [...new Uint8Array(data)] }),
+  );
+}
+
+export async function decrypt(cipherB64: string, passphrase: string) {
+  const { iv, salt, data } = JSON.parse(atob(cipherB64));
+  const key  = await deriveKey(passphrase, new Uint8Array(salt));
+  const dec  = await crypto.subtle.decrypt(
+    { name: 'AES-GCM', iv: new Uint8Array(iv) }, key, new Uint8Array(data),
+  );
+  return new TextDecoder().decode(dec);
+}
+
+/* ---- 2. custom storage routing ---------------------------------- */
+const dynamicStorage: StateStorage = {
+  getItem: (name) => localStorage.getItem(name) ?? sessionStorage.getItem(name),
+  setItem: (name, value) => {
+    try {
+      const parsed = JSON.parse(value);
+      if (parsed.state?.cipher) {
+        localStorage.setItem(name, value);
+        sessionStorage.removeItem(name);
+        return;
+      }
+    } catch {}
+    sessionStorage.setItem(name, value);
+  },
+  removeItem: (name) => {
+    localStorage.removeItem(name);
+    sessionStorage.removeItem(name);
+  },
+};
+
+/* ---- 3. Zustand secure store ------------------------------------ */
+type KeyState = {
+  apiKey: string | null;     // decrypted key in memory
+  cipher: string | null;     // encrypted key persisted
+  passphrase: string | null; // transient
+  setKey: (k: string, pass?: string) => Promise<void>;
+  applyPassphrase: (pass: string) => Promise<boolean>;
+  clearKey: () => void;
+};
+
+export const useOpenAIKey = create<KeyState>()(
+  persist(
+    (set, get) => {
+      return {
+        apiKey: null,
+        cipher: null,
+        passphrase: null,
+        setKey: async (k, pass) => {
+          if (pass) {
+            const cipher = await encrypt(k, pass);
+            set({ apiKey: k, cipher, passphrase: pass });
+          } else {
+            set({ apiKey: k, cipher: null, passphrase: null });
+          }
+        },
+        applyPassphrase: async (pass) => {
+          const { cipher } = get();
+          if (!cipher) return false;
+          try {
+            const key = await decrypt(cipher, pass);
+            set({ apiKey: key, passphrase: pass });
+            return true;
+          } catch {
+            return false;
+          }
+        },
+        clearKey: () => set({ apiKey: null, cipher: null, passphrase: null }),
+      };
+    },
+    {
+      name: 'valet-openai-key',
+      storage: createJSONStorage(() => dynamicStorage),
+      partialize: (state) => ({ cipher: state.cipher }),
+    },
+  ),
+);
+
+/* ---- 4. helper for OpenAI chat ---------------------------------- */
+export async function sendChat(messages: any[], model = 'gpt-4o') {
+  const apiKey = useOpenAIKey.getState().apiKey;
+  if (!apiKey) throw new Error('No OpenAI key set');
+
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method : 'POST',
+    headers: {
+      'Content-Type' : 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ model, messages }),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.json();
+}
+


### PR DESCRIPTION
## Summary
- add `fullWidth` prop to `TextField`
- use a `Stack` for the chat input and handle Enter
- document these input tweaks

## Testing
- `npm run build`
- `npm run build` in `docs`


------
https://chatgpt.com/codex/tasks/task_e_687a2a3878e48320b10d2cc311abfbb5