### PR TITLE
Add icon support to AppBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Added optional `icon` prop to `AppBar` with left/right placement
 
 ## [0.19.3]
 - Updated `Accordion` demo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-- Added optional `icon` prop to `AppBar` with left/right placement
+- Added optional `icon` prop to `AppBar` with left/right placement and improved spacing
 
 ## [0.19.3]
 - Updated `Accordion` demo

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -68,8 +68,8 @@ const PropPatternsPage      = page(() => import('./pages/PropPatterns'));
 export function App() {
   /* One-time initial theme + Google-font preload */
   useInitialTheme(
-    { fonts: { heading: 'Fira Sans', body: 'Ubuntu', mono: 'Ubuntu Mono' } },
-    ['Fira Sans', 'Ubuntu', 'Ubuntu Mono', 'Poppins']
+    { fonts: { heading: 'Cabin', body: 'Cabin', mono: 'Cabin Mono' } },
+    ['Fira Sans', 'Ubuntu', 'Ubuntu Mono', 'Poppins', "Cabin"]
   );
 
   /* Simple fallback – swap for a branded spinner when ready */

--- a/docs/src/pages/AppBarDemo.tsx
+++ b/docs/src/pages/AppBarDemo.tsx
@@ -1,5 +1,5 @@
 // src/pages/AppBarDemo.tsx
-import { Surface, Stack, Typography, Button, AppBar, Box, useTheme } from '@archway/valet';
+import { Surface, Stack, Typography, Button, AppBar, Box, Icon, useTheme } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
 import NavDrawer from '../components/NavDrawer';
 
@@ -10,8 +10,8 @@ export default function AppBarDemoPage() {
   return (
     <Surface>
       <NavDrawer />
-      <AppBar>
-        <Typography fontFamily="Poppins">AppBar with Typography</Typography>
+      <AppBar icon={<Icon icon="mdi:car" />} iconPlacement="right">
+        <Typography fontFamily="Poppins">AppBar with Icon</Typography>
       </AppBar>
       <Stack>
         <Typography variant="h2" bold>

--- a/docs/src/pages/AppBarDemo.tsx
+++ b/docs/src/pages/AppBarDemo.tsx
@@ -11,7 +11,7 @@ export default function AppBarDemoPage() {
     <Surface>
       <NavDrawer />
       <AppBar icon={<Icon icon="mdi:car" />}>
-        <Typography fontFamily="Poppins">AppBar with Icon</Typography>
+        <Typography fontFamily="Cabin">AppBar with Icon</Typography>
       </AppBar>
       <Stack>
         <Typography variant="h2" bold>

--- a/docs/src/pages/AppBarDemo.tsx
+++ b/docs/src/pages/AppBarDemo.tsx
@@ -10,7 +10,7 @@ export default function AppBarDemoPage() {
   return (
     <Surface>
       <NavDrawer />
-      <AppBar icon={<Icon icon="mdi:car" />} iconPlacement="right">
+      <AppBar icon={<Icon icon="mdi:car" />}>
         <Typography fontFamily="Poppins">AppBar with Icon</Typography>
       </AppBar>
       <Stack>

--- a/src/components/layout/AppBar.tsx
+++ b/src/components/layout/AppBar.tsx
@@ -1,8 +1,8 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/widgets/AppBar.tsx  | valet
+// src/components/layout/AppBar.tsx  | valet
 // minimal top navigation bar
 // ─────────────────────────────────────────────────────────────
-import React, { useLayoutEffect, useRef, useId } from 'react';
+import React, { ReactElement, useLayoutEffect, useRef, useId } from 'react';
 import { createPortal } from 'react-dom';
 import { styled } from '../../css/createStyled';
 import { useTheme } from '../../system/themeStore';
@@ -10,6 +10,7 @@ import { useSurface } from '../../system/surfaceStore';
 import { shallow } from 'zustand/shallow';
 import { preset } from '../../css/stylePresets';
 import type { Presettable } from '../../types';
+import type { IconProps } from '../primitives/Icon';
 
 /*───────────────────────────────────────────────────────────*/
 export type AppBarToken = 'primary' | 'secondary' | 'tertiary';
@@ -19,6 +20,8 @@ export interface AppBarProps
     Presettable {
   color?: AppBarToken | string;
   textColor?: AppBarToken | string;
+  icon?: ReactElement<IconProps>;
+  iconPlacement?: 'left' | 'right';
 }
 
 /*───────────────────────────────────────────────────────────*/
@@ -48,6 +51,8 @@ const Bar = styled('header')<{
 export const AppBar: React.FC<AppBarProps> = ({
   color,
   textColor,
+  icon,
+  iconPlacement = 'left',
   preset: p,
   className,
   style,
@@ -110,7 +115,9 @@ export const AppBar: React.FC<AppBarProps> = ({
       className={[presetClass, className].filter(Boolean).join(' ')}
       style={style}
     >
+      {iconPlacement === 'left' && icon}
       {children}
+      {iconPlacement === 'right' && icon}
     </Bar>
   );
 

--- a/src/components/layout/AppBar.tsx
+++ b/src/components/layout/AppBar.tsx
@@ -28,16 +28,12 @@ export interface AppBarProps
 const Bar = styled('header')<{
   $bg: string;
   $text: string;
-  $gap: string;
+  $pad: string;
 }>`
   box-sizing: border-box;
   display: flex;
   align-items: center;
-  justify-content: space-between;
   padding: 0.5rem 1rem;
-  & > * {
-    padding: ${({ $gap }) => $gap};
-  }
   position: fixed;
   top: 0;
   left: 0;
@@ -45,6 +41,21 @@ const Bar = styled('header')<{
   z-index: 10000;
   background: ${({ $bg }) => $bg};
   color: ${({ $text }) => $text};
+  & > * {
+    padding: ${({ $pad }) => $pad};
+  }
+`;
+
+const LeftWrap = styled('div')<{ $gap: string }>`
+  display: flex;
+  align-items: center;
+  gap: ${({ $gap }) => $gap};
+`;
+
+const RightWrap = styled('div')`
+  margin-left: auto;
+  display: flex;
+  align-items: center;
 `;
 
 /*───────────────────────────────────────────────────────────*/
@@ -88,7 +99,8 @@ export const AppBar: React.FC<AppBarProps> = ({
       ? theme.colors[`${textColor}Text`]
       : textColor;
   const presetClass = p ? preset(p) : '';
-  const gap = theme.spacing(1);
+  const pad = theme.spacing(1);
+  const gap = theme.spacing(2);
 
   useLayoutEffect(() => {
     const node = ref.current;
@@ -111,13 +123,15 @@ export const AppBar: React.FC<AppBarProps> = ({
       {...rest}
       $bg={bg}
       $text={text}
-      $gap={gap}
+      $pad={pad}
       className={[presetClass, className].filter(Boolean).join(' ')}
       style={style}
     >
-      {iconPlacement === 'left' && icon}
-      {children}
-      {iconPlacement === 'right' && icon}
+      <LeftWrap $gap={gap}>
+        {iconPlacement === 'left' && icon}
+        {children}
+      </LeftWrap>
+      {iconPlacement === 'right' && icon && <RightWrap>{icon}</RightWrap>}
     </Bar>
   );
 


### PR DESCRIPTION
## Summary
- add optional `icon` and `iconPlacement` props to `AppBar`
- demo icon usage in AppBar docs
- note new AppBar feature in CHANGELOG

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68847a4975688320992d82f896ec3182