### PR TITLE
Add local font support

### DIFF
--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -5,6 +5,7 @@
 import React, { Suspense, lazy }   from 'react';
 import { Routes, Route }           from 'react-router-dom';
 import { useInitialTheme, Surface, Stack, Typography } from '@archway/valet';
+import brandon from './assets/fonts/BrandonGrotesque.otf';
 
 /*───────────────────────────────────────────────────────────*/
 /* Helper – terse lazy() wrapper                            */
@@ -69,8 +70,9 @@ const PropPatternsPage      = page(() => import('./pages/PropPatterns'));
 export function App() {
   /* One-time initial theme + Google-font preload */
   useInitialTheme(
-    { fonts: { heading: 'Cabin', body: 'Cabin', mono: 'Ubuntu Mono', button: 'Ubuntu' } },
-    ['Ubuntu', 'Ubuntu Mono', 'Cabin']
+    { fonts: { heading: 'Cabin', body: 'Brandon', mono: 'Ubuntu Mono', button: 'Ubuntu' } },
+    ['Ubuntu', 'Ubuntu Mono', 'Cabin'],
+    { local: [{ name: 'Brandon', src: brandon }] }
   );
 
   /* Simple fallback – swap for a branded spinner when ready */

--- a/docs/src/pages/TypographyDemoPage.tsx
+++ b/docs/src/pages/TypographyDemoPage.tsx
@@ -149,6 +149,7 @@ export default function TypographyDemoPage() {
             <Typography variant="h3">Font &amp; size overrides</Typography>
             <Panel compact>
               <Typography fontFamily="Poppins">fontFamily="Poppins"</Typography>
+              <Typography fontFamily="Brandon">fontFamily="Brandon"</Typography>
               <Typography family="mono">family="mono"</Typography>
               <Typography family="heading">family="heading"</Typography>
               <Typography family="button">family="button"</Typography>

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,3 +70,4 @@ export * from './system/themeStore';
 export * from './system/fontStore';
 export * from './system/createInitialTheme';
 export * from './hooks/useGoogleFonts';
+export type { LocalFont } from './helpers/fontLoader';

--- a/src/system/createInitialTheme.ts
+++ b/src/system/createInitialTheme.ts
@@ -9,6 +9,8 @@ import { useEffect } from 'react';
 import {
   injectGoogleFontLinks,
   waitForGoogleFonts,
+  injectLocalFontFaces,
+  waitForLocalFonts,
   GoogleFontOptions,
 } from '../helpers/fontLoader';
 
@@ -31,8 +33,12 @@ export async function createInitialTheme(
     ])
   );
   injectGoogleFontLinks(fonts, options);
+  injectLocalFontFaces(options?.local || []);
   start();
-  await waitForGoogleFonts(fonts);
+  await Promise.all([
+    waitForGoogleFonts(fonts),
+    waitForLocalFonts(options?.local || []),
+  ]);
   finish();
 }
 


### PR DESCRIPTION
## Summary
- extend `fontLoader` with LocalFont interface and utilities
- load custom fonts in hooks and `useInitialTheme`
- expose LocalFont from package index
- demo Brandon Grotesque in docs via local font loader

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6887a4d479d883208622e4f75800912b