### PR TITLE
Add Pixi dropzone demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 - Added React 19 compatibility
+- Added Pixi dropzone example to docs
 
 ## [0.18.3]
 - `Dropzone` component for simple drag-and-drop uploads

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,9 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-dropzone": "^14.2.3",
-    "react-router-dom": "^7.6.0"
+    "react-router-dom": "^7.6.0",
+    "pixi.js": "^8.2.6",
+    "@pixi/react": "^8.0.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -58,6 +58,7 @@ const TreeDemoPage          = page(() => import('./pages/TreeDemo'));
 const DropzoneDemoPage      = page(() => import('./pages/DropzoneDemo'));
 const DateSelectorDemoPage  = page(() => import('./pages/DateSelectorDemo'));
 const MarkdownDemoPage      = page(() => import('./pages/MarkdownDemo'));
+const PixiDropzoneDemoPage = page(() => import('./pages/PixiDropzoneDemo'));
 const OverviewPage          = page(() => import('./pages/Overview'));
 const InstallationPage      = page(() => import('./pages/Installation'));
 const UsagePage             = page(() => import('./pages/Usage'));
@@ -127,6 +128,7 @@ export function App() {
         <Route path="/radio-demo"      element={<RadioGroupDemoPage />} />
         <Route path="/video-demo"      element={<VideoDemoPage />} />
         <Route path="/dropzone-demo"   element={<DropzoneDemoPage />} />
+        <Route path="/pixi-dropzone"   element={<PixiDropzoneDemoPage />} />
         <Route path="/chat-demo"       element={<LLMChatDemoPage />} />
         <Route path="/rich-chat-demo" element={<RichChatDemoPage />} />
         <Route path="/llmchat"         element={<LLMChatPage />} />

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -70,6 +70,7 @@ const examples: [string, string][] = [
   ['Presets', '/presets'],
   ['LLMChat', '/chat-demo'],
   ['RichChat', '/rich-chat-demo'],
+  ['Pixi Dropzone', '/pixi-dropzone'],
 ];
 
 const DEFAULT_EXPANDED = [

--- a/docs/src/pages/PixiDropzoneDemo.tsx
+++ b/docs/src/pages/PixiDropzoneDemo.tsx
@@ -1,0 +1,95 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/PixiDropzoneDemo.tsx | valet docs
+// PixiJS integration example with Dropzone
+// ─────────────────────────────────────────────────────────────
+import { Surface, Stack, Typography, Dropzone, Button, useTheme } from '@archway/valet';
+import { Application, extend } from '@pixi/react';
+import type { ApplicationRef } from "@pixi/react";
+import { Container, Sprite, Graphics, Texture } from 'pixi.js';
+import { useNavigate } from 'react-router-dom';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import NavDrawer from '../components/NavDrawer';
+
+extend({ Container, Sprite, Graphics });
+
+export default function PixiDropzoneDemo() {
+  const { theme } = useTheme();
+  const navigate = useNavigate();
+  const appRef = useRef<ApplicationRef | null>(null);
+  const [fileUrl, setFileUrl] = useState<string | null>(null);
+  const [size, setSize] = useState<{ w: number; h: number } | null>(null);
+
+  const handleFilesChange = (files: File[]) => {
+    const f = files[0];
+    if (f) {
+      const url = URL.createObjectURL(f);
+      setFileUrl(url);
+    }
+  };
+
+  useEffect(() => {
+    if (!fileUrl) return;
+    const img = new Image();
+    img.onload = () => setSize({ w: img.width, h: img.height });
+    img.src = fileUrl;
+  }, [fileUrl]);
+
+  const download = useCallback(() => {
+    const app = appRef.current?.getApplication?.();
+    if (!app) return;
+    const canvas = app.view as HTMLCanvasElement;
+    const link = document.createElement('a');
+    link.download = 'pixi-image.png';
+    link.href = canvas.toDataURL('image/png');
+    link.click();
+  }, []);
+
+  const drawSquare = useCallback(
+    (g: Graphics) => {
+      if (!size) return;
+      const side = Math.min(size.w, size.h) / 4;
+      g.clear();
+      g.rect((size.w - side) / 2, (size.h - side) / 2, side, side);
+      g.fill({ color: 0x00ff00 });
+    },
+    [size]
+  );
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack>
+        <Typography variant="h2" bold>
+          Pixi Dropzone
+        </Typography>
+        <Typography variant="subtitle">
+          Upload an image and add a green square
+        </Typography>
+        <Dropzone
+          accept={{ 'image/*': [] }}
+          maxFiles={1}
+          onFilesChange={handleFilesChange}
+        />
+        {fileUrl && size && (
+          <>
+            <Application
+              ref={appRef as any}
+              width={size.w}
+              height={size.h}
+              backgroundAlpha={0}
+            >
+              <pixiSprite texture={Texture.from(fileUrl)} x={0} y={0} width={size.w} height={size.h} />
+              <pixiGraphics draw={drawSquare} />
+            </Application>
+            <Button onClick={download} style={{ marginTop: theme.spacing(1) }}>
+              Download
+            </Button>
+          </>
+        )}
+        <Button onClick={() => navigate(-1)} style={{ marginTop: theme.spacing(2) }}>
+          ← Back
+        </Button>
+      </Stack>
+    </Surface>
+  );
+}


### PR DESCRIPTION
## Summary
- install PixiJS react bindings in docs
- wire up PixiDropzoneDemo route and nav item
- implement PixiDropzoneDemo page
- add entry to changelog

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` in docs
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688062bbfbec832087f3ff02f3868d05