### PR TITLE
Add provider selection for OAIChat

### DIFF
--- a/docs/src/pages/OAIChatDemo.tsx
+++ b/docs/src/pages/OAIChatDemo.tsx
@@ -11,7 +11,7 @@ import {
   OAIChat,
   sendChat,
   Snackbar,
-  useOpenAIKey,
+  useAIKey,
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
@@ -29,7 +29,7 @@ export default function OAIChatDemoPage() {
   const [noKey, setNoKey] = useState(false);
 
   const handleSend = async (m: ChatMessage) => {
-    if (!useOpenAIKey.getState().apiKey) {
+    if (!useAIKey.getState().apiKey) {
       setNoKey(true);
       return;
     }
@@ -48,7 +48,7 @@ export default function OAIChatDemoPage() {
         });
     } catch (err: any) {
       const msg = String(err.message || err);
-      if (msg.includes('No OpenAI key set yet')) {
+      if (msg.includes('No AI provider configured')) {
         setNoKey(true);
       } else {
         setMessages(prev => {
@@ -84,7 +84,7 @@ export default function OAIChatDemoPage() {
         />
         {noKey && (
           <Snackbar
-            message="No OpenAI key set yet"
+            message="No AI key set yet"
             onClose={() => setNoKey(false)}
           />
         )}

--- a/src/components/KeyModal.tsx
+++ b/src/components/KeyModal.tsx
@@ -1,6 +1,6 @@
 // ─────────────────────────────────────────────────────────────
 // src/components/KeyModal.tsx | valet
-// modal to capture an OpenAI API key
+// modal to capture an AI provider key
 // ─────────────────────────────────────────────────────────────
 import { useState } from 'react';
 import Modal from './layout/Modal';
@@ -8,7 +8,8 @@ import Panel from './layout/Panel';
 import Stack from './layout/Stack';
 import Typography from './primitives/Typography';
 import Button from './fields/Button';
-import { useOpenAIKey } from '../system/openaiKeyStore';
+import { useAIKey, Provider } from '../system/openaiKeyStore';
+import Select from './fields/Select';
 import { useTheme } from '../system/themeStore';
 
 export interface KeyModalProps {
@@ -17,7 +18,8 @@ export interface KeyModalProps {
 }
 
 export default function KeyModal({ open, onClose }: KeyModalProps) {
-  const { apiKey, cipher, setKey, applyPassphrase, clearKey } = useOpenAIKey();
+  const { apiKey, cipher, provider, setKey, applyPassphrase, clearKey } = useAIKey();
+  const [prov, setProv] = useState<Provider>(provider ?? 'openai');
   const [value, setValue] = useState('');
   const [remember, setRemember] = useState(false);
   const [passphrase, setPassphrase] = useState('');
@@ -31,14 +33,21 @@ export default function KeyModal({ open, onClose }: KeyModalProps) {
       <Panel centered compact style={{ maxWidth: 480 }}>
         <Stack spacing={1}>
           <Typography variant="h3" bold>
-            {cipher ? 'Unlock OpenAI key' : 'Paste your OpenAI key'}
+            {cipher ? `Unlock ${provider ?? prov} key` : 'Paste your API key'}
           </Typography>
+
+          {!cipher && (
+            <Select value={prov} onChange={v => setProv(v as Provider)}>
+              <Select.Option value="openai">OpenAI</Select.Option>
+              <Select.Option value="anthropic">Anthropic</Select.Option>
+            </Select>
+          )}
 
           {!cipher && (
             <input
               style={{ fontFamily: 'monospace', width: '100%', padding: '0.5rem' }}
               type="password"
-              placeholder="sk-..."
+              placeholder="api-key"
               value={value}
               onChange={(e) => {
                 setValue(e.target.value);
@@ -87,7 +96,7 @@ export default function KeyModal({ open, onClose }: KeyModalProps) {
                   return;
                 }
               } else {
-                await setKey(value.trim(), remember ? passphrase : undefined);
+                await setKey(value.trim(), prov, remember ? passphrase : undefined);
               }
               onClose?.();
             }}


### PR DESCRIPTION
## Summary
- expand key store to handle OpenAI and Anthropic providers
- update KeyModal with provider select and generic text
- add model select and provider handling in OAIChat
- adjust docs demo for new API

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b172f943c832099441edde4f92d71