### PR TITLE
Switch icon scaling to em units

### DIFF
--- a/src/components/primitives/Icon.tsx
+++ b/src/components/primitives/Icon.tsx
@@ -50,11 +50,11 @@ const Wrapper = styled('span')<{ $size: string }>`
 `;
 
 const sizeMap: Record<IconSize, string> = {
-  xs: '0.75rem',
-  sm: '1rem',
-  md: '1.5rem',
-  lg: '2.5rem',
-  xl: '4rem',
+  xs: '0.75em',
+  sm: '1em',
+  md: '1.5em',
+  lg: '2.5em',
+  xl: '4em',
 };
 
 /*───────────────────────────────────────────────────────────*/
@@ -88,7 +88,7 @@ export const Icon: React.FC<PropsWithChildren<IconProps>> = ({
     content = (
       <Iconify
         icon={icon}
-        width="100%"          /* Wrapper controls final px/rem size */
+        width="100%"          /* Wrapper controls final px/em size */
         height="100%"
         color="currentColor"  /* inherits Wrapper.text-color */
         aria-hidden={spanRest['aria-label'] ? undefined : true}


### PR DESCRIPTION
## Summary
- use `em` units for icon sizing
- note CSS comment on final size scaling

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68854db4de048320a695baee788ab1d7