### PR TITLE
Add provider selection for chat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ All notable changes to this project will be documented in this file. The format 
 - `sendChat` helper for direct OpenAI conversations
 - `KeyModal` now allows deleting the stored key
 - `OAIChat` shows a typing indicator and fades in replies
+- Anthropic provider option with model selection
 
 ### Changed
 - `OAIChat` starts disconnected with a built-in AppBar to manage the OpenAI key
+- `sendChat` now supports OpenAI and Anthropic APIs
 - Chat AppBar uses the secondary color scheme
 - Chat text field now fills available width
 - Chat input uses `Stack`; Enter sends the message while Shift+Enter newlines

--- a/docs/src/pages/OAIChatDemo.tsx
+++ b/docs/src/pages/OAIChatDemo.tsx
@@ -48,7 +48,7 @@ export default function OAIChatDemoPage() {
         });
     } catch (err: any) {
       const msg = String(err.message || err);
-      if (msg.includes('No OpenAI key set yet')) {
+      if (msg.includes('No API key set')) {
         setNoKey(true);
       } else {
         setMessages(prev => {
@@ -72,7 +72,7 @@ export default function OAIChatDemoPage() {
           Chat Showcase
         </Typography>
         <Typography variant="subtitle">
-          OAIChat component with OpenAI style messages
+          OAIChat component with API-driven messages
         </Typography>
 
         <OAIChat
@@ -84,7 +84,7 @@ export default function OAIChatDemoPage() {
         />
         {noKey && (
           <Snackbar
-            message="No OpenAI key set yet"
+            message="No API key set yet"
             onClose={() => setNoKey(false)}
           />
         )}

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ export * from './components/widgets/Tooltip';
 export * from './components/widgets/Tree';
 export { default as KeyModal } from './components/KeyModal';
 
-// ─── OpenAI Helpers ──────────────────────────────────────────
+// ─── LLM Helpers ─────────────────────────────────────────────
 export * from './system/openaiKeyStore';
 
 // ─── Core ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- support OpenAI and Anthropic providers via the key store
- expose provider and model options in OAIChat
- extend KeyModal with provider selection
- update OAIChat demo and exports

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b172f943c832099441edde4f92d71