### PR TITLE
Add Dropzone widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Unreleased
 ### Added
 - `RichChat` component for local chats with embeddable content
+- `Dropzone` component for simple drag-and-drop uploads
 
 ## [0.18.1]
 - Added `Markdown` component

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,6 +13,7 @@
     "@archway/valet": "0.18.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-dropzone": "^14.2.3",
     "react-router-dom": "^7.6.0"
   },
   "devDependencies": {

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -55,6 +55,7 @@ const RadioGroupDemoPage    = page(() => import('./pages/RadioGroupDemo'));
 const VideoDemoPage         = page(() => import('./pages/VideoDemo'));
 const SnackbarDemoPage      = page(() => import('./pages/SnackbarDemo'));
 const TreeDemoPage          = page(() => import('./pages/TreeDemo'));
+const DropzoneDemoPage      = page(() => import('./pages/DropzoneDemo'));
 const DateSelectorDemoPage  = page(() => import('./pages/DateSelectorDemo'));
 const MarkdownDemoPage      = page(() => import('./pages/MarkdownDemo'));
 const OverviewPage          = page(() => import('./pages/Overview'));
@@ -125,6 +126,7 @@ export function App() {
         <Route path="/stepper-demo"    element={<StepperDemoPage />} />
         <Route path="/radio-demo"      element={<RadioGroupDemoPage />} />
         <Route path="/video-demo"      element={<VideoDemoPage />} />
+        <Route path="/dropzone-demo"   element={<DropzoneDemoPage />} />
         <Route path="/chat-demo"       element={<LLMChatDemoPage />} />
         <Route path="/rich-chat-demo" element={<RichChatDemoPage />} />
         <Route path="/llmchat"         element={<LLMChatPage />} />

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -60,6 +60,7 @@ const widgets: [string, string][] = [
   ['Stepper', '/stepper-demo'],
   ['Table', '/table-demo'],
   ['Tooltip', '/tooltip-demo'],
+  ['Dropzone', '/dropzone-demo'],
   ['Tree', '/tree-demo'],
   ['Markdown', '/markdown-demo'],
 ];

--- a/docs/src/pages/DropzoneDemo.tsx
+++ b/docs/src/pages/DropzoneDemo.tsx
@@ -1,0 +1,27 @@
+// src/pages/DropzoneDemo.tsx
+import { Surface, Stack, Typography, Button, Dropzone, useTheme, Icon } from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
+
+export default function DropzoneDemoPage() {
+  const { theme, toggleMode } = useTheme();
+  const navigate = useNavigate();
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack>
+        <Typography variant="h2" bold>Dropzone Showcase</Typography>
+        <Typography variant="subtitle">File upload area built on react-dropzone</Typography>
+
+        <Typography variant="h3">Example</Typography>
+        <Dropzone accept={{ 'image/*': [] }} maxFiles={3} />
+
+        <Stack direction="row" style={{ marginTop: theme.spacing(1) }}>
+          <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
+          <Button onClick={() => navigate(-1)}>← Back</Button>
+        </Stack>
+      </Stack>
+    </Surface>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -40,9 +40,10 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.0",
+    "marked": "^16.1.1",
+    "react-dropzone": "^14.2.3",
     "siphash": "^1.2.0",
-    "zustand": "^4.5.7",
-    "marked": "^16.1.1"
+    "zustand": "^4.5.7"
   },
   "peerDependencies": {
     "react": ">=18.0.0 || ^19.0.0",

--- a/src/components/widgets/Dropzone.tsx
+++ b/src/components/widgets/Dropzone.tsx
@@ -1,0 +1,108 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/widgets/Dropzone.tsx | valet
+// react-dropzone wrapper with theming and previews
+// ─────────────────────────────────────────────────────────────
+import React, { useCallback, useState } from 'react';
+import {
+  useDropzone,
+  type DropzoneOptions,
+  type FileRejection,
+  type DropEvent,
+} from 'react-dropzone';
+import Panel from '../layout/Panel';
+import Grid from '../layout/Grid';
+import Icon from '../primitives/Icon';
+import { preset } from '../../css/stylePresets';
+import type { Presettable } from '../../types';
+
+/*───────────────────────────────────────────────────────────*/
+export interface DropzoneProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onDrop'>,
+    Presettable {
+  /** Allowable file types (same as react-dropzone `accept`) */
+  accept?: DropzoneOptions['accept'];
+  /** Display previews for accepted files */
+  showPreviews?: boolean;
+  /** Called whenever the file list changes */
+  onFilesChange?: (files: File[]) => void;
+  /** Maximum file count */
+  maxFiles?: number;
+  /** Allow multiple file selection */
+  multiple?: boolean;
+  /** Callback for when files are dropped */
+  onDrop?: DropzoneOptions['onDrop'];
+}
+
+/*───────────────────────────────────────────────────────────*/
+export const Dropzone: React.FC<DropzoneProps> = ({
+  accept,
+  maxFiles,
+  multiple = true,
+  showPreviews = true,
+  onDrop: onDropCb,
+  onFilesChange,
+  preset: p,
+  className,
+  style,
+  ...rest
+}) => {
+  const [files, setFiles] = useState<File[]>([]);
+
+  const handleDrop = useCallback(
+    (accepted: File[], _rej: FileRejection[], _evt: DropEvent) => {
+      const next = multiple ? [...files, ...accepted] : accepted.slice(0, 1);
+      const limited = maxFiles ? next.slice(0, maxFiles) : next;
+      setFiles(limited);
+      onFilesChange?.(limited);
+      onDropCb?.(accepted, _rej, _evt);
+    },
+    [files, multiple, maxFiles, onFilesChange, onDropCb],
+  );
+
+  const {
+    getRootProps,
+    getInputProps,
+    isDragActive,
+  } = useDropzone({ accept, maxFiles, multiple, onDrop: handleDrop });
+  const presetCls = p ? preset(p) : '';
+
+  const previews = showPreviews && files.length > 0 && (
+    <Grid columns={4} gap={0.5} style={{ width: '100%' }}>
+      {files.map((f, i) => (
+        <img
+          key={i}
+          src={URL.createObjectURL(f)}
+          alt={f.name}
+          style={{ width: '100%', height: 'auto', borderRadius: 4 }}
+        />
+      ))}
+    </Grid>
+  );
+
+  const rootProps = getRootProps();
+
+  return (
+    <Panel
+      {...rest}
+      {...rootProps}
+      ref={rootProps.ref as any}
+      variant="alt"
+      fullWidth
+      style={{
+        textAlign: 'center',
+        cursor: 'pointer',
+        ...style,
+      }}
+      className={[presetCls, className, isDragActive ? 'drag-active' : '']
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <input {...getInputProps()} />
+      <Icon icon="mdi:cloud-upload" size="lg" />
+      <div>{isDragActive ? 'Drop files here…' : 'Drag files or click to browse'}</div>
+      {previews}
+    </Panel>
+  );
+};
+
+export default Dropzone;

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ export * from './components/widgets/Snackbar';
 export * from './components/widgets/SpeedDial';
 export * from './components/widgets/Stepper';
 export * from './components/widgets/Table';
+export * from './components/widgets/Dropzone';
 export * from './components/layout/Tabs';
 export * from './components/widgets/Tooltip';
 export * from './components/widgets/Tree';


### PR DESCRIPTION
## Summary
- add Dropzone widget built on react-dropzone
- export Dropzone in the library index
- document Dropzone in docs and navigation
- depend on react-dropzone
- note Dropzone component in CHANGELOG

## Testing
- `npm run build`
- `npm run build` in docs

------
https://chatgpt.com/codex/tasks/task_e_687e3cbe1c188320bc73f4f24ee0d975