### PR TITLE
Fix Anthropics sendChat output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable changes to this project will be documented in this file. The format 
 ### Fixed
 - `OAIChat` no longer displays system prompt messages
 - Anthropic messages use top-level `system` parameter
+- `sendChat` normalizes Anthropic responses to OpenAI format
 
 ### Improved
 - `KeyModal` now shows an error when an incorrect passphrase is entered

--- a/src/system/aiKeyStore.ts
+++ b/src/system/aiKeyStore.ts
@@ -161,5 +161,17 @@ export async function sendChat(
     body: JSON.stringify({ model: mdl, system, messages: msgs, max_tokens: 1024 }),
   });
   if (!res.ok) throw new Error(await res.text());
-  return res.json();
+  const json = await res.json();
+  return {
+    choices: [
+      {
+        message: {
+          role: json.role,
+          content: Array.isArray(json.content)
+            ? json.content.map((p: any) => p.text ?? '').join('')
+            : '',
+        },
+      },
+    ],
+  };
 }


### PR DESCRIPTION
## Summary
- normalize `sendChat` return shape for Anthropic provider
- document fix in the changelog

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b3a831ca883209eae456797b79cde