### PR TITLE
Add MetroSelect component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. The format 
 - Portaled `AppBar` to `document.body` to fix background color bug on old Safari
 - Added `MetroSelect` component
 - Tweaked `MetroSelect` layout and spacing
+- Documented `MetroSelect` with usage and reference demos
 
 ## [0.21.1]
 - Adjusted `Icon` sizing for better iOS / Safari support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. The format 
 - Added `MetroSelect` component
 - Tweaked `MetroSelect` layout and spacing
 - Documented `MetroSelect` with usage and reference demos
+- Removed `size` prop from `MetroSelect.Option`; tiles use fixed 6rem size
 
 ## [0.21.1]
 - Adjusted `Icon` sizing for better iOS / Safari support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file. The format 
 ## Unreleased
 - Reworked `AppBar` to ensure background color renders on older Safari
 - Portaled `AppBar` to `document.body` to fix background color bug on old Safari
+- Added `MetroSelect` component
+- Tweaked `MetroSelect` layout and spacing
 
 ## [0.21.1]
 - Adjusted `Icon` sizing for better iOS / Safari support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to this project will be documented in this file. The format 
 - Added `MetroSelect` component
 - Tweaked `MetroSelect` layout and spacing
 - Documented `MetroSelect` with usage and reference demos
-- Removed `size` prop from `MetroSelect.Option`; tiles use fixed 6rem size
+- Removed `size` prop from `MetroSelect.Option`; tiles are now 4rem and icons are medium
 
 ## [0.21.1]
 - Adjusted `Icon` sizing for better iOS / Safari support

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -52,6 +52,7 @@ const PaginationDemoPage    = page(() => import('./pages/PaginationDemo'));
 const SpeedDialDemoPage     = page(() => import('./pages/SpeedDialDemo'));
 const StepperDemoPage       = page(() => import('./pages/StepperDemo'));
 const RadioGroupDemoPage    = page(() => import('./pages/RadioGroupDemo'));
+const MetroSelectDemoPage   = page(() => import('./pages/MetroSelectDemo'));
 const VideoDemoPage         = page(() => import('./pages/VideoDemo'));
 const SnackbarDemoPage      = page(() => import('./pages/SnackbarDemo'));
 const TreeDemoPage          = page(() => import('./pages/TreeDemo'));
