### PR TITLE
Add outline avatar variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Added `outline` variant to `Avatar`. Existing style renamed to `plain`.
+
 ## [0.19.1]
 - Removed Pixi.js integration demo
 

--- a/docs/src/pages/AvatarDemo.tsx
+++ b/docs/src/pages/AvatarDemo.tsx
@@ -74,6 +74,12 @@ export default function AvatarDemoPage() {
       description: 'Fallback style when no avatar exists',
     },
     {
+      prop: <code>variant</code>,
+      type: <code>'plain' | 'outline'</code>,
+      default: <code>'plain'</code>,
+      description: 'Visual style of the avatar',
+    },
+    {
       prop: <code>alt</code>,
       type: <code>string</code>,
       default: <code>-</code>,

--- a/src/components/primitives/Avatar.tsx
+++ b/src/components/primitives/Avatar.tsx
@@ -5,10 +5,12 @@
 import React from 'react';
 import { styled } from '../../css/createStyled';
 import { preset } from '../../css/stylePresets';
+import { useTheme } from '../../system/themeStore';
 import type { Presettable } from '../../types';
 import { md5 } from '../../helpers/md5';
 
 export type AvatarSize = 'xs' | 's' | 'm' | 'l' | 'xl';
+export type AvatarVariant = 'plain' | 'outline';
 
 export interface AvatarProps
   extends React.ImgHTMLAttributes<HTMLImageElement>,
@@ -21,6 +23,8 @@ export interface AvatarProps
   size?: AvatarSize;
   /** Fallback style when no avatar exists. */
   gravatarDefault?: string;
+  /** Visual style of the avatar. */
+  variant?: AvatarVariant;
 }
 
 const sizeMap: Record<AvatarSize, string> = {
@@ -31,23 +35,27 @@ const sizeMap: Record<AvatarSize, string> = {
   xl: '6rem',
 };
 
-const Img = styled('img')<{ $size: string }>`
+const Img = styled('img')<{ $size: string; $variant: AvatarVariant; $stroke: string }>`
   display: inline-block;
   width: ${({ $size }) => $size};
   height: ${({ $size }) => $size};
   border-radius: 50%;
   object-fit: cover;
+  ${({ $variant, $stroke }) =>
+    $variant === 'outline' ? `box-shadow: 0 0 0 0.25rem ${$stroke};` : ''}
 `;
 
 export const Avatar: React.FC<AvatarProps> = ({
   src,
   email,
   size = 'm',
+  variant = 'plain',
   gravatarDefault = 'identicon',
   preset: p,
   className,
   ...rest
 }) => {
+  const { mode } = useTheme();
   const rem = sizeMap[size];
   const px = Math.round(parseFloat(rem) * 16);
 
@@ -58,11 +66,14 @@ export const Avatar: React.FC<AvatarProps> = ({
   }
 
   const presetCls = p ? preset(p) : '';
+  const stroke = mode === 'dark' ? '#fff' : '#000';
   return (
     <Img
       {...rest}
       src={finalSrc}
       $size={rem}
+      $variant={variant}
+      $stroke={stroke}
       className={[presetCls, className].filter(Boolean).join(' ')}
     />
   );

--- a/src/components/widgets/LLMChat.tsx
+++ b/src/components/widgets/LLMChat.tsx
@@ -335,6 +335,7 @@ export const LLMChat: React.FC<ChatProps> = ({
                 <Avatar
                   src={systemAvatar}
                   size="s"
+                  variant="outline"
                   style={{ marginRight: theme.spacing(1) }}
                 />
               )}
@@ -370,6 +371,7 @@ export const LLMChat: React.FC<ChatProps> = ({
                 <Avatar
                   src={userAvatar}
                   size="s"
+                  variant="outline"
                   style={{ marginLeft: theme.spacing(1) }}
                 />
               )}

--- a/src/components/widgets/RichChat.tsx
+++ b/src/components/widgets/RichChat.tsx
@@ -260,6 +260,7 @@ export const RichChat: React.FC<RichChatProps> = ({
                     <Avatar
                       src={systemAvatar}
                       size="s"
+                      variant="outline"
                       style={{ marginRight: theme.spacing(1) }}
                     />
                   )}
@@ -316,6 +317,7 @@ export const RichChat: React.FC<RichChatProps> = ({
                     <Avatar
                       src={userAvatar}
                       size="s"
+                      variant="outline"
                       style={{ marginLeft: theme.spacing(1) }}
                     />
                   )}


### PR DESCRIPTION
## Summary
- introduce `outline` variant and rename old style `plain`
- apply outlined avatars to chat components
- document new prop in Avatar docs
- note update in CHANGELOG

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6883984e6b248320804d7bb8a016b88c