### PR TITLE
Add RichChat component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- `RichChat` component for local chats with embeddable content
+### Changed
+- Avatars now top-align on multi-line messages in `LLMChat` and `RichChat`
 
 ## [0.18.1]
 - Added `Markdown` component

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -27,6 +27,7 @@ const IconButtonDemoPage    = page(() => import('./pages/IconButtonDemoPage'));
 const ImageDemoPage         = page(() => import('./pages/ImageDemo'));
 const AvatarDemoPage        = page(() => import('./pages/AvatarDemo'));
 const LLMChatDemoPage          = page(() => import('./pages/LLMChatDemo'));
+const RichChatDemoPage         = page(() => import('./pages/RichChatDemo'));
 const PanelDemoPage         = page(() => import('./pages/components/Panel'));
 const CheckboxDemoPage      = page(() => import('./pages/CheckBoxDemo'));
 const TooltipDemoPage       = page(() => import('./pages/TooltipDemo'));
@@ -123,6 +124,7 @@ export function App() {
         <Route path="/radio-demo"      element={<RadioGroupDemoPage />} />
         <Route path="/video-demo"      element={<VideoDemoPage />} />
         <Route path="/chat-demo"       element={<LLMChatDemoPage />} />
+        <Route path="/rich-chat-demo" element={<RichChatDemoPage />} />
         <Route path="/snackbar-demo"   element={<SnackbarDemoPage />} />
         <Route path="/tree-demo"      element={<TreeDemoPage />} />
         <Route path="/iterator-demo"  element={<IteratorDemoPage />} />

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -54,6 +54,7 @@ const fields: [string, string][] = [
 
 const widgets: [string, string][] = [
   ['LLMChat', '/chat-demo'],
+  ['RichChat', '/rich-chat-demo'],
   ['Pagination', '/pagination-demo'],
   ['Parallax', '/parallax'],
   ['Snackbar', '/snackbar-demo'],

--- a/docs/src/pages/RichChatDemo.tsx
+++ b/docs/src/pages/RichChatDemo.tsx
@@ -1,0 +1,89 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// src/pages/RichChatDemo.tsx | valet
+// Showcase for <RichChat /> component with local logic
+// ─────────────────────────────────────────────────────────────────────────────
+import { useState } from 'react';
+import {
+  Surface,
+  Stack,
+  Typography,
+  Button,
+  RichChat,
+  useTheme,
+} from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
+import type { RichMessage } from '@archway/valet';
+import monkey from '../assets/monkey.jpg';
+import present from '../assets/present.jpg';
+
+export default function RichChatDemoPage() {
+  const navigate = useNavigate();
+  const { theme, toggleMode } = useTheme();
+  const [messages, setMessages] = useState<RichMessage[]>([
+    {
+      role: 'assistant',
+      content: (
+        <Stack>
+          <Typography>Do you like valet?</Typography>
+          <Stack direction="row" spacing={1}>
+            <Button onClick={() => handleAnswer('Yes')}>Yes</Button>
+            <Button onClick={() => handleAnswer('No')}>No</Button>
+          </Stack>
+        </Stack>
+      ),
+      animate: true,
+    },
+  ]);
+
+  const handleAnswer = (reply: string) => {
+    setMessages(prev => [
+      ...prev,
+      { role: 'user', content: reply, animate: true },
+      {
+        role: 'assistant',
+        content:
+          reply === 'Yes'
+            ? 'Great! Thanks for checking out valet.'
+            : "That's okay, maybe next time!",
+        animate: true,
+      },
+    ]);
+  };
+
+  const handleSend = (m: RichMessage) => {
+    setMessages(prev => [...prev, m]);
+  };
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack>
+        <Typography variant="h2" bold>
+          RichChat Demo
+        </Typography>
+        <Typography variant="subtitle">Local chat with embeddable components</Typography>
+
+        <RichChat
+          messages={messages}
+          onSend={handleSend}
+          constrainHeight
+          userAvatar={present}
+          systemAvatar={monkey}
+        />
+
+        <Button variant="outlined" onClick={toggleMode}>
+          Toggle light / dark mode
+        </Button>
+
+        <Button
+          size="lg"
+          onClick={() => navigate(-1)}
+          style={{ marginTop: theme.spacing(1) }}
+        >
+          ← Back
+        </Button>
+      </Stack>
+    </Surface>
+  );
+}

--- a/src/components/widgets/RichChat.tsx
+++ b/src/components/widgets/RichChat.tsx
@@ -1,6 +1,6 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/widgets/LLMChat.tsx  | valet
-// LLM style chat component with height constraint
+// src/components/widgets/RichChat.tsx  | valet
+// Local chat component with embeddable content
 // ─────────────────────────────────────────────────────────────
 import React, {
   useState,
@@ -21,63 +21,45 @@ import Panel from '../layout/Panel';
 import Typography from '../primitives/Typography';
 import Markdown from './Markdown';
 import Avatar from '../primitives/Avatar';
-import KeyModal from '../KeyModal';
-import Select from '../fields/Select';
-import { useAIKey, AIProvider } from '../../system/aiKeyStore';
 import type { Presettable } from '../../types';
-
-const models: Record<AIProvider, string[]> = {
-  openai: ['gpt-4o', 'gpt-4-turbo', 'gpt-3.5-turbo'],
-  anthropic: [
-    'claude-sonnet-4-20250514'
-  ],
-};
 
 /*───────────────────────────────────────────────────────────*/
 /* Types                                                      */
-export interface ChatMessage {
+export interface RichMessage {
   role: 'system' | 'user' | 'assistant' | 'function' | 'tool';
-  content: string;
+  content: React.ReactNode;
   name?: string;
-  /** Show animated typing indicator */
   typing?: boolean;
-  /** Apply fade animation when first rendered */
   animate?: boolean;
 }
 
-export interface ChatProps
+export interface RichChatProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSubmit'>,
-  Presettable {
-  messages: ChatMessage[];
-  onSend?: (message: ChatMessage) => void;
-  /** Avatar image for user messages */
+    Presettable {
+  messages: RichMessage[];
+  onSend?: (message: RichMessage) => void;
   userAvatar?: string;
-  /** Avatar image for system / assistant messages */
   systemAvatar?: string;
   placeholder?: string;
   disableInput?: boolean;
   constrainHeight?: boolean;
-  apiKey?: string;
-  provider?: AIProvider;
-  model?: string;
-  onModelChange?: (m: string) => void;
 }
 
 /*───────────────────────────────────────────────────────────*/
 /* Styled primitives                                         */
-const Wrapper = styled('div') <{ $gap: string }>`
+const Wrapper = styled('div')<{ $gap: string }>`
   display: flex;
   flex-direction: column;
   gap: ${({ $gap }) => $gap};
 `;
 
-const Messages = styled('div') <{ $gap: string }>`
+const Messages = styled('div')<{ $gap: string }>`
   display: flex;
   flex-direction: column;
   gap: ${({ $gap }) => $gap};
 `;
 
-const Row = styled('div') <{
+const Row = styled('div')<{
   $from: 'user' | 'assistant' | 'system' | 'function' | 'tool';
   $left: string;
   $right: string;
@@ -88,19 +70,6 @@ const Row = styled('div') <{
   justify-content: ${({ $from }) => ($from === 'user' ? 'flex-end' : 'flex-start')};
   padding-left: ${({ $left }) => $left};
   padding-right: ${({ $right }) => $right};
-`;
-
-
-const Bar = styled('div')<{ $bg: string; $text: string; $gap: string }>`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0.5rem 1rem;
-  background: ${({ $bg }) => $bg};
-  color: ${({ $text }) => $text};
-  & > * {
-    padding: ${({ $gap }) => $gap};
-  }
 `;
 
 const typingDot = keyframes`
@@ -130,7 +99,7 @@ const Typing = styled('div')<{ $color: string }>`
 
 /*───────────────────────────────────────────────────────────*/
 /* Component                                                  */
-export const LLMChat: React.FC<ChatProps> = ({
+export const RichChat: React.FC<RichChatProps> = ({
   messages,
   onSend,
   userAvatar,
@@ -138,10 +107,6 @@ export const LLMChat: React.FC<ChatProps> = ({
   placeholder = 'Message…',
   disableInput = false,
   constrainHeight = true,
-  apiKey: propKey,
-  provider: propProvider,
-  model: propModel,
-  onModelChange,
   preset: p,
   className,
   style,
@@ -166,37 +131,6 @@ export const LLMChat: React.FC<ChatProps> = ({
   const constraintRef = useRef(false);
 
   const [text, setText] = useState('');
-  const {
-    apiKey: storeKey,
-    provider: storeProv,
-    model: storeModel,
-    setModel,
-  } = useAIKey();
-  const [showKeyModal, setShowKeyModal] = useState(false);
-  const key = propKey ?? storeKey;
-  const provider = (propProvider ?? storeProv) as AIProvider | null;
-  const [model, setModelLocal] = useState(
-    propModel ?? storeModel ?? (provider ? models[provider][0] : ''),
-  );
-
-  useEffect(() => {
-    if (propModel) setModelLocal(propModel);
-  }, [propModel]);
-
-  useEffect(() => {
-    if (!propModel && provider) {
-      const m = storeModel ?? models[provider][0];
-      setModelLocal(m);
-    }
-  }, [provider, storeModel, propModel]);
-
-  const handleModelChange = (m: string) => {
-    if (!propModel) {
-      setModelLocal(m);
-      setModel(m);
-    }
-    onModelChange?.(m);
-  };
 
   const calcCutoff = () => {
     if (typeof document === 'undefined') return 32;
@@ -266,56 +200,24 @@ export const LLMChat: React.FC<ChatProps> = ({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!text.trim()) return;
-    const msg: ChatMessage = { role: 'user', content: text.trim() };
+    const msg: RichMessage = { role: 'user', content: text.trim() };
     onSend?.(msg);
     setText('');
   };
 
   const presetClasses = p ? preset(p) : '';
-
   const cls = [presetClasses, className].filter(Boolean).join(' ') || undefined;
 
   return (
-    <>
-      {!propKey && (
-        <KeyModal open={showKeyModal} onClose={() => setShowKeyModal(false)} />
-      )}
-      <Panel
-        {...rest}
-        compact
-        fullWidth
-        variant="alt"
-        style={style}
-        className={cls}
-      >
-        <Bar $bg={theme.colors.secondary} $text={theme.colors.secondaryText} $gap={theme.spacing(0.5)}>
-          {provider && key ? (
-            <Select
-              size="sm"
-              value={model}
-              onChange={(v) => handleModelChange(v as string)}
-            >
-              {models[provider].map(m => (
-                <Select.Option key={m} value={m}>{m}</Select.Option>
-              ))}
-            </Select>
-          ) : (
-            <span />
-          )}
-          <span
-            style={{ display: 'flex', alignItems: 'center', cursor: 'pointer', gap: theme.spacing(0.5) }}
-            onClick={() => !propKey && setShowKeyModal(true)}
-          >
-            <Typography variant="subtitle">
-              {key ? 'Connected' : 'Disconnected'}
-            </Typography>
-            <IconButton
-              icon={key ? 'carbon:checkmark' : 'carbon:circle-dash'}
-              aria-label="Set API key"
-            />
-          </span>
-        </Bar>
-        <Wrapper ref={wrapRef} $gap={theme.spacing(3)} style={{ overflow: 'hidden' }}>
+    <Panel
+      {...rest}
+      compact
+      fullWidth
+      variant="alt"
+      style={style}
+      className={cls}
+    >
+      <Wrapper ref={wrapRef} $gap={theme.spacing(3)} style={{ overflow: 'hidden' }}>
         <Messages
           $gap={theme.spacing(1.5)}
           style={shouldConstrain ? { overflowY: 'auto', maxHeight } : undefined}
@@ -335,6 +237,19 @@ export const LLMChat: React.FC<ChatProps> = ({
                   const lh = parseFloat(getComputedStyle(el).lineHeight || '16');
                   setTop(el.offsetHeight > lh * 1.5);
                 }, [surface.width, m.content]);
+                const content =
+                  typeof m.content === 'string'
+                    ? m.role === 'assistant'
+                      ? (
+                          <Markdown
+                            data={m.content}
+                            codeBackground={theme.colors.background}
+                          />
+                        )
+                      : (
+                          <Typography>{m.content}</Typography>
+                        )
+                    : m.content;
                 return (
                   <Row
                     $from={m.role}
@@ -372,10 +287,8 @@ export const LLMChat: React.FC<ChatProps> = ({
                           <span />
                           <span />
                         </Typing>
-                      ) : m.role === 'assistant' ? (
-                        <Markdown data={m.content} codeBackground={theme.colors.background} />
                       ) : (
-                        <Typography>{m.content}</Typography>
+                        content
                       )}
                     </Panel>
                     {m.role === 'user' && userAvatar && (
@@ -417,8 +330,7 @@ export const LLMChat: React.FC<ChatProps> = ({
         )}
       </Wrapper>
     </Panel>
-    </>
   );
 };
 
-export default LLMChat;
+export default RichChat;

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export * from './components/fields/Iterator';
 export * from './components/layout/Accordion';
 export * from './components/layout/AppBar';
 export * from './components/widgets/LLMChat';
+export * from './components/widgets/RichChat';
 export * from './components/layout/Drawer';
 export * from './components/fields/DateSelector';
 export * from './components/layout/List';


### PR DESCRIPTION
## Summary
- add `RichChat` component for local chats with embeddable content
- demo `RichChat` in docs
- export `RichChat` in main library
- update docs navigation
- document new component in changelog
- top-align avatars on multi-line chat messages

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687d2e50a66c8320be50c2d76b84ea68