### PR TITLE
fix button text wrapping

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -68,8 +68,8 @@ const PropPatternsPage      = page(() => import('./pages/PropPatterns'));
 export function App() {
   /* One-time initial theme + Google-font preload */
   useInitialTheme(
-    { fonts: { heading: 'Cabin', body: 'Cabin', mono: 'Cabin Mono' } },
-    ['Fira Sans', 'Ubuntu', 'Ubuntu Mono', 'Poppins', "Cabin"]
+    { fonts: { heading: 'Cabin', body: 'Cabin', mono: 'Cabin Mono', button: 'Cabin' } },
+    ['Fira Sans', 'Ubuntu', 'Ubuntu Mono', 'Poppins', 'Cabin']
   );
 
   /* Simple fallback – swap for a branded spinner when ready */

--- a/docs/src/pages/ButtonDemoPage.tsx
+++ b/docs/src/pages/ButtonDemoPage.tsx
@@ -8,6 +8,7 @@ import {
   Box,
   Typography,
   Button,
+  Icon,
   useTheme,
   Tabs,
   Table,
@@ -133,8 +134,15 @@ export default function ButtonDemoPage() {
           <Button color="#00BFA5">#00BFA5</Button>
         </Stack>
 
-        {/* 6 ▸ Outlined overrides -------------------------------------- */}
-        <Typography variant="h3">6. Outlined colour override</Typography>
+        {/* 6 ▸ Icons & text ------------------------------------------- */}
+        <Typography variant="h3">6. Icons &amp; text</Typography>
+        <Button>
+          <Icon icon="carbon:chat" style={{ marginRight: theme.spacing(1) }} />
+          With icon
+        </Button>
+
+        {/* 7 ▸ Outlined overrides -------------------------------------- */}
+        <Typography variant="h3">7. Outlined colour override</Typography>
         <Stack direction="row">
           <Button variant="outlined">default outline</Button>
           <Button variant="outlined" color="secondary">secondary outline</Button>
@@ -144,16 +152,16 @@ export default function ButtonDemoPage() {
           </Button>
         </Stack>
 
-        {/* 7 ▸ Disabled ------------------------------------------------- */}
-        <Typography variant="h3">7. Disabled</Typography>
+        {/* 8 ▸ Disabled ------------------------------------------------- */}
+        <Typography variant="h3">8. Disabled</Typography>
         <Stack direction="row">
           <Button disabled>contained</Button>
           <Button variant="outlined" disabled>outlined</Button>
           <Button color="secondary" disabled>palette</Button>
         </Stack>
 
-        {/* 8 ▸ Custom label variants ----------------------------------- */}
-        <Typography variant="h3">8. Custom label variants</Typography>
+        {/* 9 ▸ Custom label variants ----------------------------------- */}
+        <Typography variant="h3">9. Custom label variants</Typography>
         <Stack direction="row">
           <Button><Typography variant="h4">h4 in button</Typography></Button>
           <Button><Typography variant="subtitle">subtitle text</Typography></Button>
@@ -162,8 +170,8 @@ export default function ButtonDemoPage() {
           </Button>
         </Stack>
 
-            {/* 9 ▸ Theme toggle (LAST) ------------------------------------- */}
-            <Typography variant="h3">9. Theme toggle</Typography>
+            {/* 10 ▸ Theme toggle (LAST) ------------------------------------ */}
+            <Typography variant="h3">10. Theme toggle</Typography>
             <Button variant="outlined" onClick={toggleMode}>
               Toggle light / dark mode
             </Button>

--- a/docs/src/pages/TypographyDemoPage.tsx
+++ b/docs/src/pages/TypographyDemoPage.tsx
@@ -60,7 +60,7 @@ export default function TypographyDemoPage() {
     },
     {
       prop: <code>family</code>,
-      type: <code>'heading' | 'body' | 'mono'</code>,
+      type: <code>'heading' | 'body' | 'mono' | 'button'</code>,
       default: <code>'-'</code>,
       description: 'Select a theme font family',
     },
@@ -151,6 +151,7 @@ export default function TypographyDemoPage() {
               <Typography fontFamily="Poppins">fontFamily="Poppins"</Typography>
               <Typography family="mono">family="mono"</Typography>
               <Typography family="heading">family="heading"</Typography>
+              <Typography family="button">family="button"</Typography>
               <Typography fontSize="1.5rem">fontSize="1.5rem"</Typography>
               <Typography scale={1.25}>scale=1.25</Typography>
               <Typography autoSize scale={1.25}>

--- a/src/components/fields/Button.tsx
+++ b/src/components/fields/Button.tsx
@@ -203,21 +203,21 @@ export const Button: React.FC<ButtonProps> = ({
 
   const presetClasses = p ? preset(p) : '';
 
-  const isPrimitive =
-    typeof children === 'string' || typeof children === 'number';
+  const wrapText = (node: React.ReactNode) =>
+    typeof node === 'string' || typeof node === 'number'
+      ? (
+          <Typography
+            variant="button"
+            bold
+            fontSize={font}
+            style={{ pointerEvents: 'none' }}
+          >
+            {node}
+          </Typography>
+        )
+      : node;
 
-  const content = isPrimitive ? (
-    <Typography
-      variant="button"
-      bold
-      fontSize={font}
-      style={{ pointerEvents: 'none' }}
-    >
-      {children}
-    </Typography>
-  ) : (
-    children
-  );
+  const content = React.Children.map(children, wrapText);
 
   return (
     <Root

--- a/src/components/layout/Surface.tsx
+++ b/src/components/layout/Surface.tsx
@@ -122,6 +122,7 @@ export const Surface: React.FC<SurfaceProps> = ({
     '--valet-font-heading': theme.fonts.heading,
     '--valet-font-body': theme.fonts.body,
     '--valet-font-mono': theme.fonts.mono,
+    '--valet-font-button': theme.fonts.button,
   } as any;
 
   /* Layout: fixed full‑screen or flow‑based ---------------------------- */

--- a/src/components/primitives/Typography.tsx
+++ b/src/components/primitives/Typography.tsx
@@ -34,7 +34,7 @@ export interface TypographyProps
   autoSize?: boolean;
   color?: string;
   /** Choose a theme font family */
-  family?: 'heading' | 'body' | 'mono';
+  family?: 'heading' | 'body' | 'mono' | 'button';
   fontFamily?: string;
 }
 
@@ -83,7 +83,7 @@ export const Typography: React.FC<TypographyProps> = ({
         $variant: Variant;
         $color?: string;
         $fontFamily?: string;
-        $family?: 'heading' | 'body' | 'mono';
+        $family?: 'heading' | 'body' | 'mono' | 'button';
         $size: string;
         $bold: boolean;
         $italic: boolean;
@@ -101,7 +101,7 @@ export const Typography: React.FC<TypographyProps> = ({
             ? `var(--valet-font-${$family})`
             : `var(--valet-font-${
                 $variant === 'button'
-                  ? 'mono'
+                  ? 'button'
                   : $variant.startsWith('h')
                   ? 'heading'
                   : 'body'

--- a/src/system/createInitialTheme.ts
+++ b/src/system/createInitialTheme.ts
@@ -26,6 +26,7 @@ export async function createInitialTheme(
       theme.fonts.heading,
       theme.fonts.body,
       theme.fonts.mono,
+      theme.fonts.button,
       ...extras,
     ])
   );

--- a/src/system/themeStore.ts
+++ b/src/system/themeStore.ts
@@ -18,6 +18,7 @@ export interface Theme {
     heading: string;
     body: string;
     mono: string;
+    button: string;
   };
 }
 
@@ -58,6 +59,7 @@ const common: Omit<Theme, 'colors'> = {
     heading: 'Roboto',
     body   : 'Roboto Serif',
     mono   : 'Roboto Mono',
+    button : 'Roboto Mono',
   },
 };
 


### PR DESCRIPTION
## Summary
- upgrade `<Button>` to wrap primitive children with Typography
- add `button` font family in theme and CSS vars
- teach Typography about new `button` family
- add an icon example in Button demo
- document `button` family in Typography demo
- load button font in docs

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68851fce9f7883209fc18349196928f0