@@ -124,6 +125,7 @@ export function App() {
         <Route path="/pagination-demo" element={<PaginationDemoPage />} />
         <Route path="/speeddial-demo"  element={<SpeedDialDemoPage />} />
         <Route path="/stepper-demo"    element={<StepperDemoPage />} />
+        <Route path="/metroselect-demo" element={<MetroSelectDemoPage />} />
         <Route path="/radio-demo"      element={<RadioGroupDemoPage />} />
         <Route path="/video-demo"      element={<VideoDemoPage />} />
         <Route path="/dropzone-demo"   element={<DropzoneDemoPage />} />

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -45,6 +45,7 @@ const fields: [string, string][] = [
   ['Date Selector', '/dateselector-demo'],
   ['Icon Button', '/icon-button-demo'],
   ['Select', '/select-demo'],
+  ['Metro Select', '/metroselect-demo'],
   ['Iterator', '/iterator-demo'],
   ['Slider', '/slider-demo'],
   ['Switch', '/switch-demo'],

--- a/docs/src/pages/MetroSelectDemo.tsx
+++ b/docs/src/pages/MetroSelectDemo.tsx
@@ -102,12 +102,6 @@ export default function MetroSelectDemoPage() {
       description: 'Text displayed below the icon',
     },
     {
-      prop: <code>size</code>,
-      type: <code>number | string</code>,
-      default: <code>'6rem'</code>,
-      description: 'Tile width and height',
-    },
-    {
       prop: <code>disabled</code>,
       type: <code>boolean</code>,
       default: <code>false</code>,
@@ -193,13 +187,6 @@ export default function MetroSelectDemoPage() {
                 <MetroSelect.Option key={o.value} {...o} />
               ))}
             </MetroSelect>
-
-            <Typography variant="h3">4. Custom size</Typography>
-            <MetroSelect gap={4}>
-              <MetroSelect.Option value="big" icon="mdi:star" label="Big" size="7rem" />
-              <MetroSelect.Option value="sm" icon="mdi:star-outline" label="Small" size="4rem" />
-            </MetroSelect>
-
             <Stack direction="row">
               <Button variant="outlined" onClick={toggleMode}>
                 Toggle light / dark

--- a/docs/src/pages/MetroSelectDemo.tsx
+++ b/docs/src/pages/MetroSelectDemo.tsx
@@ -1,0 +1,36 @@
+// src/pages/MetroSelectDemo.tsx
+import { Surface, Stack, Typography, Button, MetroSelect, useTheme } from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
+
+export default function MetroSelectDemoPage() {
+  const { toggleMode } = useTheme();
+  const navigate = useNavigate();
+
+  const options = [
+    { icon: 'mdi:home', label: 'Home', value: 'home' },
+    { icon: 'mdi:briefcase', label: 'Work', value: 'work' },
+    { icon: 'mdi:airplane', label: 'Travel', value: 'travel' },
+  ];
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack>
+        <Typography variant="h2" bold>MetroSelect Showcase</Typography>
+        <Typography variant="subtitle">Grid style single choice</Typography>
+
+        <MetroSelect gap={4}>
+          {options.map((o) => (
+            <MetroSelect.Option key={o.value} icon={o.icon} value={o.value} label={o.label} />
+          ))}
+        </MetroSelect>
+
+        <Stack direction="row">
+          <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
+          <Button onClick={() => navigate(-1)}>← Back</Button>
+        </Stack>
+      </Stack>
+    </Surface>
+  );
+}

