### PR TITLE
Add RichChat component

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ These have been mostly tested in the [valet Docs](https://github.com/off-court-c
 | Button        |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
 | Checkbox      |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
 | LLMChat          |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
+| RichChat         |  🟡    |  🟡    |     🟡      |      🟡      |      🟡 | ----------                 |
 | Drawer        |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      | ----------                 |
 | Date Selector |  🟡    |  🟡    |     🟡      |      🟡      |      🟡      |
 ----------                 |

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -27,6 +27,7 @@ const IconButtonDemoPage    = page(() => import('./pages/IconButtonDemoPage'));
 const ImageDemoPage         = page(() => import('./pages/ImageDemo'));
 const AvatarDemoPage        = page(() => import('./pages/AvatarDemo'));
 const LLMChatDemoPage          = page(() => import('./pages/LLMChatDemo'));
+const RichChatDemoPage         = page(() => import('./pages/RichChatDemo'));
 const PanelDemoPage         = page(() => import('./pages/components/Panel'));
 const CheckboxDemoPage      = page(() => import('./pages/CheckBoxDemo'));
 const TooltipDemoPage       = page(() => import('./pages/TooltipDemo'));
@@ -123,6 +124,7 @@ export function App() {
         <Route path="/radio-demo"      element={<RadioGroupDemoPage />} />
         <Route path="/video-demo"      element={<VideoDemoPage />} />
         <Route path="/chat-demo"       element={<LLMChatDemoPage />} />
+        <Route path="/rich-chat"       element={<RichChatDemoPage />} />
         <Route path="/snackbar-demo"   element={<SnackbarDemoPage />} />
         <Route path="/tree-demo"      element={<TreeDemoPage />} />
         <Route path="/iterator-demo"  element={<IteratorDemoPage />} />

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -54,6 +54,7 @@ const fields: [string, string][] = [
 
 const widgets: [string, string][] = [
   ['LLMChat', '/chat-demo'],
+  ['RichChat', '/rich-chat'],
   ['Pagination', '/pagination-demo'],
   ['Parallax', '/parallax'],
   ['Snackbar', '/snackbar-demo'],

--- a/docs/src/pages/RichChatDemo.tsx
+++ b/docs/src/pages/RichChatDemo.tsx
@@ -1,0 +1,100 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// src/pages/RichChatDemo.tsx | valet
+// Demo for <RichChat /> component
+// ─────────────────────────────────────────────────────────────────────────────
+import { useState } from 'react';
+import {
+  Surface,
+  Stack,
+  Typography,
+  Button,
+  RichChat,
+  useTheme,
+} from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
+import type { RichMessage } from '@archway/valet';
+import present from '../assets/present.jpg';
+import monkey from '../assets/monkey.jpg';
+
+export default function RichChatDemoPage() {
+  const navigate = useNavigate();
+  const { theme, toggleMode } = useTheme();
+  const [messages, setMessages] = useState<RichMessage[]>([
+    {
+      role: 'assistant',
+      content: (
+        <Stack>
+          <Typography>Do you like valet?</Typography>
+          <Stack direction="row">
+            <Button onClick={() => handleChoice('Yes')}>Yes</Button>
+            <Button onClick={() => handleChoice('No')}>No</Button>
+          </Stack>
+        </Stack>
+      ),
+    },
+  ]);
+
+  function handleChoice(ans: string) {
+    setMessages(prev => [
+      ...prev,
+      { role: 'user', content: ans, animate: true },
+      {
+        role: 'assistant',
+        content: `You answered ${ans.toLowerCase()}.`,
+        animate: true,
+      },
+    ]);
+  }
+
+  const handleSend = (m: RichMessage) => {
+    const text = String(m.content).toLowerCase();
+    const num = parseInt(text);
+    if (!isNaN(num)) {
+      setMessages(prev => [
+        ...prev,
+        m,
+        {
+          role: 'assistant',
+          content: `Cool, ${num} dog${num === 1 ? '' : 's'}!`,
+          animate: true,
+        },
+      ]);
+    } else {
+      setMessages(prev => [...prev, m]);
+    }
+  };
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack>
+        <Typography variant="h2" bold>
+          RichChat Showcase
+        </Typography>
+        <Typography variant="subtitle">Demonstrates embedded components</Typography>
+
+        <RichChat
+          messages={messages}
+          onSend={handleSend}
+          constrainHeight
+          userAvatar={present}
+          systemAvatar={monkey}
+        />
+
+        <Button variant="outlined" onClick={toggleMode}>
+          Toggle light / dark mode
+        </Button>
+
+        <Button
+          size="lg"
+          onClick={() => navigate(-1)}
+          style={{ marginTop: theme.spacing(1) }}
+        >
+          ← Back
+        </Button>
+      </Stack>
+    </Surface>
+  );
+}
+

--- a/src/components/widgets/RichChat.tsx
+++ b/src/components/widgets/RichChat.tsx
@@ -2,17 +2,9 @@
 // src/components/widgets/RichChat.tsx  | valet
 // Local, deterministic chat component with embed support
 // ─────────────────────────────────────────────────────────────
-import React, {
-  useState,
-  useRef,
-  useId,
-  useEffect,
-  useLayoutEffect,
-} from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { styled, keyframes } from '../../css/createStyled';
 import { useTheme } from '../../system/themeStore';
-import { useSurface } from '../../system/surfaceStore';
-import { shallow } from 'zustand/shallow';
 import { preset } from '../../css/stylePresets';
 import IconButton from '../fields/IconButton';
 import TextField from '../fields/TextField';
@@ -50,12 +42,14 @@ const Wrapper = styled('div')<{ $gap: string }>`
   display: flex;
   flex-direction: column;
   gap: ${({ $gap }) => $gap};
+  max-height: 100%;
 `;
 
 const Messages = styled('div')<{ $gap: string }>`
   display: flex;
   flex-direction: column;
   gap: ${({ $gap }) => $gap};
+  flex: 1;
 `;
 
 const Row = styled('div')<{
@@ -112,89 +106,18 @@ export const RichChat: React.FC<RichChatProps> = ({
   ...rest
 }) => {
   const { theme } = useTheme();
-  const surface = useSurface(
-    s => ({
-      element: s.element,
-      width: s.width,
-      height: s.height,
-      registerChild: s.registerChild,
-      unregisterChild: s.unregisterChild,
-    }),
-    shallow,
+  const [portrait, setPortrait] = useState(() =>
+    typeof window !== 'undefined' ? window.innerHeight > window.innerWidth : false,
   );
-  const portrait = surface.height > surface.width;
+  useEffect(() => {
+    const handler = () =>
+      setPortrait(window.innerHeight > window.innerWidth);
+    window.addEventListener('resize', handler);
+    return () => window.removeEventListener('resize', handler);
+  }, []);
   const wrapRef = useRef<HTMLDivElement>(null);
-  const uniqueId = useId();
-  const [maxHeight, setMaxHeight] = useState<number>();
-  const [shouldConstrain, setShouldConstrain] = useState(false);
-  const constraintRef = useRef(false);
 
   const [text, setText] = useState('');
-
-  const calcCutoff = () => {
-    if (typeof document === 'undefined') return 32;
-    const fs = parseFloat(
-      getComputedStyle(document.documentElement).fontSize,
-    );
-    return (isNaN(fs) ? 16 : fs) * 2;
-  };
-
-  const update = () => {
-    const node = wrapRef.current;
-    const surfEl = surface.element;
-    if (!node || !surfEl) return;
-    const sRect = surfEl.getBoundingClientRect();
-    const nRect = node.getBoundingClientRect();
-    const top = Math.round(nRect.top - sRect.top + surfEl.scrollTop);
-    const bottomSpace = Math.round(
-      surfEl.scrollHeight - (nRect.bottom - sRect.top + surfEl.scrollTop),
-    );
-    const available = Math.round(surface.height - top - bottomSpace);
-    const cutoff = calcCutoff();
-
-    const next = available >= cutoff;
-    if (next) {
-      if (!constraintRef.current) {
-        surfEl.scrollTop = 0;
-        surfEl.scrollLeft = 0;
-      }
-      constraintRef.current = true;
-      setShouldConstrain(true);
-      setMaxHeight(Math.max(0, available));
-    } else {
-      constraintRef.current = false;
-      setShouldConstrain(false);
-      setMaxHeight(undefined);
-    }
-  };
-
-  useEffect(() => {
-    if (!constrainHeight) {
-      constraintRef.current = false;
-      setShouldConstrain(false);
-      setMaxHeight(undefined);
-    } else {
-      constraintRef.current = false;
-    }
-  }, [constrainHeight]);
-
-  useLayoutEffect(() => {
-    if (!constrainHeight || !wrapRef.current || !surface.element) return;
-    const node = wrapRef.current;
-    surface.registerChild(uniqueId, node, update);
-    const ro = new ResizeObserver(update);
-    ro.observe(node);
-    update();
-    return () => {
-      surface.unregisterChild(uniqueId);
-      ro.disconnect();
-    };
-  }, [constrainHeight, surface.element]);
-
-  useLayoutEffect(() => {
-    if (!constrainHeight || !wrapRef.current || !surface.element) return;
-    update();
-  }, [constrainHeight, surface.height, surface.element]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -219,7 +142,7 @@ export const RichChat: React.FC<RichChatProps> = ({
       <Wrapper ref={wrapRef} $gap={theme.spacing(3)} style={{ overflow: 'hidden' }}>
         <Messages
           $gap={theme.spacing(1.5)}
-          style={shouldConstrain ? { overflowY: 'auto', maxHeight } : undefined}
+          style={constrainHeight ? { overflowY: 'auto' } : undefined}
         >
           {messages
             .filter(m => m.role !== 'system')

--- a/src/components/widgets/RichChat.tsx
+++ b/src/components/widgets/RichChat.tsx
@@ -1,0 +1,311 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/widgets/RichChat.tsx  | valet
+// Local, deterministic chat component with embed support
+// ─────────────────────────────────────────────────────────────
+import React, {
+  useState,
+  useRef,
+  useId,
+  useEffect,
+  useLayoutEffect,
+} from 'react';
+import { styled, keyframes } from '../../css/createStyled';
+import { useTheme } from '../../system/themeStore';
+import { useSurface } from '../../system/surfaceStore';
+import { shallow } from 'zustand/shallow';
+import { preset } from '../../css/stylePresets';
+import IconButton from '../fields/IconButton';
+import TextField from '../fields/TextField';
+import Stack from '../layout/Stack';
+import Panel from '../layout/Panel';
+import Typography from '../primitives/Typography';
+import Avatar from '../primitives/Avatar';
+import type { Presettable } from '../../types';
+
+/*───────────────────────────────────────────────────────────*/
+/* Types                                                      */
+export interface RichMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: React.ReactNode;
+  name?: string;
+  typing?: boolean;
+  animate?: boolean;
+}
+
+export interface RichChatProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSubmit'>,
+    Presettable {
+  messages: RichMessage[];
+  onSend?: (message: RichMessage) => void;
+  userAvatar?: string;
+  systemAvatar?: string;
+  placeholder?: string;
+  disableInput?: boolean;
+  constrainHeight?: boolean;
+}
+
+/*───────────────────────────────────────────────────────────*/
+/* Styled primitives                                         */
+const Wrapper = styled('div')<{ $gap: string }>`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ $gap }) => $gap};
+`;
+
+const Messages = styled('div')<{ $gap: string }>`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ $gap }) => $gap};
+`;
+
+const Row = styled('div')<{
+  $from: 'user' | 'assistant' | 'system';
+  $left: string;
+  $right: string;
+}>`
+  display: flex;
+  align-items: center;
+  justify-content: ${({ $from }) =>
+    $from === 'user' ? 'flex-end' : 'flex-start'};
+  padding-left: ${({ $left }) => $left};
+  padding-right: ${({ $right }) => $right};
+`;
+
+const typingDot = keyframes`
+  0%, 80%, 100% { opacity: 0.3; transform: translateY(0); }
+  40% { opacity: 1; transform: translateY(-0.1rem); }
+`;
+
+const fadeIn = keyframes`
+  from { opacity: 0; transform: translateY(0.25rem); }
+  to   { opacity: 1; transform: translateY(0); }
+`;
+
+const Typing = styled('div')<{ $color: string }>`
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  & span {
+    width: 0.4rem;
+    height: 0.4rem;
+    border-radius: 50%;
+    background: ${({ $color }) => $color};
+    animation: ${typingDot} 1s infinite;
+  }
+  & span:nth-child(2) { animation-delay: 0.2s; }
+  & span:nth-child(3) { animation-delay: 0.4s; }
+`;
+
+/*───────────────────────────────────────────────────────────*/
+/* Component                                                  */
+export const RichChat: React.FC<RichChatProps> = ({
+  messages,
+  onSend,
+  userAvatar,
+  systemAvatar,
+  placeholder = 'Message…',
+  disableInput = false,
+  constrainHeight = true,
+  preset: p,
+  className,
+  style,
+  ...rest
+}) => {
+  const { theme } = useTheme();
+  const surface = useSurface(
+    s => ({
+      element: s.element,
+      width: s.width,
+      height: s.height,
+      registerChild: s.registerChild,
+      unregisterChild: s.unregisterChild,
+    }),
+    shallow,
+  );
+  const portrait = surface.height > surface.width;
+  const wrapRef = useRef<HTMLDivElement>(null);
+  const uniqueId = useId();
+  const [maxHeight, setMaxHeight] = useState<number>();
+  const [shouldConstrain, setShouldConstrain] = useState(false);
+  const constraintRef = useRef(false);
+
+  const [text, setText] = useState('');
+
+  const calcCutoff = () => {
+    if (typeof document === 'undefined') return 32;
+    const fs = parseFloat(
+      getComputedStyle(document.documentElement).fontSize,
+    );
+    return (isNaN(fs) ? 16 : fs) * 2;
+  };
+
+  const update = () => {
+    const node = wrapRef.current;
+    const surfEl = surface.element;
+    if (!node || !surfEl) return;
+    const sRect = surfEl.getBoundingClientRect();
+    const nRect = node.getBoundingClientRect();
+    const top = Math.round(nRect.top - sRect.top + surfEl.scrollTop);
+    const bottomSpace = Math.round(
+      surfEl.scrollHeight - (nRect.bottom - sRect.top + surfEl.scrollTop),
+    );
+    const available = Math.round(surface.height - top - bottomSpace);
+    const cutoff = calcCutoff();
+
+    const next = available >= cutoff;
+    if (next) {
+      if (!constraintRef.current) {
+        surfEl.scrollTop = 0;
+        surfEl.scrollLeft = 0;
+      }
+      constraintRef.current = true;
+      setShouldConstrain(true);
+      setMaxHeight(Math.max(0, available));
+    } else {
+      constraintRef.current = false;
+      setShouldConstrain(false);
+      setMaxHeight(undefined);
+    }
+  };
+
+  useEffect(() => {
+    if (!constrainHeight) {
+      constraintRef.current = false;
+      setShouldConstrain(false);
+      setMaxHeight(undefined);
+    } else {
+      constraintRef.current = false;
+    }
+  }, [constrainHeight]);
+
+  useLayoutEffect(() => {
+    if (!constrainHeight || !wrapRef.current || !surface.element) return;
+    const node = wrapRef.current;
+    surface.registerChild(uniqueId, node, update);
+    const ro = new ResizeObserver(update);
+    ro.observe(node);
+    update();
+    return () => {
+      surface.unregisterChild(uniqueId);
+      ro.disconnect();
+    };
+  }, [constrainHeight, surface.element]);
+
+  useLayoutEffect(() => {
+    if (!constrainHeight || !wrapRef.current || !surface.element) return;
+    update();
+  }, [constrainHeight, surface.height, surface.element]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!text.trim()) return;
+    const msg: RichMessage = { role: 'user', content: text.trim() };
+    onSend?.(msg);
+    setText('');
+  };
+
+  const presetClasses = p ? preset(p) : '';
+  const cls = [presetClasses, className].filter(Boolean).join(' ') || undefined;
+
+  return (
+    <Panel
+      {...rest}
+      compact
+      fullWidth
+      variant="alt"
+      style={style}
+      className={cls}
+    >
+      <Wrapper ref={wrapRef} $gap={theme.spacing(3)} style={{ overflow: 'hidden' }}>
+        <Messages
+          $gap={theme.spacing(1.5)}
+          style={shouldConstrain ? { overflowY: 'auto', maxHeight } : undefined}
+        >
+          {messages
+            .filter(m => m.role !== 'system')
+            .map((m, i) => {
+              const sidePad = portrait ? theme.spacing(8) : theme.spacing(24);
+              const avatarPad = theme.spacing(1);
+              return (
+                <Row
+                  key={i}
+                  $from={m.role}
+                  $left={m.role === 'user' ? sidePad : avatarPad}
+                  $right={m.role === 'user' ? avatarPad : sidePad}
+                >
+                  {m.role !== 'user' && systemAvatar && (
+                    <Avatar
+                      src={systemAvatar}
+                      size="s"
+                      style={{ marginRight: theme.spacing(1) }}
+                    />
+                  )}
+                  <Panel
+                    compact
+                    variant="main"
+                    background={m.role === 'user' ? theme.colors.primary : undefined}
+                    style={{
+                      maxWidth: '100%',
+                      width: 'fit-content',
+                      borderRadius: theme.spacing(0.5),
+                      animation: m.animate ? `${fadeIn} 0.2s ease-out` : undefined,
+                    }}
+                  >
+                    {m.name && (
+                      <Typography variant="subtitle" bold>
+                        {m.name}
+                      </Typography>
+                    )}
+                    {m.typing ? (
+                      <Typing $color={m.role === 'user' ? theme.colors.primaryText : theme.colors.text}>
+                        <span />
+                        <span />
+                        <span />
+                      </Typing>
+                    ) : typeof m.content === 'string' ? (
+                      <Typography>{m.content}</Typography>
+                    ) : (
+                      m.content
+                    )}
+                  </Panel>
+                  {m.role === 'user' && userAvatar && (
+                    <Avatar
+                      src={userAvatar}
+                      size="s"
+                      style={{ marginLeft: theme.spacing(1) }}
+                    />
+                  )}
+                </Row>
+              );
+            })}
+        </Messages>
+
+        {!disableInput && (
+          <form onSubmit={handleSubmit} style={{ width: '100%' }}>
+            <Stack direction="row" spacing={1} compact>
+              <TextField
+                as="textarea"
+                name="chat-message"
+                value={text}
+                onChange={(e) => setText(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' && !e.shiftKey) {
+                    e.preventDefault();
+                    handleSubmit(e as any);
+                  }
+                }}
+                rows={1}
+                placeholder={placeholder}
+                fullWidth
+              />
+              <IconButton icon="carbon:send" type="submit" aria-label="Send" />
+            </Stack>
+          </form>
+        )}
+      </Wrapper>
+    </Panel>
+  );
+};
+
+export default RichChat;
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export * from './components/fields/Iterator';
 export * from './components/layout/Accordion';
 export * from './components/layout/AppBar';
 export * from './components/widgets/LLMChat';
+export * from './components/widgets/RichChat';
 export * from './components/layout/Drawer';
 export * from './components/fields/DateSelector';
 export * from './components/layout/List';


### PR DESCRIPTION
## Summary
- add `RichChat` widget supporting embedded components
- demo `RichChat` usage in docs
- export in index and update nav
- document in README

## Testing
- `npm run build`
- `cd docs && npm run build` *(fails: cannot find vite typings)*

------
https://chatgpt.com/codex/tasks/task_e_687c9f28d268832088ec80a71eeca878