### PR TITLE
Fix sendChat for Anthropic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 - `OAIChat` no longer displays system prompt messages
 - Anthropic messages use top-level `system` parameter
+- `sendChat` normalizes Anthropic replies to match OpenAI format
 
 ### Improved
 - `KeyModal` now shows an error when an incorrect passphrase is entered

--- a/src/system/aiKeyStore.ts
+++ b/src/system/aiKeyStore.ts
@@ -161,5 +161,15 @@ export async function sendChat(
     body: JSON.stringify({ model: mdl, system, messages: msgs, max_tokens: 1024 }),
   });
   if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  const data = await res.json();
+  const msg = {
+    role: data.role ?? 'assistant',
+    content: data.content?.[0]?.text ?? '',
+  };
+  return {
+    id: data.id,
+    model: data.model,
+    usage: data.usage,
+    choices: [{ index: 0, message: msg, finish_reason: data.stop_reason }],
+  };
 }


### PR DESCRIPTION
## Summary
- normalize Anthropic chat responses in `sendChat`
- document the fix in the changelog

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b3a831ca883209eae456797b79cde