### PR TITLE
Add gl-react shader demo

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.9.0",
       "dependencies": {
         "@archway/valet": "0.19.1",
+        "gl-react": "^5.0.0",
+        "gl-react-dom": "^5.0.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-dropzone": "^14.2.3",
@@ -1796,6 +1798,15 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/add-line-numbers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/add-line-numbers/-/add-line-numbers-1.0.1.tgz",
+      "integrity": "sha512-w+2a1malCvWwACQFBpZ5/uwmHGaGYT+aGIxA8ONF5vlhe6X/gD3eR8qVoLWa+5nnWAOq2LuPbrqDYqj1pn0WMg==",
+      "license": "MIT",
+      "dependencies": {
+        "pad-left": "^1.0.2"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1836,6 +1847,12 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/atob-lite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-1.0.0.tgz",
+      "integrity": "sha512-ArXcmHR/vwSN37HLVap/Y5SKpz12CuEybxe1sIYl7th/S6SQPrVMNFt6rblJzCOAxn0SHbXpknUtqbAIeo3Aow==",
+      "license": "MIT"
+    },
     "node_modules/attr-accept": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/attr-accept/-/attr-accept-2.2.5.tgz",
@@ -1850,6 +1867,12 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bit-twiddle": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
+      "integrity": "sha512-B9UhK0DKFZhoTFcfvAzhqsjStvGJp9vYWf3+6SNTtdSQnvIgfkHbgHrg/e4+TH71N2GDu8tpmCVoyfrL1d7ntA==",
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -2000,6 +2023,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2021,6 +2050,15 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/cwise-compiler": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
+      "integrity": "sha512-WXlK/m+Di8DMMcCjcWr4i+XzcQra9eCdXIJrgh4TUgh0pIS/yJduLxS9JgefsHJ/YVLdgPtXm9r62W92MvanEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uniq": "^1.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",
@@ -2045,6 +2083,12 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dup": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/dup/-/dup-1.0.0.tgz",
+      "integrity": "sha512-Bz5jxMMC0wgp23Zm15ip1x8IhYRqJvF3nFC0UInJUDkN1z4uNPk9jTnfCUJXbOGiQ1JbXLQsiV41Fb+HXcj5BA==",
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -2459,6 +2503,68 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/gl-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gl-constants/-/gl-constants-1.0.0.tgz",
+      "integrity": "sha512-3DNyoAUdb1c+o7jNk5Nm7eh6RSQFi9ZmMQIQb2xxsO27rUopE+IUhoh4xlUvZYBn1YPgUC8BlCnrVjXq/d2dQA==",
+      "license": "MIT"
+    },
+    "node_modules/gl-format-compiler-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/gl-format-compiler-error/-/gl-format-compiler-error-1.0.3.tgz",
+      "integrity": "sha512-FtQaBYlsM/rnz7YhLkxG9dLcNDB+ExErIsFV2DXl0nk+YgIZ2i0jMob4BrhT9dNa179zFb0gZMWpNAokytK+Ug==",
+      "license": "Unlicense",
+      "dependencies": {
+        "add-line-numbers": "^1.0.1",
+        "gl-constants": "^1.0.0",
+        "glsl-shader-name": "^1.0.0",
+        "sprintf-js": "^1.0.3"
+      }
+    },
+    "node_modules/gl-react": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/gl-react/-/gl-react-5.2.0.tgz",
+      "integrity": "sha512-A/FxG65e8Zx2RYi9+kYpeAwfFb7qQN0T6BCRXcUiwevUC//i3cH53w0AQRGj1mm96NVvD412mYJatl52qlDuxw==",
+      "license": "MIT",
+      "dependencies": {
+        "gl-shader": "^4.2.1",
+        "invariant": "^2.2.4",
+        "ndarray": "^1.0.19",
+        "prop-types": "^15.7.2",
+        "typedarray-pool": "^1.2.0",
+        "webgltexture-loader": "1.0.0",
+        "webgltexture-loader-ndarray": "1.2.0"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/gl-react-dom": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/gl-react-dom/-/gl-react-dom-5.2.1.tgz",
+      "integrity": "sha512-RZxOovktk8czle/FiMbiEJJxHLICoHEzxU46GeQ9tqiWMYxj/wj01VbqGVlrn6wVZ+fx77bhRxzn5ptW2uuxbA==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "prop-types": "^15.7.2",
+        "raf": "^3.4.1",
+        "webgltexture-loader-dom": "1.0.0"
+      },
+      "peerDependencies": {
+        "gl-react": "*",
+        "react": "*"
+      }
+    },
+    "node_modules/gl-shader": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/gl-shader/-/gl-shader-4.3.1.tgz",
+      "integrity": "sha512-xLoN6XtRLlg97SEqtuzfKc+pVWpVkQ3YjDI1kuCale8tF7+zMhiKlMfmG4IMQPMdKJZQbIc/Ny8ZusEpfh5U+w==",
+      "license": "MIT",
+      "dependencies": {
+        "gl-format-compiler-error": "^1.0.2",
+        "weakmap-shim": "^1.1.0"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2483,6 +2589,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glsl-shader-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-shader-name/-/glsl-shader-name-1.0.0.tgz",
+      "integrity": "sha512-OtHon0dPCbJD+IrVA1vw9QDlp2cS/f9z8X/0y+W7Qy1oZ3U1iFAQUEco2v30V0SAlVLDG5rEfhjEfc3DKdGbFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "atob-lite": "^1.0.0",
+        "glsl-tokenizer": "^2.0.2"
+      }
+    },
+    "node_modules/glsl-tokenizer": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz",
+      "integrity": "sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==",
+      "license": "MIT",
+      "dependencies": {
+        "through2": "^0.6.3"
       }
     },
     "node_modules/graphemer": {
@@ -2539,6 +2664,33 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "node_modules/iota-array": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
+      "integrity": "sha512-pZ2xT+LOHckCatGQ3DcG/a+QuEqvoxqkiL7tvE8nn3uuu+f6i1TtpB5/FtWFbxUuVr5PZCx8KskuGatbJDXOWA==",
+      "license": "MIT"
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT"
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2571,6 +2723,12 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -2796,6 +2954,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ndarray": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.19.tgz",
+      "integrity": "sha512-B4JHA4vdyZU30ELBw3g7/p9bZupyew5a7tX1Y/gGeF2hafrPaQZhgrGQfsvgfYbgdFZjYwuEcnaobeM/WMW+HQ==",
+      "license": "MIT",
+      "dependencies": {
+        "iota-array": "^1.0.0",
+        "is-buffer": "^1.0.2"
+      }
+    },
+    "node_modules/ndarray-ops": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/ndarray-ops/-/ndarray-ops-1.2.2.tgz",
+      "integrity": "sha512-BppWAFRjMYF7N/r6Ie51q6D4fs0iiGmeXIACKY66fLpnwIui3Wc3CXiD/30mgLbDjPpSLrsqcp3Z62+IcHZsDw==",
+      "license": "MIT",
+      "dependencies": {
+        "cwise-compiler": "^1.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -2862,6 +3039,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pad-left": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pad-left/-/pad-left-1.0.2.tgz",
+      "integrity": "sha512-saxSV1EYAytuZDtQYEwi0DPzooG6aN18xyHrnJtzwjVwmMauzkEecd7hynVJGolNGk1Pl9tltmZqfze4TZTCxg==",
+      "license": "MIT",
+      "dependencies": {
+        "repeat-string": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2894,6 +3083,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2996,6 +3191,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
@@ -3086,6 +3290,27 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/resolve-from": {
@@ -3234,6 +3459,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "license": "MIT"
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3258,6 +3495,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/through2": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+      "integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+        "xtend": ">=4.0.0 <4.1.0-0"
       }
     },
     "node_modules/tinyglobby": {
@@ -3350,6 +3597,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/typedarray-pool": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.2.0.tgz",
+      "integrity": "sha512-YTSQbzX43yvtpfRtIDAYygoYtgT+Rpjuxy9iOpczrjpXLgGoyG7aS5USJXV2d3nn8uHTeb9rXDvzS27zUg5KYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bit-twiddle": "^1.0.0",
+        "dup": "^1.0.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
@@ -3393,6 +3650,12 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uniq": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "integrity": "sha512-Gw+zz50YNKPDKXs+9d+aKAjVwpjNwqzvNpLigIruT4HA9lMZNdMqs9x07kKHB/L9WRzqp4+DlTU5s4wG2esdoA==",
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -3548,6 +3811,67 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/weakmap-shim": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/weakmap-shim/-/weakmap-shim-1.1.1.tgz",
+      "integrity": "sha512-/wNyG+1FpiHhnfQo+TuA/XAUpvOOkKVl0A4qpT+oGcj5SlZCLmM+M1Py/3Sj8sy+YrEauCVITOxCsZKo6sPbQg=="
+    },
+    "node_modules/webgltexture-loader": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/webgltexture-loader/-/webgltexture-loader-1.0.0.tgz",
+      "integrity": "sha512-TbQUdr0Bc3tcJ4pKIFoM9dKyLdYNf9Uxq05oZuIT+2e/vCcfaQS+WjNmW1FwYqaBrzcLr9CA/HBAmvyaS/REGw==",
+      "license": "MIT"
+    },
+    "node_modules/webgltexture-loader-dom": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/webgltexture-loader-dom/-/webgltexture-loader-dom-1.0.0.tgz",
+      "integrity": "sha512-JavQ9Hvv3DIYx6WuqzVa76bn2YCcq1lazUdzf277VZWrmxVCln5QFjyTfWZozgYtT21lVeu6MdMOUIbY4xhjqA==",
+      "license": "MIT",
+      "dependencies": {
+        "webgltexture-loader-dom-canvas": "^1.0.0",
+        "webgltexture-loader-dom-image-url": "^1.0.0",
+        "webgltexture-loader-dom-video": "^1.0.0"
+      }
+    },
+    "node_modules/webgltexture-loader-dom-canvas": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/webgltexture-loader-dom-canvas/-/webgltexture-loader-dom-canvas-1.0.0.tgz",
+      "integrity": "sha512-lRDoPVE4GXFyfsl/E5+sZd7m6304RmBRky0SmgHlqJZJySFrCbQMF/hMQkWNWM5iYks84kRUGlwugW/c6OgpDw==",
+      "license": "MIT",
+      "dependencies": {
+        "webgltexture-loader": "^1.0.0"
+      }
+    },
+    "node_modules/webgltexture-loader-dom-image-url": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/webgltexture-loader-dom-image-url/-/webgltexture-loader-dom-image-url-1.0.0.tgz",
+      "integrity": "sha512-KiQ16cLBTjoCQfdvfy1SQP3wMWEPW9ADqsODyhd+6nMg7qD6FmewF3OZs6chF4yfDtlVVXRYI/cDGF1K9MK5Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "webgltexture-loader": "^1.0.0"
+      }
+    },
+    "node_modules/webgltexture-loader-dom-video": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/webgltexture-loader-dom-video/-/webgltexture-loader-dom-video-1.0.0.tgz",
+      "integrity": "sha512-o3zB2XQEMAqgHQeNavoy4q5/lwIIt1MjF6Qj+pUDju9VlovJXGJiCIZ/suv715YgS3k36/pg97847GhV3bHczQ==",
+      "license": "MIT",
+      "dependencies": {
+        "webgltexture-loader": "^1.0.0"
+      }
+    },
+    "node_modules/webgltexture-loader-ndarray": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/webgltexture-loader-ndarray/-/webgltexture-loader-ndarray-1.2.0.tgz",
+      "integrity": "sha512-gWTIqCOYs1XK6Yp4G7XvFDhvCvr6wFjTLPRN/HGBouF4u0to2fAIh5+2cxzEs1WE7eSwsxg1y5aNi1jRXSX+zA==",
+      "license": "MIT",
+      "dependencies": {
+        "ndarray": "^1.0.19",
+        "ndarray-ops": "^1.2.2",
+        "typedarray-pool": "^1.2.0",
+        "webgltexture-loader": "^1.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3572,6 +3896,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yallist": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,9 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-dropzone": "^14.2.3",
-    "react-router-dom": "^7.6.0"
+    "react-router-dom": "^7.6.0",
+    "gl-react": "^5.0.0",
+    "gl-react-dom": "^5.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -58,6 +58,7 @@ const TreeDemoPage          = page(() => import('./pages/TreeDemo'));
 const DropzoneDemoPage      = page(() => import('./pages/DropzoneDemo'));
 const DateSelectorDemoPage  = page(() => import('./pages/DateSelectorDemo'));
 const MarkdownDemoPage      = page(() => import('./pages/MarkdownDemo'));
+const ShaderDemoPage        = page(() => import('./pages/ShaderDemo'));
 const OverviewPage          = page(() => import('./pages/Overview'));
 const InstallationPage      = page(() => import('./pages/Installation'));
 const UsagePage             = page(() => import('./pages/Usage'));
@@ -136,6 +137,7 @@ export function App() {
         <Route path="/iterator-demo"  element={<IteratorDemoPage />} />
         <Route path="/dateselector-demo" element={<DateSelectorDemoPage />} />
         <Route path="/markdown-demo"  element={<MarkdownDemoPage />} />
+        <Route path="/shader-demo"    element={<ShaderDemoPage />} />
         <Route path="/prop-patterns"  element={<PropPatternsPage />} />
       </Routes>
     </Suspense>

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -70,6 +70,7 @@ const examples: [string, string][] = [
   ['Presets', '/presets'],
   ['LLMChat', '/chat-demo'],
   ['RichChat', '/rich-chat-demo'],
+  ['Shader', '/shader-demo'],
 ];
 
 const DEFAULT_EXPANDED = [

--- a/docs/src/gl-react.d.ts
+++ b/docs/src/gl-react.d.ts
@@ -1,0 +1,9 @@
+declare module 'gl-react' {
+  export const Shaders: any;
+  export const Node: any;
+  export const GLSL: any;
+}
+
+declare module 'gl-react-dom' {
+  export const Surface: any;
+}

--- a/docs/src/pages/ShaderDemo.tsx
+++ b/docs/src/pages/ShaderDemo.tsx
@@ -1,0 +1,80 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/ShaderDemo.tsx | valet docs
+// Demo of gl-react with a simple textured plane
+// ─────────────────────────────────────────────────────────────
+import React from 'react';
+import {
+  Surface as ValetSurface,
+  Stack,
+  Typography,
+  useTheme,
+} from '@archway/valet';
+import NavDrawer from '../components/NavDrawer';
+
+import { Shaders, Node, GLSL } from 'gl-react';
+import { Surface as GLSurface } from 'gl-react-dom';
+
+const shaders = Shaders.create({
+  picture: {
+    frag: GLSL`
+precision highp float;
+varying vec2 uv;
+uniform sampler2D tex;
+void main() {
+  gl_FragColor = texture2D(tex, uv);
+}
+    `,
+  },
+});
+
+const Picture = () => (
+  <Node shader={shaders.picture} uniforms={{ tex: 'https://placecats.com/louie/512/512' }} />
+);
+
+export default function ShaderDemo() {
+  const { theme } = useTheme();
+  return (
+    <ValetSurface>
+      <NavDrawer />
+      <Stack style={{ padding: theme.spacing(1) }}>
+        <Typography variant="h2" bold>
+          Shader Demo
+        </Typography>
+        <Typography variant="subtitle">
+          Textured plane rendered with gl-react
+        </Typography>
+        <div
+          style={{
+            position: 'relative',
+            width: 512,
+            height: 512,
+            marginTop: theme.spacing(1),
+            perspective: '800px',
+          }}
+        >
+          <GLSurface
+            width={512}
+            height={512}
+            style={{
+              transform: 'rotateX(20deg) rotateY(-20deg)',
+            }}
+          >
+            <Picture />
+          </GLSurface>
+          <div
+            style={{
+              position: 'absolute',
+              top: 8,
+              left: 8,
+              width: 16,
+              height: 16,
+              borderRadius: '50%',
+              background: 'magenta',
+              pointerEvents: 'none',
+            }}
+          />
+        </div>
+      </Stack>
+    </ValetSurface>
+  );
+}


### PR DESCRIPTION
## Summary
- include gl-react and gl-react-dom in docs
- provide TypeScript stubs for the modules
- add ShaderDemo example page showing a textured plane and overlay circle
- wire up ShaderDemo route and navigation entry

## Testing
- `npm run build`
- `cd docs && npm run build`
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6882784cfbb883208c406cec94597cd3