### PR TITLE
Add Fabricator demo and fix Dropzone ref

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-dropzone": "^14.2.3",
-    "react-router-dom": "^7.6.0"
+    "react-router-dom": "^7.6.0",
+    "pixi.js": "^8.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -63,6 +63,7 @@ const InstallationPage      = page(() => import('./pages/Installation'));
 const UsagePage             = page(() => import('./pages/Usage'));
 const SurfaceExplainerPage  = page(() => import('./pages/SurfaceExplainer'));
 const PropPatternsPage      = page(() => import('./pages/PropPatterns'));
+const FabricatorDemoPage    = page(() => import('./pages/FabricatorDemo'));
 
 /*───────────────────────────────────────────────────────────*/
 export function App() {
@@ -127,6 +128,7 @@ export function App() {
         <Route path="/radio-demo"      element={<RadioGroupDemoPage />} />
         <Route path="/video-demo"      element={<VideoDemoPage />} />
         <Route path="/dropzone-demo"   element={<DropzoneDemoPage />} />
+        <Route path="/fabricator-demo" element={<FabricatorDemoPage />} />
         <Route path="/chat-demo"       element={<LLMChatDemoPage />} />
         <Route path="/rich-chat-demo" element={<RichChatDemoPage />} />
         <Route path="/llmchat"         element={<LLMChatPage />} />

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -68,6 +68,7 @@ const widgets: [string, string][] = [
 const examples: [string, string][] = [
   ['Form', '/form'],
   ['Presets', '/presets'],
+  ['Fabricator', '/fabricator-demo'],
   ['LLMChat', '/chat-demo'],
   ['RichChat', '/rich-chat-demo'],
 ];

--- a/docs/src/pages/FabricatorDemo.tsx
+++ b/docs/src/pages/FabricatorDemo.tsx
@@ -1,0 +1,83 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/FabricatorDemo.tsx | valet
+// Interactive image export with PixiJS
+// ─────────────────────────────────────────────────────────────
+import * as React from 'react'
+import { Application, Sprite, Graphics } from 'pixi.js'
+import { Surface, Stack, Typography, Button, Dropzone } from '@archway/valet'
+import { useNavigate } from 'react-router-dom'
+import NavDrawer from '../components/NavDrawer'
+
+export default function FabricatorDemoPage() {
+  const navigate = useNavigate()
+  const pixiRef = React.useRef<HTMLDivElement>(null)
+  const appRef = React.useRef<Application | null>(null)
+  const [file, setFile] = React.useState<File | null>(null)
+
+  const handleFilesChange = React.useCallback((files: File[]) => {
+    setFile(files[0] ?? null)
+  }, [])
+
+  React.useEffect(() => {
+    if (!pixiRef.current || !file) return
+
+    const url = URL.createObjectURL(file)
+    const app = new Application({ backgroundAlpha: 0 })
+    appRef.current = app
+    pixiRef.current.innerHTML = ''
+    pixiRef.current.appendChild(app.view as HTMLCanvasElement)
+
+    const sprite = Sprite.from(url)
+    sprite.anchor.set(0.5)
+    sprite.texture.baseTexture.once('loaded' as any, () => {
+      app.renderer.resize(sprite.width, sprite.height)
+      sprite.position.set(sprite.width / 2, sprite.height / 2)
+      const size = Math.min(sprite.width, sprite.height) * 0.2
+      const rect = new Graphics()
+      rect.beginFill(0x00ff00)
+      rect.drawRect((sprite.width - size) / 2, (sprite.height - size) / 2, size, size)
+      rect.endFill()
+      app.stage.addChild(sprite)
+      app.stage.addChild(rect)
+    })
+
+    return () => {
+      app.destroy(true, { children: true })
+      URL.revokeObjectURL(url)
+    }
+  }, [file])
+
+  const handleExport = React.useCallback(() => {
+    if (!appRef.current) return
+    const canvas = (appRef.current.renderer as any).plugins.extract.canvas(appRef.current.stage)
+    const link = document.createElement('a')
+    link.href = canvas.toDataURL('image/png')
+    link.download = 'fabricator.png'
+    link.click()
+  }, [])
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack>
+        <Typography variant="h2" bold>Fabricator</Typography>
+        <Typography variant="subtitle">Upload an image and export it with a green square.</Typography>
+        <Dropzone
+          accept={{ 'image/*': [] }}
+          multiple={false}
+          onFilesChange={handleFilesChange}
+          showPreviews
+        />
+        <div ref={pixiRef} />
+        {file && (
+          <Button onClick={handleExport} variant="contained">
+            Export Image
+          </Button>
+        )}
+        <Button size="lg" onClick={() => navigate(-1)} style={{ marginTop: '1rem' }}>
+          ← Back
+        </Button>
+      </Stack>
+    </Surface>
+  )
+}

--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -89,18 +89,21 @@ const Base = styled('div')<{
     $center !== undefined && `--valet-centered: ${$center ? '1' : '0'};`}
 `;
 
-export const Panel: React.FC<PanelProps> = ({
-  variant = 'main',
-  fullWidth = false,
-  centered,
-  preset: p,
-  className,
-  style,
-  background,
-  compact,
-  children,
-  ...rest
-}) => {
+export const Panel = React.forwardRef<HTMLDivElement, PanelProps>(function Panel(
+  {
+    variant = 'main',
+    fullWidth = false,
+    centered,
+    preset: p,
+    className,
+    style,
+    background,
+    compact,
+    children,
+    ...rest
+  },
+  ref,
+) {
   const { theme } = useTheme();
   const hasBgProp = typeof background === 'string';
   const hasPresetBg = p ? presetHas(p, 'background') : false;
@@ -132,6 +135,7 @@ export const Panel: React.FC<PanelProps> = ({
   return (
     <Base
       {...rest}
+      ref={ref}
       $variant={variant}
       $full={fullWidth}
       $center={centered}
@@ -146,6 +150,6 @@ export const Panel: React.FC<PanelProps> = ({
       {children}
     </Base>
   );
-};
+});
 
 export default Panel;

--- a/src/components/widgets/Dropzone.tsx
+++ b/src/components/widgets/Dropzone.tsx
@@ -138,7 +138,6 @@ export const Dropzone: React.FC<DropzoneProps> = ({
     <Panel
       {...rest}
       {...rootProps}
-      ref={rootProps.ref as any}
       variant="alt"
       fullWidth={fullWidth}
       style={{


### PR DESCRIPTION
## Summary
- forward ref through `Panel` so root props work
- clean up Dropzone root ref usage
- document pixi example page
- expose new page in NavDrawer and routing
- install pixi.js for docs only

## Testing
- `npm run build`
- `cd docs && npm link @archway/valet && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687f9de8a21c8320857adc9c0a460072