### PR TITLE
Add PixiJS dropzone demo

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,9 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-dropzone": "^14.2.3",
-    "react-router-dom": "^7.6.0"
+    "react-router-dom": "^7.6.0",
+    "@pixi/react": "^8.0.2",
+    "pixi.js": "^8.11.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -56,6 +56,7 @@ const VideoDemoPage         = page(() => import('./pages/VideoDemo'));
 const SnackbarDemoPage      = page(() => import('./pages/SnackbarDemo'));
 const TreeDemoPage          = page(() => import('./pages/TreeDemo'));
 const DropzoneDemoPage      = page(() => import('./pages/DropzoneDemo'));
+const PixiDropzoneDemoPage  = page(() => import('./pages/PixiDropzoneDemo'));
 const DateSelectorDemoPage  = page(() => import('./pages/DateSelectorDemo'));
 const MarkdownDemoPage      = page(() => import('./pages/MarkdownDemo'));
 const OverviewPage          = page(() => import('./pages/Overview'));
@@ -127,6 +128,7 @@ export function App() {
         <Route path="/radio-demo"      element={<RadioGroupDemoPage />} />
         <Route path="/video-demo"      element={<VideoDemoPage />} />
         <Route path="/dropzone-demo"   element={<DropzoneDemoPage />} />
+        <Route path="/pixi-dropzone-demo" element={<PixiDropzoneDemoPage />} />
         <Route path="/chat-demo"       element={<LLMChatDemoPage />} />
         <Route path="/rich-chat-demo" element={<RichChatDemoPage />} />
         <Route path="/llmchat"         element={<LLMChatPage />} />

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -70,6 +70,7 @@ const examples: [string, string][] = [
   ['Presets', '/presets'],
   ['LLMChat', '/chat-demo'],
   ['RichChat', '/rich-chat-demo'],
+  ['Pixi Dropzone', '/pixi-dropzone-demo'],
 ];
 
 const DEFAULT_EXPANDED = [

--- a/docs/src/pages/PixiDropzoneDemo.tsx
+++ b/docs/src/pages/PixiDropzoneDemo.tsx
@@ -1,0 +1,101 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/PixiDropzoneDemo.tsx | valet docs
+// Dropzone upload with PixiJS overlay example
+// ─────────────────────────────────────────────────────────────
+import { useState, useRef } from 'react';
+import {
+  Surface,
+  Stack,
+  Typography,
+  Dropzone,
+  Button,
+  useTheme,
+} from '@archway/valet';
+import NavDrawer from '../components/NavDrawer';
+import { Stage, Sprite, Graphics } from '@pixi/react';
+import * as PIXI from 'pixi.js';
+import { useNavigate } from 'react-router-dom';
+
+export default function PixiDropzoneDemo() {
+  const { theme } = useTheme();
+  const navigate = useNavigate();
+  const [image, setImage] = useState<string | null>(null);
+  const [size, setSize] = useState({ width: 512, height: 512 });
+  const appRef = useRef<PIXI.Application | null>(null);
+
+  const handleFiles = (files: File[]) => {
+    const file = files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const url = String(reader.result);
+      const img = new Image();
+      img.onload = () => {
+        setSize({ width: img.width, height: img.height });
+      };
+      img.src = url;
+      setImage(url);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const drawSquare = (g: PIXI.Graphics) => {
+    g.clear();
+    g.beginFill(0x00ff00);
+    const side = Math.min(size.width, size.height) / 4;
+    g.drawRect((size.width - side) / 2, (size.height - side) / 2, side, side);
+    g.endFill();
+  };
+
+  const handleDownload = () => {
+    if (!appRef.current) return;
+    const canvas = appRef.current.renderer.extract.canvas();
+    const url = canvas.toDataURL('image/png');
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'image.png';
+    a.click();
+  };
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack>
+        <Typography variant="h2" bold>
+          Pixi Dropzone
+        </Typography>
+        <Typography variant="subtitle">
+          Upload a photo, add a green square, then download
+        </Typography>
+
+        <Dropzone
+          accept={{ 'image/*': [] }}
+          maxFiles={1}
+          multiple={false}
+          onFilesChange={handleFiles}
+        />
+
+        {image && (
+          <Stage
+            width={size.width}
+            height={size.height}
+            options={{ backgroundAlpha: 0 }}
+            ref={appRef}
+          >
+            <Sprite image={image} width={size.width} height={size.height} />
+            <Graphics draw={drawSquare} />
+          </Stage>
+        )}
+
+        {image && (
+          <Button onClick={handleDownload}>Download</Button>
+        )}
+
+        <Button onClick={() => navigate(-1)} style={{ marginTop: theme.spacing(1) }}>
+          ← Back
+        </Button>
+      </Stack>
+    </Surface>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add @pixi/react and pixi.js to docs
- create PixiDropzoneDemo page
- wire demo into router and nav

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_688062bbfbec832087f3ff02f3868d05