--- a/docs/src/pages/MetroSelectDemo.tsx
+++ b/docs/src/pages/MetroSelectDemo.tsx
@@ -1,35 +1,223 @@
-// src/pages/MetroSelectDemo.tsx
-import { Surface, Stack, Typography, Button, MetroSelect, useTheme } from '@archway/valet';
+// ─────────────────────────────────────────────────────────────
+// src/pages/MetroSelectDemo.tsx | valet
+// Showcase of MetroSelect component
+// ─────────────────────────────────────────────────────────────
+import React, { useState } from 'react';
+import {
+  Surface,
+  Stack,
+  Typography,
+  Button,
+  MetroSelect,
+  Tabs,
+  Table,
+  useTheme,
+} from '@archway/valet';
+import type { TableColumn } from '@archway/valet';
+import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import NavDrawer from '../components/NavDrawer';
 
 export default function MetroSelectDemoPage() {
-  const { toggleMode } = useTheme();
+  const { theme, toggleMode } = useTheme();
   const navigate = useNavigate();
 
-  const options = [
+  interface Row {
+    prop: ReactNode;
+    type: ReactNode;
+    default: ReactNode;
+    description: ReactNode;
+  }
+
+  const columns: TableColumn<Row>[] = [
+    { header: 'Prop', accessor: 'prop' },
+    { header: 'Type', accessor: 'type' },
+    { header: 'Default', accessor: 'default' },
+    { header: 'Description', accessor: 'description' },
+  ];
+
+  const data: Row[] = [
+    {
+      prop: <code>value</code>,
+      type: <code>string | number</code>,
+      default: <code>-</code>,
+      description: 'Controlled value',
+    },
+    {
+      prop: <code>defaultValue</code>,
+      type: <code>string | number</code>,
+      default: <code>-</code>,
+      description: 'Uncontrolled initial value',
+    },
+    {
+      prop: <code>gap</code>,
+      type: <code>number | string</code>,
+      default: <code>4</code>,
+      description: 'Spacing between tiles (theme units if number)',
+    },
+    {
+      prop: <code>onChange</code>,
+      type: <code>(val: Primitive) =&gt; void</code>,
+      default: <code>-</code>,
+      description: 'Change handler',
+    },
+    {
+      prop: <code>preset</code>,
+      type: <code>string | string[]</code>,
+      default: <code>-</code>,
+      description: 'Apply style presets',
+    },
+    {
+      prop: <code>children</code>,
+      type: <code>React.ReactNode</code>,
+      default: <code>-</code>,
+      description: 'MetroSelect.Option elements',
+    },
+  ];
+
+  const optionColumns: TableColumn<Row>[] = [
+    { header: 'Prop', accessor: 'prop' },
+    { header: 'Type', accessor: 'type' },
+    { header: 'Default', accessor: 'default' },
+    { header: 'Description', accessor: 'description' },
+  ];
+
+  const optionData: Row[] = [
+    {
+      prop: <code>value</code>,
+      type: <code>string | number</code>,
+      default: <code>-</code>,
+      description: 'Value for selection',
+    },
+    {
+      prop: <code>icon</code>,
+      type: <code>string | ReactElement</code>,
+      default: <code>-</code>,
+      description: 'Icon element or Iconify name',
+    },
+    {
+      prop: <code>label</code>,
+      type: <code>React.ReactNode</code>,
+      default: <code>-</code>,
+      description: 'Text displayed below the icon',
+    },
+    {
+      prop: <code>size</code>,
+      type: <code>number | string</code>,
+      default: <code>'6rem'</code>,
+      description: 'Tile width and height',
+    },
+    {
+      prop: <code>disabled</code>,
+      type: <code>boolean</code>,
+      default: <code>false</code>,
+      description: 'Disable selection',
+    },
+    {
+      prop: <code>preset</code>,
+      type: <code>string | string[]</code>,
+      default: <code>-</code>,
+      description: 'Apply style presets',
+    },
+  ];
+
+  // Sample option lists -------------------------------------------------
+  const basic = [
     { icon: 'mdi:home', label: 'Home', value: 'home' },
     { icon: 'mdi:briefcase', label: 'Work', value: 'work' },
     { icon: 'mdi:airplane', label: 'Travel', value: 'travel' },
+  ];
+
+  const [transport, setTransport] = useState('car');
+  const controlled = [
+    { icon: 'mdi:car', label: 'Car', value: 'car' },
+    { icon: 'mdi:bike', label: 'Bike', value: 'bike' },
+    { icon: 'mdi:train', label: 'Train', value: 'train' },
+  ];
+
+  const many = [
+    { icon: 'mdi:home', value: 'home', label: 'Home' },
+    { icon: 'mdi:briefcase', value: 'work', label: 'Work' },
+    { icon: 'mdi:airplane', value: 'travel', label: 'Travel' },
+    { icon: 'mdi:school', value: 'school', label: 'School' },
+    { icon: 'mdi:cog', value: 'settings', label: 'Settings' },
+    { icon: 'mdi:information', value: 'info', label: 'Info' },
+    { icon: 'mdi:music', value: 'music', label: 'Music' },
+    { icon: 'mdi:film', value: 'film', label: 'Film' },
+    { icon: 'mdi:email', value: 'email', label: 'Email' },
+    { icon: 'mdi:message', value: 'chat', label: 'Chat' },
+    { icon: 'mdi:camera', value: 'camera', label: 'Camera' },
+    { icon: 'mdi:gamepad-variant', value: 'games', label: 'Games' },
+    { icon: 'mdi:phone', value: 'phone', label: 'Phone' },
+    { icon: 'mdi:wifi', value: 'wifi', label: 'WiFi' },
+    { icon: 'mdi:bluetooth', value: 'bt', label: 'Bluetooth' },
+    { icon: 'mdi:power', value: 'power', label: 'Power' },
   ];
 
   return (
     <Surface>
       <NavDrawer />
       <Stack>
-        <Typography variant="h2" bold>MetroSelect Showcase</Typography>
-        <Typography variant="subtitle">Grid style single choice</Typography>
+        <Typography variant="h2" bold>
+          MetroSelect
+        </Typography>
+        <Typography variant="subtitle">
+          Touch-friendly grid selection
+        </Typography>
 
-        <MetroSelect gap={4}>
-          {options.map((o) => (
-            <MetroSelect.Option key={o.value} icon={o.icon} value={o.value} label={o.label} />
-          ))}
-        </MetroSelect>
+        <Tabs>
+          <Tabs.Tab label="Usage" />
+          <Tabs.Panel>
+            <Typography variant="h3">1. Uncontrolled</Typography>
+            <MetroSelect defaultValue="home" gap={4}>
+              {basic.map((o) => (
+                <MetroSelect.Option key={o.value} {...o} />
+              ))}
+            </MetroSelect>
 
-        <Stack direction="row">
-          <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
-          <Button onClick={() => navigate(-1)}>← Back</Button>
-        </Stack>
+            <Typography variant="h3">2. Controlled value</Typography>
+            <MetroSelect
+              value={transport}
+              onChange={(v) => setTransport(v as string)}
+              gap={4}
+            >
+              {controlled.map((o) => (
+                <MetroSelect.Option key={o.value} {...o} />
+              ))}
+            </MetroSelect>
+            <Typography>Current: <b>{transport}</b></Typography>
+
+            <Typography variant="h3">3. Many options</Typography>
+            <MetroSelect gap={4}>
+              {many.map((o) => (
+                <MetroSelect.Option key={o.value} {...o} />
+              ))}
+            </MetroSelect>
+
+            <Typography variant="h3">4. Custom size</Typography>
+            <MetroSelect gap={4}>
+              <MetroSelect.Option value="big" icon="mdi:star" label="Big" size="7rem" />
+              <MetroSelect.Option value="sm" icon="mdi:star-outline" label="Small" size="4rem" />
+            </MetroSelect>
+
+            <Stack direction="row">
+              <Button variant="outlined" onClick={toggleMode}>
+                Toggle light / dark
+              </Button>
+              <Button onClick={() => navigate(-1)}>← Back</Button>
+            </Stack>
+          </Tabs.Panel>
+
+          <Tabs.Tab label="Reference" />
+          <Tabs.Panel>
+            <Typography variant="h3">MetroSelect props</Typography>
+            <Table data={data} columns={columns} constrainHeight={false} />
+            <Typography variant="h3" style={{ marginTop: theme.spacing(3) }}>
+              Option props
+            </Typography>
+            <Table data={optionData} columns={optionColumns} constrainHeight={false} />
+          </Tabs.Panel>
+        </Tabs>
       </Stack>
     </Surface>
   );

--- a/src/components/fields/MetroSelect.tsx
+++ b/src/components/fields/MetroSelect.tsx
@@ -87,9 +87,9 @@ export const Option: React.FC<MetroOptionProps> = ({
       variant="alt"
       compact
       onClick={() => !disabled && setValue(value)}
-    style={{
-        width: '6rem',
-        height: '6rem',
+      style={{
+        width: '4rem',
+        height: '4rem',
         cursor: disabled ? 'not-allowed' : 'pointer',
         display: 'flex',
         alignItems: 'center',
@@ -102,10 +102,10 @@ export const Option: React.FC<MetroOptionProps> = ({
       className={[presetCls, className].filter(Boolean).join(' ')}
     >
       <div style={innerStyle}>
-        {typeof icon === 'string' ? (
-          <Icon icon={icon} size="xl" />
+          {typeof icon === 'string' ? (
+          <Icon icon={icon} size="md" />
         ) : (
-          <Icon size="xl">{icon}</Icon>
+          <Icon size="md">{icon}</Icon>
         )}
         <Typography variant="h5" centered>
           {label}

--- a/src/components/fields/MetroSelect.tsx
+++ b/src/components/fields/MetroSelect.tsx
@@ -76,7 +76,7 @@ export const Option: React.FC<MetroOptionProps> = ({
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
-    gap: theme.spacing(0.25),
+    gap: theme.spacing(1),
     height: '100%',
     width: '100%',
   };
@@ -88,8 +88,8 @@ export const Option: React.FC<MetroOptionProps> = ({
       compact
       onClick={() => !disabled && setValue(value)}
       style={{
-        width: '4rem',
-        height: '4rem',
+        width: '6rem',
+        height: '6rem',
         cursor: disabled ? 'not-allowed' : 'pointer',
         display: 'flex',
         alignItems: 'center',
@@ -103,11 +103,11 @@ export const Option: React.FC<MetroOptionProps> = ({
     >
       <div style={innerStyle}>
           {typeof icon === 'string' ? (
-          <Icon icon={icon} size="md" />
+          <Icon icon={icon} size="lg" />
         ) : (
-          <Icon size="md">{icon}</Icon>
+          <Icon size="lg">{icon}</Icon>
         )}
-        <Typography variant="h5" centered>
+        <Typography variant="h6" centered>
           {label}
         </Typography>
       </div>
@@ -124,7 +124,7 @@ export interface MetroSelectComponent
 export const MetroSelect: MetroSelectComponent = ({
   value: valueProp,
   defaultValue,
-  gap = 4,
+  gap = 0,
   onChange,
   preset: p,
   className,
@@ -157,7 +157,7 @@ export const MetroSelect: MetroSelectComponent = ({
         <Stack
           direction="row"
           wrap
-          spacing={gap}
+          spacing={0.5 * Number(gap)}
           compact
           {...rest}
           style={style}

--- a/src/components/fields/MetroSelect.tsx
+++ b/src/components/fields/MetroSelect.tsx
@@ -1,0 +1,178 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/fields/MetroSelect.tsx | valet
+// windows 8 start screen style grid select
+// ─────────────────────────────────────────────────────────────
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
+import Stack from '../layout/Stack';
+import Panel from '../layout/Panel';
+import { Icon } from '../primitives/Icon';
+import { Typography } from '../primitives/Typography';
+import { useTheme } from '../../system/themeStore';
+import { preset } from '../../css/stylePresets';
+import type { Presettable } from '../../types';
+
+export type Primitive = string | number;
+
+interface MetroCtx {
+  value: Primitive | null;
+  setValue: (v: Primitive) => void;
+}
+
+const MetroCtx = createContext<MetroCtx | null>(null);
+const useMetro = () => {
+  const ctx = useContext(MetroCtx);
+  if (!ctx) throw new Error('MetroSelect.Option must be inside MetroSelect');
+  return ctx;
+};
+
+export interface MetroSelectProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange'>,
+    Presettable {
+  value?: Primitive;
+  defaultValue?: Primitive;
+  gap?: number | string;
+  onChange?: (v: Primitive) => void;
+  children: React.ReactNode;
+}
+
+export interface MetroOptionProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    Presettable {
+  value: Primitive;
+  icon: string | React.ReactElement;
+  label: React.ReactNode;
+  disabled?: boolean;
+  size?: number | string;
+}
+
+export const Option: React.FC<MetroOptionProps> = ({
+  value,
+  icon,
+  label,
+  disabled = false,
+  size = '6rem',
+  preset: p,
+  style,
+  className,
+  ...rest
+}) => {
+  const { theme } = useTheme();
+  const { value: sel, setValue } = useMetro();
+
+  const selected = sel !== null && String(sel) === String(value);
+
+  const dim = typeof size === 'number' ? `${size}px` : String(size);
+  const presetCls = p ? preset(p) : '';
+
+  const innerStyle: React.CSSProperties = {
+    paddingTop: theme.spacing(3),
+    paddingBottom: theme.spacing(3),
+    paddingLeft: theme.spacing(1),
+    paddingRight: theme.spacing(1),
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: theme.spacing(0.25),
+    height: '100%',
+    width: '100%',
+  };
+
+  return (
+    <Panel
+      {...rest}
+      variant="alt"
+      compact
+      onClick={() => !disabled && setValue(value)}
+      style={{
+        width: dim,
+        height: dim,
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderColor: selected ? theme.colors.primary : undefined,
+        background: selected ? theme.colors.primary : undefined,
+        color: selected ? theme.colors.primaryText : undefined,
+        ...style,
+      }}
+      className={[presetCls, className].filter(Boolean).join(' ')}
+    >
+      <div style={innerStyle}>
+        {typeof icon === 'string' ? (
+          <Icon icon={icon} size="xl" />
+        ) : (
+          <Icon size="xl">{icon}</Icon>
+        )}
+        <Typography variant="h5" centered>
+          {label}
+        </Typography>
+      </div>
+    </Panel>
+  );
+};
+Option.displayName = 'MetroSelect.Option';
+
+export interface MetroSelectComponent
+  extends React.FC<MetroSelectProps> {
+  Option: React.FC<MetroOptionProps>;
+}
+
+export const MetroSelect: MetroSelectComponent = ({
+  value: valueProp,
+  defaultValue,
+  gap = 4,
+  onChange,
+  preset: p,
+  className,
+  style,
+  children,
+  ...rest
+}) => {
+    const controlled = valueProp !== undefined;
+    const [self, setSelf] = useState<Primitive | null>(defaultValue ?? null);
+
+    const val = controlled ? valueProp! : self;
+
+    const setValue = useCallback(
+      (v: Primitive) => {
+        if (!controlled) setSelf(v);
+        onChange?.(v);
+      },
+      [controlled, onChange],
+    );
+
+    const presetCls = p ? preset(p) : '';
+
+    const ctx = useMemo<MetroCtx>(
+      () => ({ value: val ?? null, setValue }),
+      [val, setValue],
+    );
+
+    return (
+      <MetroCtx.Provider value={ctx}>
+        <Stack
+          direction="row"
+          wrap
+          spacing={gap}
+          compact
+          {...rest}
+          style={style}
+          className={[presetCls, className].filter(Boolean).join(' ')}
+        >
+          {children}
+        </Stack>
+      </MetroCtx.Provider>
+    );
+  };
+
+MetroSelect.displayName = 'MetroSelect';
+MetroSelect.Option = Option;
+
+export default MetroSelect;

--- a/src/components/fields/MetroSelect.tsx
+++ b/src/components/fields/MetroSelect.tsx
@@ -48,7 +48,6 @@ export interface MetroOptionProps
   icon: string | React.ReactElement;
   label: React.ReactNode;
   disabled?: boolean;
-  size?: number | string;
 }
 
 export const Option: React.FC<MetroOptionProps> = ({
@@ -56,7 +55,6 @@ export const Option: React.FC<MetroOptionProps> = ({
   icon,
   label,
   disabled = false,
-  size = '6rem',
   preset: p,
   style,
   className,
@@ -67,7 +65,6 @@ export const Option: React.FC<MetroOptionProps> = ({
 
   const selected = sel !== null && String(sel) === String(value);
 
-  const dim = typeof size === 'number' ? `${size}px` : String(size);
   const presetCls = p ? preset(p) : '';
 
   const innerStyle: React.CSSProperties = {
@@ -90,9 +87,9 @@ export const Option: React.FC<MetroOptionProps> = ({
       variant="alt"
       compact
       onClick={() => !disabled && setValue(value)}
-      style={{
-        width: dim,
-        height: dim,
+    style={{
+        width: '6rem',
+        height: '6rem',
         cursor: disabled ? 'not-allowed' : 'pointer',
         display: 'flex',
         alignItems: 'center',

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,11 @@ export type {
   SelectProps,
   OptionProps as SelectOptionProps,
 } from './components/fields/Select';
+export { default as MetroSelect } from './components/fields/MetroSelect';
+export type {
+  MetroSelectProps,
+  MetroOptionProps,
+} from './components/fields/MetroSelect';
 export * from './components/fields/Slider';
 export * from './components/fields/Switch';
 export * from './components/fields/TextField';


### PR DESCRIPTION
## Summary
- introduce MetroSelect for grid-style single selection
- document MetroSelect in docs and navigation
- export MetroSelect from package
- update changelog
- tweak MetroSelect spacing
- refine MetroSelect layout

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6886ac64de80832099fd7fd3fcddce62