### PR TITLE
Add Markdown renderer component

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -57,6 +57,7 @@ const OverviewPage          = page(() => import('./pages/Overview'));
 const InstallationPage      = page(() => import('./pages/Installation'));
 const UsagePage             = page(() => import('./pages/Usage'));
 const SurfaceExplainerPage  = page(() => import('./pages/SurfaceExplainer'));
+const MarkdownDemoPage = page(() => import('./pages/MarkdownDemo'));
 const PropPatternsPage      = page(() => import('./pages/PropPatterns'));
 
 /*───────────────────────────────────────────────────────────*/
@@ -126,6 +127,7 @@ export function App() {
         <Route path="/tree-demo"      element={<TreeDemoPage />} />
         <Route path="/iterator-demo"  element={<IteratorDemoPage />} />
         <Route path="/dateselector-demo" element={<DateSelectorDemoPage />} />
+        <Route path="/markdown-demo" element={<MarkdownDemoPage />} />
         <Route path="/prop-patterns"  element={<PropPatternsPage />} />
       </Routes>
     </Suspense>

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -62,8 +62,9 @@ const widgets: [string, string][] = [
   ['Table', '/table-demo'],
   ['Tooltip', '/tooltip-demo'],
   ['Tree', '/tree-demo'],
+  ['Markdown', '/markdown-demo'],
+  
 ];
-
 const demos: [string, string][] = [
   ['Form', '/form'],
   ['Parallax', '/parallax'],

--- a/docs/src/pages/MarkdownDemo.tsx
+++ b/docs/src/pages/MarkdownDemo.tsx
@@ -1,0 +1,48 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/MarkdownDemo.tsx | valet
+// Demo page for Markdown component
+// ─────────────────────────────────────────────────────────────
+import { Surface, Stack, Typography, Tabs, Panel, useTheme, Markdown } from '@archway/valet';
+import NavDrawer from '../components/NavDrawer';
+
+export default function MarkdownDemo() {
+  const { theme } = useTheme();
+  const sample = `# Markdown Example
+
+This is **markdown** rendered with _valet_.
+
+![Kitten](https://placecats.com/400/200)
+
+| Animal | Sound |
+| ------ | ----- |
+| Cat    | Meow  |
+| Dog    | Woof  |
+
+\`\`\`ts
+console.log('hello');
+\`\`\``;
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack>
+        <Typography variant="h2" bold>
+          Markdown
+        </Typography>
+
+        <Tabs>
+          <Tabs.Tab label="Usage" />
+          <Tabs.Panel>
+            <Typography variant="h3">Raw text</Typography>
+            <Panel preset="codePanel">
+              <pre style={{ margin: 0 }}>{sample}</pre>
+            </Panel>
+
+            <Typography variant="h3">Markdown component</Typography>
+            <Markdown data={sample} />
+          </Tabs.Panel>
+        </Tabs>
+      </Stack>
+    </Surface>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.0",
+    "marked": "^16.1.1",
     "siphash": "^1.2.0",
     "zustand": "^4.5.7"
   },

--- a/src/components/widgets/Markdown.tsx
+++ b/src/components/widgets/Markdown.tsx
@@ -1,0 +1,136 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/widgets/Markdown.tsx  | valet
+// Minimal markdown renderer using valet primitives
+// ─────────────────────────────────────────────────────────────
+import React from 'react';
+import { marked, type Tokens } from 'marked';
+import Stack from '../layout/Stack';
+import Panel from '../layout/Panel';
+import { Typography } from '../primitives/Typography';
+import Image from '../primitives/Image';
+import { Table, type TableColumn } from './Table';
+import { preset } from '../../css/stylePresets';
+import type { Presettable } from '../../types';
+
+export interface MarkdownProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    Presettable {
+  /** Raw markdown string */
+  data: string;
+}
+
+function inline(tokens: Tokens.Generic[] = []): React.ReactNode[] {
+  return tokens.map((t, i) => {
+    switch (t.type) {
+      case 'strong':
+        return <strong key={i}>{inline(t.tokens)}</strong>;
+      case 'em':
+        return <em key={i}>{inline(t.tokens)}</em>;
+      case 'codespan':
+        return <code key={i}>{t.text}</code>;
+      case 'link':
+        return (
+          <a key={i} href={t.href} title={t.title ?? undefined}>
+            {inline(t.tokens)}
+          </a>
+        );
+      case 'image':
+        return <Image key={i} src={t.href} alt={t.text} />;
+      case 'text':
+        return t.text;
+      default:
+        return null;
+    }
+  });
+}
+
+function blocks(tokens: Tokens.Generic[]): React.ReactNode[] {
+  const out: React.ReactNode[] = [];
+  tokens.forEach((t, i) => {
+    if (t.type === 'space') return;
+    switch (t.type) {
+      case 'heading':
+        out.push(
+          <Typography key={i} variant={`h${t.depth}` as any} bold>
+            {inline(t.tokens)}
+          </Typography>,
+        );
+        break;
+      case 'paragraph':
+        out.push(
+          <Typography key={i} variant="body">
+            {inline(t.tokens)}
+          </Typography>,
+        );
+        break;
+      case 'list':
+        out.push(
+          React.createElement(
+            t.ordered ? 'ol' : 'ul',
+            { key: i },
+            t.items.map((item: Tokens.ListItem, j: number) => (
+              <li key={j}>{inline(item.tokens)}</li>
+            )),
+          ),
+        );
+        break;
+      case 'code':
+        out.push(
+          <Panel key={i} preset="codePanel">
+            <pre style={{ margin: 0 }}>{t.text}</pre>
+          </Panel>,
+        );
+        break;
+      case 'blockquote':
+        out.push(
+          <Panel key={i} style={{ borderLeft: '4px solid currentColor' }}>
+            {blocks(t.tokens ?? [])}
+          </Panel>,
+        );
+        break;
+      case 'image':
+        out.push(<Image key={i} src={t.href} alt={t.text} />);
+        break;
+      case 'table': {
+        const columns: TableColumn<Record<string, React.ReactNode>>[] = t.header.map(
+          (cell: Tokens.TableCell, c: number) => ({
+            header: inline(cell.tokens),
+            accessor: `c${c}`,
+          }),
+        );
+        const data = t.rows.map((row: Tokens.TableCell[]) => {
+          const obj: Record<string, React.ReactNode> = {};
+          row.forEach((cell: Tokens.TableCell, c: number) => {
+            obj[`c${c}`] = inline(cell.tokens);
+          });
+          return obj;
+        });
+        out.push(
+          <Table key={i} data={data} columns={columns} constrainHeight={false} />,
+        );
+        break;
+      }
+      default:
+        break;
+    }
+  });
+  return out;
+}
+
+export const Markdown: React.FC<MarkdownProps> = ({
+  data,
+  preset: p,
+  className,
+  style,
+  ...rest
+}) => {
+  const tokens = marked.lexer(data);
+  const cls = p ? preset(p) : '';
+  return (
+    <Stack {...rest} className={[cls, className].filter(Boolean).join(' ')} style={style}>
+      {blocks(tokens)}
+    </Stack>
+  );
+};
+
+export default Markdown;

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export * from './components/widgets/Table';
 export * from './components/layout/Tabs';
 export * from './components/widgets/Tooltip';
 export * from './components/widgets/Tree';
+export * from './components/widgets/Markdown';
 export { default as KeyModal } from './components/KeyModal';
 
 // ─── AI Helpers ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add Markdown widget built from valet primitives
- export Markdown from library index
- document Markdown usage and show a demo
- include nav entry and route
- add marked dependency

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687b55a553c08320b5896c91fd62df4f