### PR TITLE
Add Pixi demo and fix Dropzone refs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -10,11 +10,12 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@archway/valet": "0.18.2",
+    "@archway/valet": "file:..",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-dropzone": "^14.2.3",
-    "react-router-dom": "^7.6.0"
+    "react-router-dom": "^7.6.0",
+    "pixi.js": "^8.11.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -56,6 +56,7 @@ const VideoDemoPage         = page(() => import('./pages/VideoDemo'));
 const SnackbarDemoPage      = page(() => import('./pages/SnackbarDemo'));
 const TreeDemoPage          = page(() => import('./pages/TreeDemo'));
 const DropzoneDemoPage      = page(() => import('./pages/DropzoneDemo'));
+const FabricatorDemoPage    = page(() => import('./pages/FabricatorDemo'));
 const DateSelectorDemoPage  = page(() => import('./pages/DateSelectorDemo'));
 const MarkdownDemoPage      = page(() => import('./pages/MarkdownDemo'));
 const OverviewPage          = page(() => import('./pages/Overview'));
@@ -127,6 +128,7 @@ export function App() {
         <Route path="/radio-demo"      element={<RadioGroupDemoPage />} />
         <Route path="/video-demo"      element={<VideoDemoPage />} />
         <Route path="/dropzone-demo"   element={<DropzoneDemoPage />} />
+        <Route path="/fabricator-demo" element={<FabricatorDemoPage />} />
         <Route path="/chat-demo"       element={<LLMChatDemoPage />} />
         <Route path="/rich-chat-demo" element={<RichChatDemoPage />} />
         <Route path="/llmchat"         element={<LLMChatPage />} />

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -70,6 +70,7 @@ const examples: [string, string][] = [
   ['Presets', '/presets'],
   ['LLMChat', '/chat-demo'],
   ['RichChat', '/rich-chat-demo'],
+  ['Fabricator', '/fabricator-demo'],
 ];
 
 const DEFAULT_EXPANDED = [

--- a/docs/src/pages/FabricatorDemo.tsx
+++ b/docs/src/pages/FabricatorDemo.tsx
@@ -1,0 +1,88 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/FabricatorDemo.tsx | valet docs
+// Example integrating Dropzone with PixiJS
+// ─────────────────────────────────────────────────────────────
+import * as React from 'react';
+import { Application, Sprite, Graphics } from 'pixi.js';
+import { Surface, Stack, Typography, Button, Dropzone, useTheme } from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
+
+export default function FabricatorDemo() {
+  const pixiRef = React.useRef<HTMLDivElement>(null);
+  const appRef = React.useRef<Application | null>(null);
+  const [file, setFile] = React.useState<File | null>(null);
+  const navigate = useNavigate();
+  const { theme } = useTheme();
+
+  const handleFilesChange = React.useCallback((files: File[]) => {
+    setFile(files[0] ?? null);
+  }, []);
+
+  React.useEffect(() => {
+    if (!pixiRef.current || !file) return;
+
+    const url = URL.createObjectURL(file);
+    const app = new Application({ backgroundAlpha: 0 });
+    appRef.current = app;
+    pixiRef.current.innerHTML = '';
+    pixiRef.current.appendChild(app.view as HTMLCanvasElement);
+
+    const sprite = Sprite.from(url);
+    sprite.anchor.set(0.5);
+    (sprite.texture.baseTexture as any).once('loaded', () => {
+      app.renderer.resize(sprite.width, sprite.height);
+      sprite.position.set(sprite.width / 2, sprite.height / 2);
+      const size = Math.min(sprite.width, sprite.height) * 0.2;
+      const rect = new Graphics();
+      rect.beginFill(0x00ff00);
+      rect.drawRect((sprite.width - size) / 2, (sprite.height - size) / 2, size, size);
+      rect.endFill();
+      app.stage.addChild(sprite);
+      app.stage.addChild(rect);
+    });
+
+    return () => {
+      app.destroy(true, { children: true });
+      URL.revokeObjectURL(url);
+    };
+  }, [file]);
+
+  const handleExport = React.useCallback(() => {
+    if (!appRef.current) return;
+    const canvas = (appRef.current.renderer as any).plugins.extract.canvas(appRef.current.stage);
+    const link = document.createElement('a');
+    link.href = canvas.toDataURL('image/png');
+    link.download = 'fabricator.png';
+    link.click();
+  }, []);
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack spacing={1}>
+        <Typography variant="h2" bold>
+          Pixi Fabricator
+        </Typography>
+        <Typography variant="subtitle">
+          Upload an image and export it with a green square.
+        </Typography>
+        <Dropzone
+          accept={{ 'image/*': [] }}
+          multiple={false}
+          onFilesChange={handleFilesChange}
+          showPreviews
+        />
+        <div ref={pixiRef} />
+        {file && (
+          <Button onClick={handleExport} variant="contained" color="primary">
+            Export Image
+          </Button>
+        )}
+        <Button size="lg" onClick={() => navigate(-1)} style={{ marginTop: theme.spacing(1) }}>
+          ← Back
+        </Button>
+      </Stack>
+    </Surface>
+  );
+}

--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -2,7 +2,7 @@
 // src/components/layout/Panel.tsx  | valet
 // overhaul: internal scrollbars & boundary guards – 2025‑07‑17
 // ─────────────────────────────────────────────────────────────
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { styled } from '../../css/createStyled';
 import { useTheme } from '../../system/themeStore';
 import { preset, presetHas } from '../../css/stylePresets';
@@ -89,18 +89,22 @@ const Base = styled('div')<{
     $center !== undefined && `--valet-centered: ${$center ? '1' : '0'};`}
 `;
 
-export const Panel: React.FC<PanelProps> = ({
-  variant = 'main',
-  fullWidth = false,
-  centered,
-  preset: p,
-  className,
-  style,
-  background,
-  compact,
-  children,
-  ...rest
-}) => {
+export const Panel = forwardRef<HTMLDivElement, PanelProps>(
+  (
+    {
+      variant = 'main',
+      fullWidth = false,
+      centered,
+      preset: p,
+      className,
+      style,
+      background,
+      compact,
+      children,
+      ...rest
+    },
+    ref,
+  ) => {
   const { theme } = useTheme();
   const hasBgProp = typeof background === 'string';
   const hasPresetBg = p ? presetHas(p, 'background') : false;
@@ -132,6 +136,7 @@ export const Panel: React.FC<PanelProps> = ({
   return (
     <Base
       {...rest}
+      ref={ref}
       $variant={variant}
       $full={fullWidth}
       $center={centered}
@@ -146,6 +151,6 @@ export const Panel: React.FC<PanelProps> = ({
       {children}
     </Base>
   );
-};
+});
 
 export default Panel;

--- a/src/components/widgets/Dropzone.tsx
+++ b/src/components/widgets/Dropzone.tsx
@@ -2,7 +2,7 @@
 // src/components/widgets/Dropzone.tsx | valet
 // react-dropzone wrapper with theming and previews
 // ─────────────────────────────────────────────────────────────
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useState, forwardRef } from 'react';
 import {
   useDropzone,
   type DropzoneOptions,
@@ -40,20 +40,24 @@ export interface DropzoneProps
 }
 
 /*───────────────────────────────────────────────────────────*/
-export const Dropzone: React.FC<DropzoneProps> = ({
-  accept,
-  maxFiles,
-  multiple = true,
-  showPreviews = true,
-  showFileList = false,
-  onDrop: onDropCb,
-  onFilesChange,
-  preset: p,
-  fullWidth = false,
-  className,
-  style,
-  ...rest
-}) => {
+export const Dropzone = forwardRef<HTMLDivElement, DropzoneProps>(
+  (
+    {
+      accept,
+      maxFiles,
+      multiple = true,
+      showPreviews = true,
+      showFileList = false,
+      onDrop: onDropCb,
+      onFilesChange,
+      preset: p,
+      fullWidth = false,
+      className,
+      style,
+      ...rest
+    },
+    ref,
+  ) => {
   const [files, setFiles] = useState<File[]>([]);
   const { theme } = useTheme();
 
@@ -138,7 +142,11 @@ export const Dropzone: React.FC<DropzoneProps> = ({
     <Panel
       {...rest}
       {...rootProps}
-      ref={rootProps.ref as any}
+      ref={(el) => {
+        (rootProps.ref as (node: HTMLDivElement | null) => void)(el);
+        if (typeof ref === 'function') ref(el);
+        else if (ref) (ref as React.MutableRefObject<HTMLDivElement | null>).current = el;
+      }}
       variant="alt"
       fullWidth={fullWidth}
       style={{
@@ -157,6 +165,6 @@ export const Dropzone: React.FC<DropzoneProps> = ({
       {previews || fileList}
     </Panel>
   );
-};
+});
 
 export default Dropzone;


### PR DESCRIPTION
## Summary
- forward `ref` through `Panel`
- refactor `Dropzone` to use `forwardRef`
- add Fabricator demo page using PixiJS
- wire new page into docs navigation
- depend on local valet build for docs and install `pixi.js`

## Testing
- `npm run build`
- `(cd docs && npm run build)`

------
https://chatgpt.com/codex/tasks/task_e_687f9de8a21c8320857adc9c0a460072