### PR TITLE
Fix key removal from local storage

### DIFF
--- a/src/system/aiKeyStore.ts
+++ b/src/system/aiKeyStore.ts
@@ -104,7 +104,10 @@ export const useAIKey = create<KeyState>()(
           return false;
         }
       },
-      clearKey: () => set({ apiKey: null, provider: null, model: null, cipher: null, passphrase: null }),
+      clearKey: () => {
+        dynamicStorage.removeItem('valet-ai-key');
+        set({ apiKey: null, provider: null, model: null, cipher: null, passphrase: null });
+      },
     }),
     {
       name: 'valet-ai-key',


### PR DESCRIPTION
## Summary
- ensure `clearKey` removes persisted keys

## Testing
- `npm install`
- `npm run build`
- `npm run build` in `docs` *(fails: sendChat and useAIKey missing)*

------
https://chatgpt.com/codex/tasks/task_e_687b445c67408320ac03070f2368ac15