### PR TITLE
Fix Dropzone ref and add Pixi demo

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -10,11 +10,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@archway/valet": "0.18.2",
+    "@archway/valet": "file:..",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-dropzone": "^14.2.3",
-    "react-router-dom": "^7.6.0"
+    "react-router-dom": "^7.6.0",
+    "pixi.js": "^7.3.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -58,6 +58,7 @@ const TreeDemoPage          = page(() => import('./pages/TreeDemo'));
 const DropzoneDemoPage      = page(() => import('./pages/DropzoneDemo'));
 const DateSelectorDemoPage  = page(() => import('./pages/DateSelectorDemo'));
 const MarkdownDemoPage      = page(() => import('./pages/MarkdownDemo'));
+const FabricatorDemoPage    = page(() => import('./pages/FabricatorDemo'));
 const OverviewPage          = page(() => import('./pages/Overview'));
 const InstallationPage      = page(() => import('./pages/Installation'));
 const UsagePage             = page(() => import('./pages/Usage'));
@@ -127,6 +128,7 @@ export function App() {
         <Route path="/radio-demo"      element={<RadioGroupDemoPage />} />
         <Route path="/video-demo"      element={<VideoDemoPage />} />
         <Route path="/dropzone-demo"   element={<DropzoneDemoPage />} />
+        <Route path="/fabricator-demo" element={<FabricatorDemoPage />} />
         <Route path="/chat-demo"       element={<LLMChatDemoPage />} />
         <Route path="/rich-chat-demo" element={<RichChatDemoPage />} />
         <Route path="/llmchat"         element={<LLMChatPage />} />

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -70,6 +70,7 @@ const examples: [string, string][] = [
   ['Presets', '/presets'],
   ['LLMChat', '/chat-demo'],
   ['RichChat', '/rich-chat-demo'],
+  ['Fabricator', '/fabricator-demo'],
 ];
 
 const DEFAULT_EXPANDED = [

--- a/docs/src/pages/FabricatorDemo.tsx
+++ b/docs/src/pages/FabricatorDemo.tsx
@@ -1,0 +1,92 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/FabricatorDemo.tsx | valet
+// Pixi.js dropzone example
+// ─────────────────────────────────────────────────────────────
+import * as React from 'react';
+import { Application, Sprite, Graphics } from 'pixi.js';
+import { Surface, Stack, Typography, Button, Dropzone, useTheme } from '@archway/valet';
+import NavDrawer from '../components/NavDrawer';
+import { useNavigate } from 'react-router-dom';
+
+export default function FabricatorDemo() {
+  const { theme } = useTheme();
+  const navigate = useNavigate();
+  const pixiRef = React.useRef<HTMLDivElement>(null);
+  const appRef = React.useRef<Application | null>(null);
+  const [file, setFile] = React.useState<File | null>(null);
+
+  const handleFilesChange = React.useCallback((files: File[]) => {
+    setFile(files[0] ?? null);
+  }, []);
+
+  React.useEffect(() => {
+    if (!pixiRef.current || !file) return;
+
+    const url = URL.createObjectURL(file);
+    const app = new Application({ backgroundAlpha: 0 });
+    appRef.current = app;
+    pixiRef.current.innerHTML = '';
+    pixiRef.current.appendChild(app.view as HTMLCanvasElement);
+
+    const sprite = Sprite.from(url);
+    sprite.anchor.set(0.5);
+    sprite.texture.baseTexture.once('loaded', () => {
+      app.renderer.resize(sprite.width, sprite.height);
+      sprite.position.set(sprite.width / 2, sprite.height / 2);
+      const size = Math.min(sprite.width, sprite.height) * 0.2;
+      const rect = new Graphics();
+      rect.beginFill(0x00ff00);
+      rect.drawRect((sprite.width - size) / 2, (sprite.height - size) / 2, size, size);
+      rect.endFill();
+      app.stage.addChild(sprite);
+      app.stage.addChild(rect);
+    });
+
+    return () => {
+      app.destroy(true, { children: true });
+      URL.revokeObjectURL(url);
+    };
+  }, [file]);
+
+  const handleExport = React.useCallback(() => {
+    if (!appRef.current) return;
+    const canvas = (appRef.current.renderer.plugins as any).extract.canvas(
+      appRef.current.stage,
+    );
+    const link = document.createElement('a');
+    link.href = canvas.toDataURL('image/png');
+    link.download = 'fabricator.png';
+    link.click();
+  }, []);
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack spacing={1}>
+        <Typography variant="h2" bold>
+          Fabricator Demo
+        </Typography>
+        <Typography>
+          Upload an image and export it with a green square.
+        </Typography>
+        <Dropzone
+          accept={{ 'image/*': [] }}
+          multiple={false}
+          onFilesChange={handleFilesChange}
+          showPreviews
+        />
+        <div ref={pixiRef} />
+        <Stack direction="row">
+          {file && (
+            <Button onClick={handleExport} color="primary" variant="contained">
+              Export Image
+            </Button>
+          )}
+          <Button onClick={() => navigate(-1)} style={{ marginLeft: theme.spacing(1) }}>
+            ← Back
+          </Button>
+        </Stack>
+      </Stack>
+    </Surface>
+  );
+}

--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -89,18 +89,22 @@ const Base = styled('div')<{
     $center !== undefined && `--valet-centered: ${$center ? '1' : '0'};`}
 `;
 
-export const Panel: React.FC<PanelProps> = ({
-  variant = 'main',
-  fullWidth = false,
-  centered,
-  preset: p,
-  className,
-  style,
-  background,
-  compact,
-  children,
-  ...rest
-}) => {
+export const Panel = React.forwardRef<HTMLDivElement, PanelProps>(
+  function Panel(
+    {
+      variant = 'main',
+      fullWidth = false,
+      centered,
+      preset: p,
+      className,
+      style,
+      background,
+      compact,
+      children,
+      ...rest
+    },
+    ref,
+  ) {
   const { theme } = useTheme();
   const hasBgProp = typeof background === 'string';
   const hasPresetBg = p ? presetHas(p, 'background') : false;
@@ -132,6 +136,7 @@ export const Panel: React.FC<PanelProps> = ({
   return (
     <Base
       {...rest}
+      ref={ref}
       $variant={variant}
       $full={fullWidth}
       $center={centered}
@@ -146,6 +151,6 @@ export const Panel: React.FC<PanelProps> = ({
       {children}
     </Base>
   );
-};
+});
 
 export default Panel;

--- a/src/components/widgets/Dropzone.tsx
+++ b/src/components/widgets/Dropzone.tsx
@@ -138,7 +138,6 @@ export const Dropzone: React.FC<DropzoneProps> = ({
     <Panel
       {...rest}
       {...rootProps}
-      ref={rootProps.ref as any}
       variant="alt"
       fullWidth={fullWidth}
       style={{


### PR DESCRIPTION
## Summary
- forward ref from `Panel` to its root element
- update `Dropzone` to rely on Panel's forwarded ref
- add Pixi.js demo page with Dropzone usage
- expose new demo route and link from docs navigation
- depend on local valet build and pixi.js in docs

## Testing
- `npm run build`
- `npm --prefix docs run build`


------
https://chatgpt.com/codex/tasks/task_e_687f9de8a21c8320857adc9c0a460072