### PR TITLE
Fix AppBar color on older Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+- Reworked `AppBar` to ensure background color renders on older Safari
 
 ## [0.21.1]
 - Adjusted `Icon` sizing for better iOS / Safari support

--- a/src/components/layout/AppBar.tsx
+++ b/src/components/layout/AppBar.tsx
@@ -25,11 +25,7 @@ export interface AppBarProps
 }
 
 /*───────────────────────────────────────────────────────────*/
-const Bar = styled('header')<{
-  $bg: string;
-  $text: string;
-  $pad: string;
-}>`
+const Bar = styled('header')<{ $text: string; $pad: string }>`
   box-sizing: border-box;
   display: flex;
   align-items: center;
@@ -39,11 +35,18 @@ const Bar = styled('header')<{
   left: 0;
   right: 0;
   z-index: 10000;
-  background: ${({ $bg }) => $bg};
   color: ${({ $text }) => $text};
   & > * {
     padding: ${({ $pad }) => $pad};
   }
+`;
+
+const BarBg = styled('div')<{ $bg: string }>`
+  position: absolute;
+  inset: 0;
+  background: ${({ $bg }) => $bg};
+  pointer-events: none;
+  z-index: -1;
 `;
 
 const LeftWrap = styled('div')<{ $gap: string }>`
@@ -121,12 +124,18 @@ export const AppBar: React.FC<AppBarProps> = ({
     <Bar
       ref={ref}
       {...rest}
-      $bg={bg}
       $text={text}
       $pad={pad}
       className={[presetClass, className].filter(Boolean).join(' ')}
-      style={style}
+      style={{
+        '--valet-bg': bg,
+        '--valet-text-color': text,
+        background: bg,
+        color: text,
+        ...style,
+      } as React.CSSProperties}
     >
+      <BarBg $bg={bg} />
       <LeftWrap $gap={gap}>
         {iconPlacement === 'left' && icon}
         {children}


### PR DESCRIPTION
## Summary
- ensure AppBar background color renders on older Safari versions

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688552557dcc832091ae039bbf17c0b6