### PR TITLE
Fix font loading via theme patches

### DIFF
--- a/src/components/layout/Surface.tsx
+++ b/src/components/layout/Surface.tsx
@@ -116,12 +116,13 @@ export const Surface: React.FC<SurfaceProps> = ({
     background: theme.colors.background,
     color: theme.colors.text,
   };
+  const quote = (f: string) => (f.includes(' ') ? `'${f}'` : f);
   const cssVars: React.CSSProperties = {
     '--valet-bg': theme.colors.background,
     '--valet-text-color': theme.colors.text,
-    '--valet-font-heading': theme.fonts.heading,
-    '--valet-font-body': theme.fonts.body,
-    '--valet-font-mono': theme.fonts.mono,
+    '--valet-font-heading': quote(theme.fonts.heading),
+    '--valet-font-body': quote(theme.fonts.body),
+    '--valet-font-mono': quote(theme.fonts.mono),
   } as any;
 
   /* Layout: fixed full‑screen or flow‑based ---------------------------- */

--- a/src/system/createInitialTheme.ts
+++ b/src/system/createInitialTheme.ts
@@ -15,18 +15,19 @@ import {
 export async function createInitialTheme(
   patch: Partial<Theme>,
   extras: string[] = [],
-  options?: GoogleFontOptions
+  options?: GoogleFontOptions,
 ): Promise<void> {
-  const { setTheme, theme } = useTheme.getState();
+  const { setTheme } = useTheme.getState();
   const { start, finish } = useFonts.getState();
   setTheme(patch);
+  const { theme } = useTheme.getState();
   const fonts = Array.from(
     new Set([
       theme.fonts.heading,
       theme.fonts.body,
       theme.fonts.mono,
       ...extras,
-    ])
+    ]),
   );
   injectGoogleFontLinks(fonts, options);
   start();


### PR DESCRIPTION
## Summary
- ensure fonts patched via `useInitialTheme` actually load
- quote font family CSS variables so multi-word fonts apply correctly

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688514c75fe48320be55ce51847e8750