### PR TITLE
Add Dropzone file list option

### DIFF
--- a/docs/src/pages/DropzoneDemo.tsx
+++ b/docs/src/pages/DropzoneDemo.tsx
@@ -49,6 +49,12 @@ export default function DropzoneDemoPage() {
       description: 'Show preview thumbnails',
     },
     {
+      prop: <code>showFileList</code>,
+      type: <code>boolean</code>,
+      default: <code>false</code>,
+      description: 'Show icons and names',
+    },
+    {
       prop: <code>onFilesChange</code>,
       type: <code>(files: File[]) =&gt; void</code>,
       default: <code>-</code>,
@@ -110,13 +116,16 @@ export default function DropzoneDemoPage() {
               <Typography variant="h3">3. Limit to two files</Typography>
               <Dropzone maxFiles={2} />
 
-              <Typography variant="h3">4. No previews</Typography>
+              <Typography variant="h3">4. File list</Typography>
+              <Dropzone showPreviews={false} showFileList />
+
+              <Typography variant="h3">5. No previews</Typography>
               <Dropzone showPreviews={false} />
 
-              <Typography variant="h3">5. Full width</Typography>
+              <Typography variant="h3">6. Full width</Typography>
               <Dropzone fullWidth />
 
-              <Typography variant="h3">6. Theme toggle</Typography>
+              <Typography variant="h3">7. Theme toggle</Typography>
               <Button variant="outlined" onClick={toggleMode}>
                 Toggle light / dark
               </Button>

--- a/src/components/widgets/Dropzone.tsx
+++ b/src/components/widgets/Dropzone.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react-dropzone';
 import Panel from '../layout/Panel';
 import Grid from '../layout/Grid';
+import Stack from '../layout/Stack';
 import Icon from '../primitives/Icon';
 import { useTheme } from '../../system/themeStore';
 import { preset } from '../../css/stylePresets';
@@ -24,6 +25,8 @@ export interface DropzoneProps
   accept?: DropzoneOptions['accept'];
   /** Display previews for accepted files */
   showPreviews?: boolean;
+  /** Show file icons and names rather than thumbnails */
+  showFileList?: boolean;
   /** Called whenever the file list changes */
   onFilesChange?: (files: File[]) => void;
   /** Maximum file count */
@@ -42,6 +45,7 @@ export const Dropzone: React.FC<DropzoneProps> = ({
   maxFiles,
   multiple = true,
   showPreviews = true,
+  showFileList = false,
   onDrop: onDropCb,
   onFilesChange,
   preset: p,
@@ -84,6 +88,50 @@ export const Dropzone: React.FC<DropzoneProps> = ({
     </Grid>
   );
 
+  const iconMap: Record<string, string> = {
+    jpg: 'carbon:image',
+    jpeg: 'carbon:image',
+    png: 'carbon:image',
+    gif: 'carbon:image',
+    svg: 'carbon:image',
+    bmp: 'carbon:image',
+    webp: 'carbon:image',
+    mp3: 'carbon:music',
+    wav: 'carbon:music',
+    ogg: 'carbon:music',
+    flac: 'carbon:music',
+    mp4: 'carbon:video',
+    webm: 'carbon:video',
+    mov: 'carbon:video',
+    mkv: 'carbon:video',
+    pdf: 'carbon:pdf',
+    doc: 'carbon:document',
+    docx: 'carbon:document',
+    txt: 'carbon:document',
+    csv: 'carbon:csv',
+    xls: 'carbon:csv',
+    xlsx: 'carbon:csv',
+    zip: 'carbon:zip',
+    rar: 'carbon:zip',
+    gz: 'carbon:zip',
+  };
+
+  const fileIcon = (name: string) => {
+    const ext = name.split('.').pop()?.toLowerCase() ?? '';
+    return iconMap[ext] ?? 'carbon:document';
+  };
+
+  const fileList = showFileList && !showPreviews && files.length > 0 && (
+    <Stack spacing={0.5} style={{ width: '100%' }}>
+      {files.map((f, i) => (
+        <Stack key={i} direction="row" spacing={0.5} style={{ alignItems: 'center' }}>
+          <Icon icon={fileIcon(f.name)} />
+          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{f.name}</span>
+        </Stack>
+      ))}
+    </Stack>
+  );
+
   const rootProps = getRootProps();
 
   return (
@@ -106,7 +154,7 @@ export const Dropzone: React.FC<DropzoneProps> = ({
       <input {...getInputProps()} />
       <Icon icon="mdi:cloud-upload" size="lg" />
       <div>{isDragActive ? 'Drop files here…' : 'Drag files or click to browse'}</div>
-      {previews}
+      {previews || fileList}
     </Panel>
   );
 };


### PR DESCRIPTION
## Summary
- add `showFileList` prop to Dropzone
- display file icons and names using Carbon icons
- demo Dropzone file list usage in docs

## Testing
- `npm run build`
- `cd docs && npm link @archway/valet && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e52f102408320ac24f7a1a71910f5