### PR TITLE
Implement animated typing indicator in OAIChat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. The format 
 - `KeyModal` component and secure `openaiKeyStore` for browser-stored keys
 - `sendChat` helper for direct OpenAI conversations
 - `KeyModal` now allows deleting the stored key
+- `OAIChat` shows a typing indicator and fades in replies
 
 ### Changed
 - `OAIChat` starts disconnected with a built-in AppBar to manage the OpenAI key

--- a/docs/src/pages/OAIChatDemo.tsx
+++ b/docs/src/pages/OAIChatDemo.tsx
@@ -34,20 +34,32 @@ export default function OAIChatDemoPage() {
       return;
     }
     const history = [...messages, m];
-    setMessages(history);
+    setMessages([...history, { role: 'assistant', content: '', typing: true }]);
     try {
       const res = await sendChat(history);
       const reply = res.choices[0]?.message as ChatMessage | undefined;
-      if (reply) setMessages(prev => [...prev, reply]);
+      if (reply)
+        setMessages(prev => {
+          const next = [...prev];
+          const idx = next.findIndex(x => x.typing);
+          if (idx >= 0) next[idx] = { ...reply, animate: true } as ChatMessage;
+          else next.push({ ...reply, animate: true } as ChatMessage);
+          return next;
+        });
     } catch (err: any) {
       const msg = String(err.message || err);
       if (msg.includes('No OpenAI key set yet')) {
         setNoKey(true);
       } else {
-        setMessages(prev => [
-          ...prev,
-          { role: 'assistant', content: msg },
-        ]);
+        setMessages(prev => {
+          const next = [...prev];
+          const idx = next.findIndex(x => x.typing);
+          if (idx >= 0)
+            next[idx] = { role: 'assistant', content: msg, animate: true };
+          else
+            next.push({ role: 'assistant', content: msg, animate: true });
+          return next;
+        });
       }
     }
   };


### PR DESCRIPTION
## Summary
- add optional `typing` and `animate` flags on `ChatMessage`
- show animated dots while assistant is typing and fade replies in
- update chat demo to display new behaviour
- note the change in `CHANGELOG`

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687b0e237c608320b7f58b1bf40071d7