### PR TITLE
Add MetroSelect component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file. The format 
 ## Unreleased
 - Reworked `AppBar` to ensure background color renders on older Safari
 - Portaled `AppBar` to `document.body` to fix background color bug on old Safari
+- Added `MetroSelect` component
+- `MetroSelect` tiles now spaced via flexbox rather than Grid
 
 ## [0.21.1]
 - Adjusted `Icon` sizing for better iOS / Safari support

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -52,6 +52,7 @@ const PaginationDemoPage    = page(() => import('./pages/PaginationDemo'));
 const SpeedDialDemoPage     = page(() => import('./pages/SpeedDialDemo'));
 const StepperDemoPage       = page(() => import('./pages/StepperDemo'));
 const RadioGroupDemoPage    = page(() => import('./pages/RadioGroupDemo'));
+const MetroSelectDemoPage   = page(() => import('./pages/MetroSelectDemo'));
 const VideoDemoPage         = page(() => import('./pages/VideoDemo'));
 const SnackbarDemoPage      = page(() => import('./pages/SnackbarDemo'));
 const TreeDemoPage          = page(() => import('./pages/TreeDemo'));
@@ -124,6 +125,7 @@ export function App() {
         <Route path="/pagination-demo" element={<PaginationDemoPage />} />
         <Route path="/speeddial-demo"  element={<SpeedDialDemoPage />} />
         <Route path="/stepper-demo"    element={<StepperDemoPage />} />
+        <Route path="/metroselect-demo" element={<MetroSelectDemoPage />} />
         <Route path="/radio-demo"      element={<RadioGroupDemoPage />} />
         <Route path="/video-demo"      element={<VideoDemoPage />} />
         <Route path="/dropzone-demo"   element={<DropzoneDemoPage />} />

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -45,6 +45,7 @@ const fields: [string, string][] = [
   ['Date Selector', '/dateselector-demo'],
   ['Icon Button', '/icon-button-demo'],
   ['Select', '/select-demo'],
+  ['Metro Select', '/metroselect-demo'],
   ['Iterator', '/iterator-demo'],
   ['Slider', '/slider-demo'],
   ['Switch', '/switch-demo'],

--- a/docs/src/pages/MetroSelectDemo.tsx
+++ b/docs/src/pages/MetroSelectDemo.tsx
@@ -1,0 +1,36 @@
+// src/pages/MetroSelectDemo.tsx
+import { Surface, Stack, Typography, Button, MetroSelect, useTheme } from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
+
+export default function MetroSelectDemoPage() {
+  const { toggleMode } = useTheme();
+  const navigate = useNavigate();
+
+  const options = [
+    { icon: 'mdi:home', label: 'Home', value: 'home' },
+    { icon: 'mdi:briefcase', label: 'Work', value: 'work' },
+    { icon: 'mdi:airplane', label: 'Travel', value: 'travel' },
+  ];
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack>
+        <Typography variant="h2" bold>MetroSelect Showcase</Typography>
+        <Typography variant="subtitle">Grid style single choice</Typography>
+
+        <MetroSelect gap={4}>
+          {options.map((o) => (
+            <MetroSelect.Option key={o.value} icon={o.icon} value={o.value} label={o.label} />
+          ))}
+        </MetroSelect>
+
+        <Stack direction="row">
+          <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
+          <Button onClick={() => navigate(-1)}>← Back</Button>
+        </Stack>
+      </Stack>
+    </Surface>
+  );
+}

--- a/src/components/fields/MetroSelect.tsx
+++ b/src/components/fields/MetroSelect.tsx
@@ -1,0 +1,179 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/fields/MetroSelect.tsx | valet
+// windows 8 start screen style grid select
+// ─────────────────────────────────────────────────────────────
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import { styled } from '../../css/createStyled';
+import Panel from '../layout/Panel';
+import { Icon } from '../primitives/Icon';
+import { Typography } from '../primitives/Typography';
+import { useTheme } from '../../system/themeStore';
+import { preset } from '../../css/stylePresets';
+import type { Presettable } from '../../types';
+
+export type Primitive = string | number;
+
+interface MetroCtx {
+  value: Primitive | null;
+  setValue: (v: Primitive) => void;
+}
+
+const MetroCtx = createContext<MetroCtx | null>(null);
+const useMetro = () => {
+  const ctx = useContext(MetroCtx);
+  if (!ctx) throw new Error('MetroSelect.Option must be inside MetroSelect');
+  return ctx;
+};
+
+const Container = styled('div')<{ $gap: string }>`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${({ $gap }) => $gap};
+`;
+
+export interface MetroSelectProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'>,
+    Presettable {
+  value?: Primitive;
+  defaultValue?: Primitive;
+  /** Spacing between option tiles */
+  gap?: number | string;
+  onChange?: (v: Primitive) => void;
+  children: React.ReactNode;
+}
+
+export interface MetroOptionProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    Presettable {
+  value: Primitive;
+  icon: string | React.ReactElement;
+  label: React.ReactNode;
+  disabled?: boolean;
+  size?: number | string;
+}
+
+export const Option: React.FC<MetroOptionProps> = ({
+  value,
+  icon,
+  label,
+  disabled = false,
+  size = '6rem',
+  preset: p,
+  style,
+  className,
+  ...rest
+}) => {
+  const { theme } = useTheme();
+  const { value: sel, setValue } = useMetro();
+
+  const selected = sel !== null && String(sel) === String(value);
+
+  const dim = typeof size === 'number' ? `${size}px` : String(size);
+  const presetCls = p ? preset(p) : '';
+
+  const innerStyle: React.CSSProperties = {
+    paddingTop: theme.spacing(4),
+    paddingBottom: theme.spacing(4),
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: theme.spacing(0.25),
+    height: '100%',
+    width: '100%',
+  };
+
+  return (
+    <Panel
+      {...rest}
+      variant="alt"
+      compact
+      onClick={() => !disabled && setValue(value)}
+      style={{
+        width: dim,
+        height: dim,
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderColor: selected ? theme.colors.primary : undefined,
+        background: selected ? theme.colors.primary : undefined,
+        color: selected ? theme.colors.primaryText : undefined,
+        ...style,
+      }}
+      className={[presetCls, className].filter(Boolean).join(' ')}
+    >
+      <div style={innerStyle}>
+        {typeof icon === 'string' ? (
+          <Icon icon={icon} size="xl" />
+        ) : (
+          <Icon size="xl">{icon}</Icon>
+        )}
+        <Typography variant="h5" centered>
+          {label}
+        </Typography>
+      </div>
+    </Panel>
+  );
+};
+Option.displayName = 'MetroSelect.Option';
+
+export const MetroSelect: React.FC<MetroSelectProps> = ({
+  value: valueProp,
+  defaultValue,
+  gap = 4,
+  onChange,
+  preset: p,
+  className,
+  style,
+  children,
+  ...rest
+}) => {
+    const { theme } = useTheme();
+    const controlled = valueProp !== undefined;
+    const [self, setSelf] = useState<Primitive | null>(defaultValue ?? null);
+
+    const val = controlled ? valueProp! : self;
+
+    const setValue = useCallback(
+      (v: Primitive) => {
+        if (!controlled) setSelf(v);
+        onChange?.(v);
+      },
+      [controlled, onChange],
+    );
+
+    const presetCls = p ? preset(p) : '';
+    const g = typeof gap === 'number' ? theme.spacing(gap) : String(gap);
+
+    const ctx = useMemo<MetroCtx>(
+      () => ({ value: val ?? null, setValue }),
+      [val, setValue],
+    );
+
+    return (
+      <MetroCtx.Provider value={ctx}>
+        <Container
+          {...rest}
+          $gap={g}
+          style={style}
+          className={[presetCls, className].filter(Boolean).join(' ')}
+        >
+          {children}
+        </Container>
+      </MetroCtx.Provider>
+    );
+  };
+
+MetroSelect.displayName = 'MetroSelect';
+(MetroSelect as any).Option = Option;
+
+export default MetroSelect;

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,11 @@ export type {
   SelectProps,
   OptionProps as SelectOptionProps,
 } from './components/fields/Select';
+export { default as MetroSelect } from './components/fields/MetroSelect';
+export type {
+  MetroSelectProps,
+  MetroOptionProps,
+} from './components/fields/MetroSelect';
 export * from './components/fields/Slider';
 export * from './components/fields/Switch';
 export * from './components/fields/TextField';


### PR DESCRIPTION
## Summary
- introduce MetroSelect for grid-style single selection
- document MetroSelect in docs and navigation
- export MetroSelect from package
- update changelog
- tweak MetroSelect spacing
- refine MetroSelect layout

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6886ac64de80832099fd7fd3fcddce62