### PR TITLE
Add Pixi dropzone demo

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@archway/valet": "0.18.3",
+    "@pixi/react": "^8.0.2",
+    "pixi.js": "^8.11.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-dropzone": "^14.2.3",

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -56,6 +56,7 @@ const VideoDemoPage         = page(() => import('./pages/VideoDemo'));
 const SnackbarDemoPage      = page(() => import('./pages/SnackbarDemo'));
 const TreeDemoPage          = page(() => import('./pages/TreeDemo'));
 const DropzoneDemoPage      = page(() => import('./pages/DropzoneDemo'));
+const PixiDropzoneDemoPage  = page(() => import('./pages/PixiDropzoneDemo'));
 const DateSelectorDemoPage  = page(() => import('./pages/DateSelectorDemo'));
 const MarkdownDemoPage      = page(() => import('./pages/MarkdownDemo'));
 const OverviewPage          = page(() => import('./pages/Overview'));
@@ -127,6 +128,7 @@ export function App() {
         <Route path="/radio-demo"      element={<RadioGroupDemoPage />} />
         <Route path="/video-demo"      element={<VideoDemoPage />} />
         <Route path="/dropzone-demo"   element={<DropzoneDemoPage />} />
+        <Route path="/pixi-dropzone"   element={<PixiDropzoneDemoPage />} />
         <Route path="/chat-demo"       element={<LLMChatDemoPage />} />
         <Route path="/rich-chat-demo" element={<RichChatDemoPage />} />
         <Route path="/llmchat"         element={<LLMChatPage />} />

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -70,6 +70,7 @@ const examples: [string, string][] = [
   ['Presets', '/presets'],
   ['LLMChat', '/chat-demo'],
   ['RichChat', '/rich-chat-demo'],
+  ['Pixi Dropzone', '/pixi-dropzone'],
 ];
 
 const DEFAULT_EXPANDED = [

--- a/docs/src/pages/PixiDropzoneDemo.tsx
+++ b/docs/src/pages/PixiDropzoneDemo.tsx
@@ -1,0 +1,101 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/PixiDropzoneDemo.tsx | valet
+// Dropzone to PixiJS example with download
+// ─────────────────────────────────────────────────────────────
+import { useCallback, useRef, useState } from 'react';
+import { Surface, Stack, Typography, Dropzone, Button, useTheme } from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
+import { Application } from '@pixi/react';
+import { Texture } from 'pixi.js';
+import type { Graphics } from 'pixi.js';
+
+export default function PixiDropzoneDemo() {
+  const { theme } = useTheme();
+  const navigate = useNavigate();
+  const appRef = useRef<import('@pixi/react').ApplicationRef | null>(null);
+  const [imgSrc, setImgSrc] = useState<string | null>(null);
+  const [size, setSize] = useState<{ w: number; h: number } | null>(null);
+  const [texture, setTexture] = useState<Texture | null>(null);
+
+  const handleFiles = useCallback((files: File[]) => {
+    const file = files[0];
+    if (!file) return;
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = () => {
+      setSize({ w: img.width, h: img.height });
+      setImgSrc(url);
+      setTexture(Texture.from(url));
+    };
+    img.src = url;
+  }, []);
+
+  const drawSquare = useCallback(
+    (g: Graphics) => {
+      if (!size) return;
+      const s = 80;
+      g.clear();
+      g.beginFill(0x00ff00);
+      g.drawRect((size.w - s) / 2, (size.h - s) / 2, s, s);
+      g.endFill();
+    },
+    [size],
+  );
+
+  const handleDownload = () => {
+    const app = appRef.current?.getApplication();
+    if (app) {
+      const canvas = app.renderer.extract.canvas(app.stage) as HTMLCanvasElement;
+      const link = document.createElement('a');
+      link.href = canvas.toDataURL('image/png');
+      link.download = 'pixi-image.png';
+      link.click();
+    }
+  };
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack spacing={1} style={{ padding: theme.spacing(1) }}>
+        <Typography variant="h2" bold>
+          Pixi Dropzone Demo
+        </Typography>
+        <Typography variant="subtitle">
+          Upload an image, add a green square, then download it
+        </Typography>
+        <Dropzone
+          accept={{ 'image/*': [] }}
+          maxFiles={1}
+          multiple={false}
+          onFilesChange={handleFiles}
+        />
+        {imgSrc && size && (
+          <Application
+            width={size.w}
+            height={size.h}
+            backgroundAlpha={0}
+            ref={appRef}
+          >
+            {texture && (
+              <pixiSprite
+                texture={texture}
+                x={0}
+                y={0}
+                width={size.w}
+                height={size.h}
+              />
+            )}
+            <pixiGraphics draw={drawSquare} />
+          </Application>
+        )}
+        {imgSrc && (
+          <Button onClick={handleDownload}>Download image</Button>
+        )}
+        <Button onClick={() => navigate(-1)} style={{ marginTop: theme.spacing(2) }}>
+          ← Back
+        </Button>
+      </Stack>
+    </Surface>
+  );
+}


### PR DESCRIPTION
## Summary
- add `@pixi/react` and `pixi.js` to docs
- create PixiDropzoneDemo example
- link new demo in App routes and nav

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688062bbfbec832087f3ff02f3868d05