### PR TITLE
Add provider-aware AI chat

### DIFF
--- a/docs/src/pages/OAIChatDemo.tsx
+++ b/docs/src/pages/OAIChatDemo.tsx
@@ -11,7 +11,7 @@ import {
   OAIChat,
   sendChat,
   Snackbar,
-  useOpenAIKey,
+  useAI,
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
@@ -29,7 +29,7 @@ export default function OAIChatDemoPage() {
   const [noKey, setNoKey] = useState(false);
 
   const handleSend = async (m: ChatMessage) => {
-    if (!useOpenAIKey.getState().apiKey) {
+    if (!useAI.getState().apiKey) {
       setNoKey(true);
       return;
     }
@@ -48,7 +48,7 @@ export default function OAIChatDemoPage() {
         });
     } catch (err: any) {
       const msg = String(err.message || err);
-      if (msg.includes('No OpenAI key set yet')) {
+      if (msg.includes('No API key set')) {
         setNoKey(true);
       } else {
         setMessages(prev => {
@@ -84,7 +84,7 @@ export default function OAIChatDemoPage() {
         />
         {noKey && (
           <Snackbar
-            message="No OpenAI key set yet"
+            message="No API key set"
             onClose={() => setNoKey(false)}
           />
         )}

--- a/src/components/KeyModal.tsx
+++ b/src/components/KeyModal.tsx
@@ -1,6 +1,6 @@
 // ─────────────────────────────────────────────────────────────
 // src/components/KeyModal.tsx | valet
-// modal to capture an OpenAI API key
+// modal to capture an AI API key and provider
 // ─────────────────────────────────────────────────────────────
 import { useState } from 'react';
 import Modal from './layout/Modal';
@@ -8,7 +8,8 @@ import Panel from './layout/Panel';
 import Stack from './layout/Stack';
 import Typography from './primitives/Typography';
 import Button from './fields/Button';
-import { useOpenAIKey } from '../system/openaiKeyStore';
+import { useAI } from '../system/aiStore';
+import Select from './fields/Select';
 import { useTheme } from '../system/themeStore';
 
 export interface KeyModalProps {
@@ -17,7 +18,15 @@ export interface KeyModalProps {
 }
 
 export default function KeyModal({ open, onClose }: KeyModalProps) {
-  const { apiKey, cipher, setKey, applyPassphrase, clearKey } = useOpenAIKey();
+  const {
+    apiKey,
+    cipher,
+    provider,
+    setProvider,
+    setKey,
+    applyPassphrase,
+    clearKey,
+  } = useAI();
   const [value, setValue] = useState('');
   const [remember, setRemember] = useState(false);
   const [passphrase, setPassphrase] = useState('');
@@ -31,8 +40,15 @@ export default function KeyModal({ open, onClose }: KeyModalProps) {
       <Panel centered compact style={{ maxWidth: 480 }}>
         <Stack spacing={1}>
           <Typography variant="h3" bold>
-            {cipher ? 'Unlock OpenAI key' : 'Paste your OpenAI key'}
+            {cipher ? 'Unlock API key' : 'Paste your API key'}
           </Typography>
+
+          {!cipher && (
+            <Select value={provider} onChange={(v) => setProvider(v as any)}>
+              <Select.Option value="openai">OpenAI</Select.Option>
+              <Select.Option value="anthropic">Anthropic</Select.Option>
+            </Select>
+          )}
 
           {!cipher && (
             <input

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ export * from './components/widgets/Tree';
 export { default as KeyModal } from './components/KeyModal';
 
 // ─── OpenAI Helpers ──────────────────────────────────────────
-export * from './system/openaiKeyStore';
+export * from './system/aiStore';
 
 // ─── Core ────────────────────────────────────────────────────
 export * from './css/createStyled';


### PR DESCRIPTION
## Summary
- add `aiStore` with provider-aware key storage
- update `KeyModal` to choose provider
- extend `OAIChat` with model select
- handle Anthropic requests in `sendChat`
- adjust docs demo

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b172f943c832099441edde4f92d71