### PR TITLE
Add outline avatar variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+## [0.19.2]
+- Adjusted `Accordion`
+- Adjust `RichChat` and `LLMChat` to use "outlined" `Accordion`
+
 ## [0.19.1]
 - Removed Pixi.js integration demo
 
@@ -268,6 +272,7 @@ responsive logic uses the selected `Surface` element to handle persistent margin
 ## [v0.2.1]
 ### Other
 - vibe coded
+[v0.19.2]: https://github.com/off-court-creations/valet/releases/tag/v0.19.2
 [v0.19.1]: https://github.com/off-court-creations/valet/releases/tag/v0.19.1
 [v0.19.0]: https://github.com/off-court-creations/valet/releases/tag/v0.19.0
 [v0.18.3]: https://github.com/off-court-creations/valet/releases/tag/v0.18.3

--- a/docs/src/pages/AvatarDemo.tsx
+++ b/docs/src/pages/AvatarDemo.tsx
@@ -68,6 +68,12 @@ export default function AvatarDemoPage() {
       description: 'Relative size token',
     },
     {
+      prop: <code>variant</code>,
+      type: <code>'plain' | 'outline'</code>,
+      default: <code>'plain'</code>,
+      description: 'Visual style variant',
+    },
+    {
       prop: <code>gravatarDefault</code>,
       type: <code>string</code>,
       default: <code>'identicon'</code>,
@@ -130,6 +136,9 @@ export default function AvatarDemoPage() {
                 </Stack>
               ))}
             </Stack>
+
+            <Typography variant="h3">5. Outline</Typography>
+            <Avatar email="support@gravatar.com" size="l" variant="outline" />
           </Tabs.Panel>
 
           <Tabs.Tab label="Reference" />

--- a/src/components/primitives/Avatar.tsx
+++ b/src/components/primitives/Avatar.tsx
@@ -5,10 +5,12 @@
 import React from 'react';
 import { styled } from '../../css/createStyled';
 import { preset } from '../../css/stylePresets';
+import { useTheme } from '../../system/themeStore';
 import type { Presettable } from '../../types';
 import { md5 } from '../../helpers/md5';
 
 export type AvatarSize = 'xs' | 's' | 'm' | 'l' | 'xl';
+export type AvatarVariant = 'plain' | 'outline';
 
 export interface AvatarProps
   extends React.ImgHTMLAttributes<HTMLImageElement>,
@@ -19,6 +21,8 @@ export interface AvatarProps
   email?: string;
   /** Size token controlling relative dimensions. */
   size?: AvatarSize;
+  /** Visual style variant. */
+  variant?: AvatarVariant;
   /** Fallback style when no avatar exists. */
   gravatarDefault?: string;
 }
@@ -31,18 +35,25 @@ const sizeMap: Record<AvatarSize, string> = {
   xl: '6rem',
 };
 
-const Img = styled('img')<{ $size: string }>`
+const Img = styled('img')<{
+  $size: string;
+  $variant: AvatarVariant;
+  $stroke: string;
+}>`
   display: inline-block;
   width: ${({ $size }) => $size};
   height: ${({ $size }) => $size};
   border-radius: 50%;
   object-fit: cover;
+  ${({ $variant, $stroke }) =>
+    $variant === 'outline' ? `box-shadow: 0 0 0 0.25rem ${$stroke};` : ''}
 `;
 
 export const Avatar: React.FC<AvatarProps> = ({
   src,
   email,
   size = 'm',
+  variant = 'plain',
   gravatarDefault = 'identicon',
   preset: p,
   className,
@@ -57,12 +68,17 @@ export const Avatar: React.FC<AvatarProps> = ({
     finalSrc = `https://www.gravatar.com/avatar/${hash}?s=${px}&d=${encodeURIComponent(gravatarDefault)}`;
   }
 
+  const { mode } = useTheme();
+  const stroke = mode === 'dark' ? '#fff' : '#000';
+
   const presetCls = p ? preset(p) : '';
   return (
     <Img
       {...rest}
       src={finalSrc}
       $size={rem}
+      $variant={variant}
+      $stroke={stroke}
       className={[presetCls, className].filter(Boolean).join(' ')}
     />
   );

--- a/src/components/primitives/Avatar.tsx
+++ b/src/components/primitives/Avatar.tsx
@@ -68,8 +68,8 @@ export const Avatar: React.FC<AvatarProps> = ({
     finalSrc = `https://www.gravatar.com/avatar/${hash}?s=${px}&d=${encodeURIComponent(gravatarDefault)}`;
   }
 
-  const { mode } = useTheme();
-  const stroke = mode === 'dark' ? '#fff' : '#000';
+  const { theme } = useTheme();
+  const stroke = theme.colors.backgroundAlt;
 
   const presetCls = p ? preset(p) : '';
   return (

--- a/src/components/widgets/LLMChat.tsx
+++ b/src/components/widgets/LLMChat.tsx
@@ -335,6 +335,7 @@ export const LLMChat: React.FC<ChatProps> = ({
                 <Avatar
                   src={systemAvatar}
                   size="s"
+                  variant="outline"
                   style={{ marginRight: theme.spacing(1) }}
                 />
               )}
@@ -370,6 +371,7 @@ export const LLMChat: React.FC<ChatProps> = ({
                 <Avatar
                   src={userAvatar}
                   size="s"
+                  variant="outline"
                   style={{ marginLeft: theme.spacing(1) }}
                 />
               )}

--- a/src/components/widgets/RichChat.tsx
+++ b/src/components/widgets/RichChat.tsx
@@ -260,6 +260,7 @@ export const RichChat: React.FC<RichChatProps> = ({
                     <Avatar
                       src={systemAvatar}
                       size="s"
+                      variant="outline"
                       style={{ marginRight: theme.spacing(1) }}
                     />
                   )}
@@ -316,6 +317,7 @@ export const RichChat: React.FC<RichChatProps> = ({
                     <Avatar
                       src={userAvatar}
                       size="s"
+                      variant="outline"
                       style={{ marginLeft: theme.spacing(1) }}
                     />
                   )}


### PR DESCRIPTION
## Summary
- add Avatar variants with new outline style
- outline adds a theme-aware stroke
- show outline example in Avatar docs
- update RichChat and LLMChat to use outline avatars

## Testing
- `npm run build`
- `cd docs && npm link @archway/valet && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6883984e6b248320804d7bb8a016b88c