### PR TITLE
Add Markdown renderer component

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -53,6 +53,7 @@ const VideoDemoPage         = page(() => import('./pages/VideoDemo'));
 const SnackbarDemoPage      = page(() => import('./pages/SnackbarDemo'));
 const TreeDemoPage          = page(() => import('./pages/TreeDemo'));
 const DateSelectorDemoPage  = page(() => import('./pages/DateSelectorDemo'));
+const MarkdownDemoPage      = page(() => import('./pages/MarkdownDemo'));
 const OverviewPage          = page(() => import('./pages/Overview'));
 const InstallationPage      = page(() => import('./pages/Installation'));
 const UsagePage             = page(() => import('./pages/Usage'));
@@ -126,6 +127,7 @@ export function App() {
         <Route path="/tree-demo"      element={<TreeDemoPage />} />
         <Route path="/iterator-demo"  element={<IteratorDemoPage />} />
         <Route path="/dateselector-demo" element={<DateSelectorDemoPage />} />
+        <Route path="/markdown-demo"  element={<MarkdownDemoPage />} />
         <Route path="/prop-patterns"  element={<PropPatternsPage />} />
       </Routes>
     </Suspense>

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -62,6 +62,7 @@ const widgets: [string, string][] = [
   ['Table', '/table-demo'],
   ['Tooltip', '/tooltip-demo'],
   ['Tree', '/tree-demo'],
+  ['Markdown', '/markdown-demo'],
 ];
 
 const demos: [string, string][] = [

--- a/docs/src/pages/MarkdownDemo.tsx
+++ b/docs/src/pages/MarkdownDemo.tsx
@@ -1,0 +1,51 @@
+// src/pages/MarkdownDemo.tsx
+import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
+import {
+  Surface,
+  Stack,
+  Typography,
+  Panel,
+  Button,
+  Markdown as MarkdownRenderer,
+  useTheme,
+} from '@archway/valet';
+
+export default function MarkdownDemoPage() {
+  const { theme, toggleMode } = useTheme();
+  const navigate = useNavigate();
+
+  const sample = `# Markdown Demo\n\nThis text **renders** *Markdown* using valet components.\n\n## Table Example\n| Fruit | Colour |\n| ----- | ------ |\n| Apple | Red    |\n| Pear  | Green  |\n\n\`\`\`ts\nconst x = 42;\nconsole.log(x);\n\`\`\``;
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack>
+        <Typography variant="h2" bold>
+          Markdown
+        </Typography>
+        <Typography variant="subtitle">
+          Render Markdown text with valet primitives
+        </Typography>
+
+        <Typography variant="h3">Raw Text</Typography>
+        <Panel preset="codePanel">
+          <Typography as="pre" style={{ whiteSpace: 'pre-wrap' }}>
+            {sample}
+          </Typography>
+        </Panel>
+
+        <Typography variant="h3">Markdown Component</Typography>
+        <MarkdownRenderer data={sample} />
+
+        <Button variant="outlined" onClick={toggleMode} style={{ marginTop: theme.spacing(1) }}>
+          Toggle light / dark mode
+        </Button>
+
+        <Button size="lg" onClick={() => navigate(-1)} style={{ marginTop: theme.spacing(1) }}>
+          ← Back
+        </Button>
+      </Stack>
+    </Surface>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   "dependencies": {
     "@iconify/react": "^6.0.0",
     "siphash": "^1.2.0",
-    "zustand": "^4.5.7"
+    "zustand": "^4.5.7",
+    "marked": "^16.1.1"
   },
   "peerDependencies": {
     "react": ">=18.0.0 || ^19.0.0",

--- a/src/components/widgets/LLMChat.tsx
+++ b/src/components/widgets/LLMChat.tsx
@@ -19,6 +19,7 @@ import TextField from '../fields/TextField';
 import Stack from '../layout/Stack';
 import Panel from '../layout/Panel';
 import Typography from '../primitives/Typography';
+import Markdown from './Markdown';
 import Avatar from '../primitives/Avatar';
 import KeyModal from '../KeyModal';
 import Select from '../fields/Select';
@@ -359,6 +360,8 @@ export const LLMChat: React.FC<ChatProps> = ({
                     <span />
                     <span />
                   </Typing>
+                ) : m.role === 'assistant' ? (
+                  <Markdown data={m.content} codeBackground={theme.colors.background} />
                 ) : (
                   <Typography>{m.content}</Typography>
                 )}

--- a/src/components/widgets/Markdown.tsx
+++ b/src/components/widgets/Markdown.tsx
@@ -1,0 +1,135 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/widgets/Markdown.tsx | valet
+// Lightweight Markdown renderer using valet primitives
+// ─────────────────────────────────────────────────────────────
+import React from 'react';
+import { marked } from 'marked';
+import type { TokensList, Token, Tokens } from 'marked';
+import Stack from '../layout/Stack';
+import Panel from '../layout/Panel';
+import Typography, { type Variant } from '../primitives/Typography';
+import Image from '../primitives/Image';
+import Table, { type TableColumn } from './Table';
+
+export interface MarkdownProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Raw markdown text */
+  data: string;
+  /** Optional override for code block background */
+  codeBackground?: string;
+}
+
+const renderInline = (tokens?: Token[]): React.ReactNode => {
+  if (!tokens) return null;
+  return tokens.map((t: Token, i: number) => {
+    switch (t.type) {
+      case 'strong':
+        return <strong key={i}>{renderInline(t.tokens)}</strong>;
+      case 'em':
+        return <em key={i}>{renderInline(t.tokens)}</em>;
+      case 'codespan':
+        return <code key={i}>{(t as Tokens.Codespan).text}</code>;
+      case 'link':
+        return (
+          <a key={i} href={t.href} title={t.title}>
+            {renderInline(t.tokens)}
+          </a>
+        );
+      case 'image':
+        return (
+          <Image
+            key={i}
+            src={(t as Tokens.Image).href}
+            alt={(t as Tokens.Image).text}
+            style={{ maxWidth: '100%' }}
+          />
+        );
+      case 'text':
+        return (t as Tokens.Text).text;
+      default:
+        return (t as any).raw || '';
+    }
+  });
+};
+
+const renderTokens = (tokens: TokensList, codeBg?: string): React.ReactNode =>
+  tokens.map((t: Token, i: number) => {
+    switch (t.type) {
+      case 'heading':
+        const variant = (`h${t.depth}`) as Variant;
+        return (
+          <Typography key={i} variant={variant} bold>
+            {renderInline(t.tokens)}
+          </Typography>
+        );
+      case 'paragraph':
+        return (
+          <Typography key={i} style={{ margin: '0.5rem 0' }}>
+            {renderInline(t.tokens)}
+          </Typography>
+        );
+      case 'list':
+        return (
+          <ul key={i} style={{ paddingLeft: '1.25rem' }}>
+            {t.items.map((item: Tokens.ListItem, j: number) => (
+              <li key={j}>{renderInline(item.tokens)}</li>
+            ))}
+          </ul>
+        );
+      case 'code':
+        return (
+          <Panel
+            key={i}
+            preset="codePanel"
+            background={codeBg}
+            style={{ margin: '0.5rem 0' }}
+          >
+            <code>{t.text}</code>
+          </Panel>
+        );
+      case 'table':
+        const columns: TableColumn<Record<string, string>>[] = t.header.map((h: Tokens.TableCell, idx: number) => ({
+          header: renderInline(h.tokens),
+          accessor: idx.toString() as any,
+        }));
+        const data = t.rows.map((row: Tokens.TableCell[]) => {
+          const obj: Record<string, string> = {};
+          row.forEach((cell: Tokens.TableCell, idx: number) => {
+            obj[idx] = cell.text;
+          });
+          return obj;
+        });
+        return (
+          <Table
+            key={i}
+            data={data}
+            columns={columns}
+            constrainHeight={false}
+          />
+        );
+      case 'space':
+        return null;
+      default:
+        return (
+          <Typography key={i}>
+            {('raw' in t && (t as any).raw) || ''}
+          </Typography>
+        );
+    }
+  });
+
+export const Markdown: React.FC<MarkdownProps> = ({
+  data,
+  codeBackground,
+  className,
+  style,
+  ...rest
+}) => {
+  const tokens = React.useMemo(() => marked.lexer(data) as TokensList, [data]);
+  return (
+    <Stack {...rest} className={className} style={style}>
+      {renderTokens(tokens, codeBackground)}
+    </Stack>
+  );
+};
+
+export default Markdown;

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export * from './components/widgets/Table';
 export * from './components/layout/Tabs';
 export * from './components/widgets/Tooltip';
 export * from './components/widgets/Tree';
+export * from './components/widgets/Markdown';
 export { default as KeyModal } from './components/KeyModal';
 
 // ─── AI Helpers ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add new `Markdown` widget for rendering markdown text via valet primitives
- showcase Markdown usage in docs
- wire docs navigation and routes for Markdown
- export component in library index
- include `marked` dependency
- fix assistant Markdown code panel background in `LLMChat`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687b55a553c08320b5896c91fd62df4f