### PR TITLE
Add outline variant for avatars

### DIFF
--- a/src/components/primitives/Avatar.tsx
+++ b/src/components/primitives/Avatar.tsx
@@ -5,10 +5,12 @@
 import React from 'react';
 import { styled } from '../../css/createStyled';
 import { preset } from '../../css/stylePresets';
+import { useTheme } from '../../system/themeStore';
 import type { Presettable } from '../../types';
 import { md5 } from '../../helpers/md5';
 
 export type AvatarSize = 'xs' | 's' | 'm' | 'l' | 'xl';
+export type AvatarVariant = 'plain' | 'outline';
 
 export interface AvatarProps
   extends React.ImgHTMLAttributes<HTMLImageElement>,
@@ -21,6 +23,8 @@ export interface AvatarProps
   size?: AvatarSize;
   /** Fallback style when no avatar exists. */
   gravatarDefault?: string;
+  /** Visual variant */
+  variant?: AvatarVariant;
 }
 
 const sizeMap: Record<AvatarSize, string> = {
@@ -31,12 +35,21 @@ const sizeMap: Record<AvatarSize, string> = {
   xl: '6rem',
 };
 
-const Img = styled('img')<{ $size: string }>`
+const Img = styled('img')<{
+  $size: string;
+  $variant: AvatarVariant;
+  $mode: 'light' | 'dark';
+}>`
   display: inline-block;
+  box-sizing: border-box;
   width: ${({ $size }) => $size};
   height: ${({ $size }) => $size};
   border-radius: 50%;
   object-fit: cover;
+  ${({ $variant, $mode }) =>
+    $variant === 'outline'
+      ? `border: 0.25rem solid ${$mode === 'light' ? '#000' : '#fff'};`
+      : ''}
 `;
 
 export const Avatar: React.FC<AvatarProps> = ({
@@ -44,12 +57,14 @@ export const Avatar: React.FC<AvatarProps> = ({
   email,
   size = 'm',
   gravatarDefault = 'identicon',
+  variant = 'plain',
   preset: p,
   className,
   ...rest
 }) => {
   const rem = sizeMap[size];
   const px = Math.round(parseFloat(rem) * 16);
+  const { mode } = useTheme();
 
   let finalSrc = src;
   if (!finalSrc) {
@@ -63,6 +78,8 @@ export const Avatar: React.FC<AvatarProps> = ({
       {...rest}
       src={finalSrc}
       $size={rem}
+      $variant={variant}
+      $mode={mode}
       className={[presetCls, className].filter(Boolean).join(' ')}
     />
   );

--- a/src/components/widgets/LLMChat.tsx
+++ b/src/components/widgets/LLMChat.tsx
@@ -335,6 +335,7 @@ export const LLMChat: React.FC<ChatProps> = ({
                 <Avatar
                   src={systemAvatar}
                   size="s"
+                  variant="outline"
                   style={{ marginRight: theme.spacing(1) }}
                 />
               )}
@@ -370,6 +371,7 @@ export const LLMChat: React.FC<ChatProps> = ({
                 <Avatar
                   src={userAvatar}
                   size="s"
+                  variant="outline"
                   style={{ marginLeft: theme.spacing(1) }}
                 />
               )}

--- a/src/components/widgets/RichChat.tsx
+++ b/src/components/widgets/RichChat.tsx
@@ -260,6 +260,7 @@ export const RichChat: React.FC<RichChatProps> = ({
                     <Avatar
                       src={systemAvatar}
                       size="s"
+                      variant="outline"
                       style={{ marginRight: theme.spacing(1) }}
                     />
                   )}
@@ -316,6 +317,7 @@ export const RichChat: React.FC<RichChatProps> = ({
                     <Avatar
                       src={userAvatar}
                       size="s"
+                      variant="outline"
                       style={{ marginLeft: theme.spacing(1) }}
                     />
                   )}


### PR DESCRIPTION
## Summary
- add new `outline` variant to `Avatar`
- default style renamed to `plain`
- use outline avatars in RichChat and LLMChat

## Testing
- `npm install`
- `npm run build`
- `cd docs && npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6883984e6b248320804d7bb8a016b88c