### PR TITLE
Add form support to RichChat

### DIFF
--- a/docs/src/pages/MarkdownDemo.tsx
+++ b/docs/src/pages/MarkdownDemo.tsx
@@ -30,9 +30,7 @@ export default function MarkdownDemoPage() {
 
         <Typography variant="h3">Raw Text</Typography>
         <Panel preset="codePanel">
-          <Typography as="pre" style={{ whiteSpace: 'pre-wrap' }}>
-            {sample}
-          </Typography>
+          <pre style={{ whiteSpace: 'pre-wrap', margin: 0 }}>{sample}</pre>
         </Panel>
 
         <Typography variant="h3">Markdown Component</Typography>

--- a/src/components/widgets/RichChat.tsx
+++ b/src/components/widgets/RichChat.tsx
@@ -272,39 +272,51 @@ export const RichChat: React.FC<RichChatProps> = ({
                       width: 'fit-content',
                       borderRadius: theme.spacing(0.5),
                       animation: m.animate ? `${fadeIn} 0.2s ease-out` : undefined,
+                      position: 'relative',
                     }}
                   >
-                    {m.name && (
-                      <Typography variant="subtitle" bold>
-                        {m.name}
-                      </Typography>
+                    <div
+                      style={{
+                        paddingRight: m.role === 'user' && m.onEdit ? theme.spacing(3) : undefined,
+                      }}
+                    >
+                      {m.name && (
+                        <Typography variant="subtitle" bold>
+                          {m.name}
+                        </Typography>
+                      )}
+                      {m.typing ? (
+                        <Typing $color={m.role === 'user' ? theme.colors.primaryText : theme.colors.text}>
+                          <span />
+                          <span />
+                          <span />
+                        </Typing>
+                      ) : (
+                        content
+                      )}
+                      {Form && <Form onSubmit={(v: string) => onFormSubmit?.(v, i)} />}
+                    </div>
+                    {m.role === 'user' && m.onEdit && (
+                      <IconButton
+                        icon="mdi:pencil"
+                        size="sm"
+                        variant="outlined"
+                        onClick={m.onEdit}
+                        aria-label="Edit"
+                        style={{
+                          position: 'absolute',
+                          top: theme.spacing(0.5),
+                          right: theme.spacing(0.5),
+                          padding: 0,
+                        }}
+                      />
                     )}
-                    {m.typing ? (
-                      <Typing $color={m.role === 'user' ? theme.colors.primaryText : theme.colors.text}>
-                        <span />
-                        <span />
-                        <span />
-                      </Typing>
-                    ) : (
-                      content
-                    )}
-                    {Form && <Form onSubmit={(v: string) => onFormSubmit?.(v, i)} />}
                   </Panel>
                   {m.role === 'user' && userAvatar && (
                     <Avatar
                       src={userAvatar}
                       size="s"
                       style={{ marginLeft: theme.spacing(1) }}
-                    />
-                  )}
-                  {m.role === 'user' && m.onEdit && (
-                    <IconButton
-                      icon="mdi:pencil"
-                      size="sm"
-                      variant="outlined"
-                      onClick={m.onEdit}
-                      aria-label="Edit"
-                      style={{ marginLeft: theme.spacing(0.5) }}
                     />
                   )}
                 </Row>

--- a/src/components/widgets/RichChat.tsx
+++ b/src/components/widgets/RichChat.tsx
@@ -277,7 +277,7 @@ export const RichChat: React.FC<RichChatProps> = ({
                   >
                     <div
                       style={{
-                        paddingRight: m.role === 'user' && m.onEdit ? theme.spacing(3) : undefined,
+                        paddingRight: m.role === 'user' && m.onEdit ? theme.spacing(9) : undefined,
                       }}
                     >
                       {m.name && (
@@ -306,7 +306,7 @@ export const RichChat: React.FC<RichChatProps> = ({
                         style={{
                           position: 'absolute',
                           top: theme.spacing(0.5),
-                          right: theme.spacing(0.5),
+                          right: theme.spacing(1),
                           padding: 0,
                         }}
                       />

--- a/src/components/widgets/RichChat.tsx
+++ b/src/components/widgets/RichChat.tsx
@@ -277,7 +277,7 @@ export const RichChat: React.FC<RichChatProps> = ({
                   >
                     <div
                       style={{
-                        paddingRight: m.role === 'user' && m.onEdit ? theme.spacing(9) : undefined,
+                        paddingRight: m.role === 'user' && m.onEdit ? theme.spacing(7) : undefined,
                       }}
                     >
                       {m.name && (


### PR DESCRIPTION
## Summary
- extend `RichChat` with a form slot and edit handler
- expose `onFormSubmit` callback
- disable input while form is active and show edit pencil for user answers
- update RichChat demo to demonstrate form mode and editing
- fix Markdown demo type error

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d3ce6acec83209754842ca2d927db