### PR TITLE
Add PixiJS Dropzone example

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@archway/valet": "0.18.3",
+    "@pixi/react": "^8.0.2",
+    "pixi.js": "^8.11.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-dropzone": "^14.2.3",

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -56,6 +56,7 @@ const VideoDemoPage         = page(() => import('./pages/VideoDemo'));
 const SnackbarDemoPage      = page(() => import('./pages/SnackbarDemo'));
 const TreeDemoPage          = page(() => import('./pages/TreeDemo'));
 const DropzoneDemoPage      = page(() => import('./pages/DropzoneDemo'));
+const PixiDropzoneDemoPage  = page(() => import('./pages/PixiDropzoneDemo'));
 const DateSelectorDemoPage  = page(() => import('./pages/DateSelectorDemo'));
 const MarkdownDemoPage      = page(() => import('./pages/MarkdownDemo'));
 const OverviewPage          = page(() => import('./pages/Overview'));
@@ -127,6 +128,7 @@ export function App() {
         <Route path="/radio-demo"      element={<RadioGroupDemoPage />} />
         <Route path="/video-demo"      element={<VideoDemoPage />} />
         <Route path="/dropzone-demo"   element={<DropzoneDemoPage />} />
+        <Route path="/pixi-dropzone"   element={<PixiDropzoneDemoPage />} />
         <Route path="/chat-demo"       element={<LLMChatDemoPage />} />
         <Route path="/rich-chat-demo" element={<RichChatDemoPage />} />
         <Route path="/llmchat"         element={<LLMChatPage />} />

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -70,6 +70,7 @@ const examples: [string, string][] = [
   ['Presets', '/presets'],
   ['LLMChat', '/chat-demo'],
   ['RichChat', '/rich-chat-demo'],
+  ['Pixi Dropzone', '/pixi-dropzone'],
 ];
 
 const DEFAULT_EXPANDED = [

--- a/docs/src/pages/PixiDropzoneDemo.tsx
+++ b/docs/src/pages/PixiDropzoneDemo.tsx
@@ -1,0 +1,94 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/PixiDropzoneDemo.tsx | valet
+// Demo of pixi.js with Dropzone
+// ─────────────────────────────────────────────────────────────
+import { useState, useRef, useEffect } from 'react';
+import {
+  Surface,
+  Stack,
+  Typography,
+  Dropzone,
+  Button,
+} from '@archway/valet';
+import { Application, extend } from '@pixi/react';
+import type { ApplicationRef } from '@pixi/react';
+import { Sprite, Graphics, Texture } from 'pixi.js';
+extend({ Sprite, Graphics });
+import NavDrawer from '../components/NavDrawer';
+
+export default function PixiDropzoneDemo() {
+  const [imageUrl, setImageUrl] = useState<string | null>(null);
+  const [size, setSize] = useState<{ w: number; h: number } | null>(null);
+  const appRef = useRef<ApplicationRef>(null);
+
+  const handleFiles = (files: File[]) => {
+    const file = files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const url = e.target?.result as string;
+      setImageUrl(url);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  useEffect(() => {
+    if (!imageUrl) return;
+    const img = new Image();
+    img.onload = () => setSize({ w: img.width, h: img.height });
+    img.src = imageUrl;
+  }, [imageUrl]);
+
+  const download = () => {
+    const canvas = appRef.current?.getCanvas();
+    if (!canvas) return;
+    const link = document.createElement('a');
+    link.download = 'pixi-image.png';
+    link.href = canvas.toDataURL('image/png');
+    link.click();
+  };
+
+  const drawSquare = (g: Graphics) => {
+    if (!size) return;
+    const sqSize = Math.min(size.w, size.h) / 4;
+    g.clear();
+    g.beginFill(0x00ff00);
+    g.drawRect((size.w - sqSize) / 2, (size.h - sqSize) / 2, sqSize, sqSize);
+    g.endFill();
+  };
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack>
+        <Typography variant="h2" bold>
+          PixiJS Dropzone Example
+        </Typography>
+        <Typography variant="subtitle">
+          Upload an image, add a green square, then download
+        </Typography>
+        <Dropzone
+          accept={{ 'image/*': [] }}
+          maxFiles={1}
+          onFilesChange={handleFiles}
+        />
+        {imageUrl && size && (
+          <>
+            <Application
+              ref={appRef}
+              width={size.w}
+              height={size.h}
+              background={0xffffff}
+            >
+              <pixiSprite texture={Texture.from(imageUrl)} x={0} y={0} width={size.w} height={size.h} />
+              <pixiGraphics draw={drawSquare} />
+            </Application>
+            <Button onClick={download} style={{ marginTop: '1rem' }}>
+              Download image
+            </Button>
+          </>
+        )}
+      </Stack>
+    </Surface>
+  );
+}


### PR DESCRIPTION
## Summary
- install pixi.js and @pixi/react to the docs
- add a PixiJS Dropzone demo page
- wire up routing and navigation

## Testing
- `npm run build` *(fails: none)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688062bbfbec832087f3ff02f3868d05