### PR TITLE
Fix AppBar color on older Safari

### DIFF
--- a/src/components/layout/AppBar.tsx
+++ b/src/components/layout/AppBar.tsx
@@ -40,6 +40,12 @@ const Bar = styled('header')<{
   right: 0;
   z-index: 10000;
   background: ${({ $bg }) => $bg};
+  background-color: ${({ $bg }) => $bg};
+  --valet-bg: ${({ $bg }) => $bg};
+  --valet-text-color: ${({ $text }) => $text};
+  will-change: transform;
+  -webkit-transform: translateZ(0);
+  transform: translateZ(0);
   color: ${({ $text }) => $text};
   & > * {
     padding: ${({ $pad }) => $pad};


### PR DESCRIPTION
## Summary
- ensure AppBar background color renders on older Safari versions

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688552557dcc832091ae039bbf17c0b6