### PR TITLE
Fix old Safari icon sizing

### DIFF
--- a/src/components/primitives/Icon.tsx
+++ b/src/components/primitives/Icon.tsx
@@ -88,8 +88,8 @@ export const Icon: React.FC<PropsWithChildren<IconProps>> = ({
     content = (
       <Iconify
         icon={icon}
-        width="100%"          /* Wrapper controls final px/rem size */
-        height="100%"
+        width={finalSize}
+        height={finalSize}
         color="currentColor"  /* inherits Wrapper.text-color */
         aria-hidden={spanRest['aria-label'] ? undefined : true}
         focusable="false"


### PR DESCRIPTION
## Summary
- set explicit width/height on Iconify icons to avoid huge icons on older Safari

## Testing
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688549f45ea883209429760b04f87492