### PR TITLE
Fix MetroSelect scroll on mobile

### DIFF
--- a/src/components/fields/MetroSelect.tsx
+++ b/src/components/fields/MetroSelect.tsx
@@ -90,6 +90,7 @@ export const Option: React.FC<MetroOptionProps> = ({
       style={{
         width: '6rem',
         height: '6rem',
+        overflow: 'hidden',
         cursor: disabled ? 'not-allowed' : 'pointer',
         display: 'flex',
         alignItems: 'center',


### PR DESCRIPTION
## Summary
- prevent internal scrolling in MetroSelect options

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6886bd4035e08320a78609bd9128e09b