### PR TITLE
Add custom font support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+## [0.22.0]
+- Added support support for local OTF font files
+
 ## [0.21.3]
 - Adjusted internal Zustand store setup
 
@@ -300,6 +303,7 @@ responsive logic uses the selected `Surface` element to handle persistent margin
 ### Other
 - vibe coded
 
+[v0.22.0]: https://github.com/off-court-creations/valet/releases/tag/v0.22.0
 [v0.21.3]: https://github.com/off-court-creations/valet/releases/tag/v0.21.3
 [v0.21.2]: https://github.com/off-court-creations/valet/releases/tag/v0.21.2
 [v0.21.1]: https://github.com/off-court-creations/valet/releases/tag/v0.21.1

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -5,6 +5,7 @@
 import React, { Suspense, lazy }   from 'react';
 import { Routes, Route }           from 'react-router-dom';
 import { useInitialTheme, Surface, Stack, Typography } from '@archway/valet';
+import brandonUrl from './assets/fonts/BrandonGrotesque.otf';
 
 /*───────────────────────────────────────────────────────────*/
 /* Helper – terse lazy() wrapper                            */
@@ -69,8 +70,13 @@ const PropPatternsPage      = page(() => import('./pages/PropPatterns'));
 export function App() {
   /* One-time initial theme + Google-font preload */
   useInitialTheme(
-    { fonts: { heading: 'Cabin', body: 'Cabin', mono: 'Ubuntu Mono', button: 'Ubuntu' } },
-    ['Ubuntu', 'Ubuntu Mono', 'Cabin']
+    { fonts: { heading: { name: 'Brandon', src: brandonUrl }, body: 'Cabin', mono: 'Ubuntu Mono', button: 'Ubuntu' } },
+    [
+      { name: 'Brandon', src: brandonUrl },
+      'Ubuntu',
+      'Ubuntu Mono',
+      'Cabin',
+    ]
   );
 
   /* Simple fallback – swap for a branded spinner when ready */

--- a/docs/src/pages/IconDemoPage.tsx
+++ b/docs/src/pages/IconDemoPage.tsx
@@ -18,7 +18,7 @@ import type { TableColumn } from '@archway/valet';
 import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import NavDrawer from '../components/NavDrawer';
-import mymoSVG from "../assets/mygymlogo.svg"
+import mymoSVG from "../assets/mygymlogo.svg?raw"
 
 /*─────────────────────────────────────────────────────────────────────────────*/
 /* Style presets – demonstrate Icon inside themed containers                   */

--- a/docs/src/pages/TypographyDemoPage.tsx
+++ b/docs/src/pages/TypographyDemoPage.tsx
@@ -149,6 +149,7 @@ export default function TypographyDemoPage() {
             <Typography variant="h3">Font &amp; size overrides</Typography>
             <Panel compact>
               <Typography fontFamily="Poppins">fontFamily="Poppins"</Typography>
+              <Typography fontFamily="Brandon">fontFamily="Brandon"</Typography>
               <Typography family="mono">family="mono"</Typography>
               <Typography family="heading">family="heading"</Typography>
               <Typography family="button">family="button"</Typography>

--- a/docs/src/vite-env.d.ts
+++ b/docs/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+declare module '*.otf' {
+  const src: string;
+  export default src;
+}

--- a/src/helpers/fontLoader.ts
+++ b/src/helpers/fontLoader.ts
@@ -1,16 +1,27 @@
 // ─────────────────────────────────────────────────────────────
 // src/helpers/fontLoader.ts | valet
-// shared utilities for injecting and loading Google Fonts
+// shared utilities for injecting Google and custom fonts
 // ─────────────────────────────────────────────────────────────
 export interface GoogleFontOptions {
   preload?: boolean;
 }
 
-const loadedFonts = new Set<string>();
+export interface CustomFont {
+  name: string;
+  src: string;
+}
 
-export function injectGoogleFontLinks(fonts: string[], options: GoogleFontOptions = {}): () => void {
+export type Font = string | CustomFont;
+
+const loadedFonts = new Set<string>();
+const customFaces = new Map<string, FontFace>();
+
+export function injectFontLinks(fonts: Font[], options: GoogleFontOptions = {}): () => void {
   const { preload = true } = options;
-  if (!document.getElementById('valet-fonts-preconnect')) {
+  const added: HTMLLinkElement[] = [];
+
+  const googleFonts = fonts.filter((f): f is string => typeof f === 'string');
+  if (googleFonts.length && !document.getElementById('valet-fonts-preconnect')) {
     const preconnect1 = document.createElement('link');
     preconnect1.id = 'valet-fonts-preconnect';
     preconnect1.rel = 'preconnect';
@@ -25,42 +36,79 @@ export function injectGoogleFontLinks(fonts: string[], options: GoogleFontOption
     document.head.appendChild(preconnect2);
   }
 
-  const added: HTMLLinkElement[] = [];
   fonts.forEach((font) => {
-    if (!font || loadedFonts.has(font)) return;
-    const formatted = font.replace(/ /g, '+');
-    const href = `https://fonts.googleapis.com/css2?family=${formatted}:wght@400;700&display=swap`;
+    if (typeof font === 'string') {
+      if (!font || loadedFonts.has(font)) return;
+      const formatted = font.replace(/ /g, '+');
+      const href = `https://fonts.googleapis.com/css2?family=${formatted}:wght@400;700&display=swap`;
 
-    if (preload) {
-      const preloadLink = document.createElement('link');
-      preloadLink.rel = 'preload';
-      preloadLink.as = 'style';
-      preloadLink.href = href;
-      preloadLink.crossOrigin = 'anonymous';
-      document.head.appendChild(preloadLink);
-      added.push(preloadLink);
+      if (preload) {
+        const preloadLink = document.createElement('link');
+        preloadLink.rel = 'preload';
+        preloadLink.as = 'style';
+        preloadLink.href = href;
+        preloadLink.crossOrigin = 'anonymous';
+        document.head.appendChild(preloadLink);
+        added.push(preloadLink);
+      }
+
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = href;
+      link.crossOrigin = 'anonymous';
+      document.head.appendChild(link);
+      added.push(link);
+      loadedFonts.add(font);
+    } else {
+      if (!font.name || loadedFonts.has(font.name)) return;
+      if (preload) {
+        const preloadLink = document.createElement('link');
+        preloadLink.rel = 'preload';
+        preloadLink.as = 'font';
+        preloadLink.href = font.src;
+        preloadLink.crossOrigin = 'anonymous';
+        document.head.appendChild(preloadLink);
+        added.push(preloadLink);
+      }
+
+      const face = new FontFace(font.name, `url(${font.src})`);
+      (document as any).fonts.add(face);
+      face.load().catch(() => {});
+      customFaces.set(font.name, face);
+      loadedFonts.add(font.name);
     }
-
-    const link = document.createElement('link');
-    link.rel = 'stylesheet';
-    link.href = href;
-    link.crossOrigin = 'anonymous';
-    document.head.appendChild(link);
-    added.push(link);
-    loadedFonts.add(font);
   });
 
   return () => {
     added.forEach((el) => document.head.removeChild(el));
-    fonts.forEach((f) => loadedFonts.delete(f));
+    fonts.forEach((f) => loadedFonts.delete(typeof f === 'string' ? f : f.name));
   };
 }
 
-export async function waitForGoogleFonts(fonts: string[]): Promise<void> {
-  await Promise.all(fonts.map((f) => document.fonts.load(`400 1em ${f}`)));
+export async function waitForFonts(fonts: Font[]): Promise<void> {
+  await Promise.all(
+    fonts.map((font) => {
+      if (typeof font === 'string') {
+        return document.fonts.load(`400 1em ${font}`);
+      }
+      const face =
+        customFaces.get(font.name) ||
+        new FontFace(font.name, `url(${font.src})`);
+      if (!customFaces.has(font.name)) {
+        customFaces.set(font.name, face);
+        (document as any).fonts.add(face);
+      }
+      return face.load();
+    })
+  );
   if ((document as any).fonts?.ready) {
     await (document as any).fonts.ready;
   }
   await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
   await new Promise((r) => setTimeout(r, 200));
 }
+
+export {
+  injectFontLinks as injectGoogleFontLinks,
+  waitForFonts as waitForGoogleFonts,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,3 +70,4 @@ export * from './system/themeStore';
 export * from './system/fontStore';
 export * from './system/createInitialTheme';
 export * from './hooks/useGoogleFonts';
+export type { Font, CustomFont } from './helpers/fontLoader';


### PR DESCRIPTION
## Summary
- load custom fonts alongside Google fonts
- expose new `Font` typing in the engine
- allow initial themes to use font objects
- demo custom `BrandonGrotesque` font in docs

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6887a4d479d883208622e4f75800912b