### PR TITLE
fix createInitialTheme font loading

### DIFF
--- a/src/system/createInitialTheme.ts
+++ b/src/system/createInitialTheme.ts
@@ -17,9 +17,10 @@ export async function createInitialTheme(
   extras: string[] = [],
   options?: GoogleFontOptions
 ): Promise<void> {
-  const { setTheme, theme } = useTheme.getState();
+  const { setTheme } = useTheme.getState();
   const { start, finish } = useFonts.getState();
   setTheme(patch);
+  const { theme } = useTheme.getState();
   const fonts = Array.from(
     new Set([
       theme.fonts.heading,


### PR DESCRIPTION
## Summary
- ensure font patch is used when creating initial theme

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688514c75fe48320be55ce51847e8750