### PR TITLE
Add icon-based tabs example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+## [0.19.3]
+- Updated `Accordion` demo
+
 ## [0.19.2]
 - Adjusted `Accordion`
 - Adjust `RichChat` and `LLMChat` to use "outlined" `Accordion`

--- a/docs/src/pages/TabsDemo.tsx
+++ b/docs/src/pages/TabsDemo.tsx
@@ -9,6 +9,7 @@ import {
   Typography,
   Button,
   Tabs,
+  Icon,
   useTheme,
 } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
@@ -116,8 +117,21 @@ export default function TabsDemoPage() {
           <Tabs.Panel>{'Third → ' + SIX}</Tabs.Panel>
         </Tabs>
 
+        {/* 6. Icon headings ----------------------------------------------- */}
+        <Typography variant="h3">6. Icon headings</Typography>
+        <Tabs>
+          <Tabs.Tab label={<Icon icon="mdi:home" />} aria-label="Home" />
+          <Tabs.Panel>{'Home → ' + ONE}</Tabs.Panel>
+
+          <Tabs.Tab label={<Icon icon="mdi:account" />} aria-label="Profile" />
+          <Tabs.Panel>{'Profile → ' + TWO}</Tabs.Panel>
+
+          <Tabs.Tab label={<Icon icon="mdi:cog" />} aria-label="Settings" />
+          <Tabs.Panel>{'Settings → ' + THREE}</Tabs.Panel>
+        </Tabs>
+
         {/* Theme switcher -------------------------------------------------- */}
-        <Typography variant="h3">6. Theme coupling</Typography>
+        <Typography variant="h3">7. Theme coupling</Typography>
         <Button variant="outlined" onClick={toggleMode}>
           Toggle light / dark
         </Button>


### PR DESCRIPTION
## Summary
- demonstrate icon-based tab headings in the Tabs demo

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6883a8cfea488320968a36b8b9a1e21c