### PR TITLE
Update Stepper style and docs

### DIFF
--- a/docs/src/pages/PaginationDemo.tsx
+++ b/docs/src/pages/PaginationDemo.tsx
@@ -1,6 +1,17 @@
 // src/pages/PaginationDemo.tsx
 import { useState } from 'react';
-import { Surface, Stack, Typography, Button, Pagination, useTheme } from '@archway/valet';
+import {
+  Surface,
+  Stack,
+  Typography,
+  Button,
+  Pagination,
+  useTheme,
+  Tabs,
+  Table,
+} from '@archway/valet';
+import type { TableColumn } from '@archway/valet';
+import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import NavDrawer from '../components/NavDrawer';
 
@@ -9,6 +20,47 @@ export default function PaginationDemoPage() {
   const navigate = useNavigate();
   const [page, setPage] = useState(1);
 
+  interface Row {
+    prop: ReactNode;
+    type: ReactNode;
+    default: ReactNode;
+    description: ReactNode;
+  }
+
+  const columns: TableColumn<Row>[] = [
+    { header: 'Prop', accessor: 'prop' },
+    { header: 'Type', accessor: 'type' },
+    { header: 'Default', accessor: 'default' },
+    { header: 'Description', accessor: 'description' },
+  ];
+
+  const data: Row[] = [
+    {
+      prop       : <code>count</code>,
+      type       : <code>number</code>,
+      default    : <code>1</code>,
+      description: 'Total pages',
+    },
+    {
+      prop       : <code>page</code>,
+      type       : <code>number</code>,
+      default    : <code>1</code>,
+      description: 'Current page',
+    },
+    {
+      prop       : <code>onChange</code>,
+      type       : <code>(p: number) =&gt; void</code>,
+      default    : <code>-</code>,
+      description: 'Change handler',
+    },
+    {
+      prop       : <code>preset</code>,
+      type       : <code>string | string[]</code>,
+      default    : <code>-</code>,
+      description: 'Apply style presets',
+    },
+  ];
+
   return (
     <Surface>
       <NavDrawer />
@@ -16,13 +68,32 @@ export default function PaginationDemoPage() {
         <Typography variant="h2" bold>Pagination Showcase</Typography>
         <Typography variant="subtitle">Controlled page selection</Typography>
 
-        <Pagination count={5} page={page} onChange={setPage} />
-        <Typography variant="body">Current page: {page}</Typography>
+        <Tabs>
+          <Tabs.Tab label="Usage" />
+          <Tabs.Panel>
+            <Stack>
+              <Pagination count={5} page={page} onChange={setPage} />
+              <Typography variant="body">Current page: {page}</Typography>
+              <Button variant="outlined" onClick={toggleMode}>
+                Toggle light / dark
+              </Button>
+            </Stack>
+          </Tabs.Panel>
 
-        <Stack direction="row">
-          <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
-          <Button onClick={() => navigate(-1)}>← Back</Button>
-        </Stack>
+          <Tabs.Tab label="Reference" />
+          <Tabs.Panel>
+            <Typography variant="h3">Prop reference</Typography>
+            <Table data={data} columns={columns} constrainHeight={false} />
+          </Tabs.Panel>
+        </Tabs>
+
+        <Button
+          size="lg"
+          onClick={() => navigate(-1)}
+          style={{ marginTop: theme.spacing(1) }}
+        >
+          ← Back
+        </Button>
       </Stack>
     </Surface>
   );

--- a/docs/src/pages/ProgressDemo.tsx
+++ b/docs/src/pages/ProgressDemo.tsx
@@ -15,7 +15,11 @@ import {
   Slider,
   Progress,
   useTheme,
+  Tabs,
+  Table,
 } from '@archway/valet';
+import type { TableColumn } from '@archway/valet';
+import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import NavDrawer from '../components/NavDrawer';
 
@@ -28,6 +32,71 @@ export default function ProgressDemoPage() {
   /* Controlled value / buffer ------------------------------------------- */
   const [value,  setValue]  = useState(40);
   const [buffer, setBuffer] = useState(60);
+
+  interface Row {
+    prop: ReactNode;
+    type: ReactNode;
+    default: ReactNode;
+    description: ReactNode;
+  }
+
+  const columns: TableColumn<Row>[] = [
+    { header: 'Prop', accessor: 'prop' },
+    { header: 'Type', accessor: 'type' },
+    { header: 'Default', accessor: 'default' },
+    { header: 'Description', accessor: 'description' },
+  ];
+
+  const data: Row[] = [
+    {
+      prop       : <code>variant</code>,
+      type       : <code>'linear' | 'circular'</code>,
+      default    : <code>'linear'</code>,
+      description: 'Visual style',
+    },
+    {
+      prop       : <code>mode</code>,
+      type       : <code>'determinate' | 'indeterminate' | 'buffer'</code>,
+      default    : <code>'determinate'</code>,
+      description: 'Progress behaviour',
+    },
+    {
+      prop       : <code>value</code>,
+      type       : <code>number</code>,
+      default    : <code>0</code>,
+      description: 'Primary progress value',
+    },
+    {
+      prop       : <code>buffer</code>,
+      type       : <code>number</code>,
+      default    : <code>0</code>,
+      description: 'Buffer value (linear only)',
+    },
+    {
+      prop       : <code>size</code>,
+      type       : <code>ProgressSize | number | string</code>,
+      default    : <code>'md'</code>,
+      description: 'Size token or custom value',
+    },
+    {
+      prop       : <code>showLabel</code>,
+      type       : <code>boolean</code>,
+      default    : <code>false</code>,
+      description: 'Show numeric label',
+    },
+    {
+      prop       : <code>color</code>,
+      type       : <code>string</code>,
+      default    : <code>-</code>,
+      description: 'Override theme colour',
+    },
+    {
+      prop       : <code>preset</code>,
+      type       : <code>string | string[]</code>,
+      default    : <code>-</code>,
+      description: 'Apply style presets',
+    },
+  ];
 
   /* Auto-increment animation just for show ------------------------------ */
   useEffect(() => {
@@ -57,69 +126,80 @@ export default function ProgressDemoPage() {
           Every variant, mode, and size – plus interactive controls
         </Typography>
 
-        {/* 1. Circular indeterminate -------------------------------------- */}
-        <Typography variant="h3">1. Circular – indeterminate</Typography>
-        <Stack direction="row">
-          <Progress variant="circular" mode="indeterminate" size="xs" />
-          <Progress variant="circular" mode="indeterminate" size="sm" />
-          <Progress variant="circular" mode="indeterminate" />
-          <Progress variant="circular" mode="indeterminate" size="lg" />
-          <Progress variant="circular" mode="indeterminate" size="xl" />
-        </Stack>
+        <Tabs>
+          <Tabs.Tab label="Usage" />
+          <Tabs.Panel>
+            {/* 1. Circular indeterminate -------------------------------------- */}
+            <Typography variant="h3">1. Circular – indeterminate</Typography>
+            <Stack direction="row">
+              <Progress variant="circular" mode="indeterminate" size="xs" />
+              <Progress variant="circular" mode="indeterminate" size="sm" />
+              <Progress variant="circular" mode="indeterminate" />
+              <Progress variant="circular" mode="indeterminate" size="lg" />
+              <Progress variant="circular" mode="indeterminate" size="xl" />
+            </Stack>
 
-        {/* 2. Circular determinate (controlled) --------------------------- */}
-        <Typography variant="h3">2. Circular – determinate (controlled)</Typography>
-        <Stack direction="row" style={{ alignItems: 'center' }}>
-          <Progress
-            variant="circular"
-            mode="determinate"
-            value={value}
-            showLabel
-          />
-          <Progress
-            variant="circular"
-            mode="determinate"
-            value={value}
-            size="lg"
-            color={theme.colors['error']}
-          />
-          <IconButton icon="mdi:home" onClick={reset} aria-label="reset" />
-        </Stack>
+            {/* 2. Circular determinate (controlled) --------------------------- */}
+            <Typography variant="h3">2. Circular – determinate (controlled)</Typography>
+            <Stack direction="row" style={{ alignItems: 'center' }}>
+              <Progress
+                variant="circular"
+                mode="determinate"
+                value={value}
+                showLabel
+              />
+              <Progress
+                variant="circular"
+                mode="determinate"
+                value={value}
+                size="lg"
+                color={theme.colors['error']}
+              />
+              <IconButton icon="mdi:home" onClick={reset} aria-label="reset" />
+            </Stack>
 
-        {/* 3. Linear indeterminate ---------------------------------------- */}
-        <Typography variant="h3">3. Linear – indeterminate</Typography>
-        <Progress mode="indeterminate" />
+            {/* 3. Linear indeterminate ---------------------------------------- */}
+            <Typography variant="h3">3. Linear – indeterminate</Typography>
+            <Progress mode="indeterminate" />
 
-        {/* 4. Linear determinate (controlled) ----------------------------- */}
-        <Typography variant="h3">4. Linear – determinate (controlled)</Typography>
-        <Progress value={value} />
-        <Progress value={value} size={50} />
+            {/* 4. Linear determinate (controlled) ----------------------------- */}
+            <Typography variant="h3">4. Linear – determinate (controlled)</Typography>
+            <Progress value={value} />
+            <Progress value={value} size={50} />
 
-        {/* 5. Linear buffer ----------------------------------------------- */}
-        <Typography variant="h3">5. Linear – buffer</Typography>
-        <Progress mode="buffer" value={value} buffer={buffer} />
+            {/* 5. Linear buffer ----------------------------------------------- */}
+            <Typography variant="h3">5. Linear – buffer</Typography>
+            <Progress mode="buffer" value={value} buffer={buffer} />
 
-        {/* 6. Interactive controls ---------------------------------------- */}
-        <Typography variant="h3">6. Play with value</Typography>
-        <Stack>
-          <Box style={{ maxWidth: 480 }}>
-            <Slider value={value} onChange={setValue} />
-          </Box>
-          <Stack direction="row">
-            <Button onClick={() => setValue((v) => Math.max(0, v - 10))}>
-              –10
-            </Button>
-            <Button onClick={() => setValue((v) => Math.min(100, v + 10))}>
-              +10
-            </Button>
-            <Button variant="outlined" onClick={reset}>
-              Reset
-            </Button>
-            <Button variant="outlined" onClick={toggleMode}>
-              Toggle light / dark
-            </Button>
-          </Stack>
-        </Stack>
+            {/* 6. Interactive controls ---------------------------------------- */}
+            <Typography variant="h3">6. Play with value</Typography>
+            <Stack>
+              <Box style={{ maxWidth: 480 }}>
+                <Slider value={value} onChange={setValue} />
+              </Box>
+              <Stack direction="row">
+                <Button onClick={() => setValue((v) => Math.max(0, v - 10))}>
+                  –10
+                </Button>
+                <Button onClick={() => setValue((v) => Math.min(100, v + 10))}>
+                  +10
+                </Button>
+                <Button variant="outlined" onClick={reset}>
+                  Reset
+                </Button>
+                <Button variant="outlined" onClick={toggleMode}>
+                  Toggle light / dark
+                </Button>
+              </Stack>
+            </Stack>
+          </Tabs.Panel>
+
+          <Tabs.Tab label="Reference" />
+          <Tabs.Panel>
+            <Typography variant="h3">Prop reference</Typography>
+            <Table data={data} columns={columns} constrainHeight={false} />
+          </Tabs.Panel>
+        </Tabs>
 
         {/* Back nav -------------------------------------------------------- */}
         <Button

--- a/docs/src/pages/SnackbarDemo.tsx
+++ b/docs/src/pages/SnackbarDemo.tsx
@@ -1,7 +1,6 @@
 // ─────────────────────────────────────────────────────────────────────────────
 // src/pages/SnackbarDemoPage.tsx | valet
-// Comprehensive live demo for <Snackbar/> – showcases uncontrolled / controlled
-// usage, custom children, noStack layout, auto-hide tuning, & live theme toggle.
+// Comprehensive live demo for <Snackbar/>
 // ─────────────────────────────────────────────────────────────────────────────
 import React, { useState } from 'react';
 import {
@@ -12,7 +11,11 @@ import {
   Snackbar,
   useSnackbar,
   useTheme,
+  Tabs,
+  Table,
 } from '@archway/valet';
+import type { TableColumn } from '@archway/valet';
+import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import NavDrawer from '../components/NavDrawer';
 
@@ -39,6 +42,59 @@ export default function SnackbarDemoPage() {
   const [ctrlOpen,    setCtrlOpen]    = useState(false);
   const [noStackOpen, setNoStackOpen] = useState(false);
 
+  interface Row {
+    prop: ReactNode;
+    type: ReactNode;
+    default: ReactNode;
+    description: ReactNode;
+  }
+
+  const columns: TableColumn<Row>[] = [
+    { header: 'Prop', accessor: 'prop' },
+    { header: 'Type', accessor: 'type' },
+    { header: 'Default', accessor: 'default' },
+    { header: 'Description', accessor: 'description' },
+  ];
+
+  const data: Row[] = [
+    {
+      prop: <code>open</code>,
+      type: <code>boolean</code>,
+      default: <code>false</code>,
+      description: 'Controlled visibility flag',
+    },
+    {
+      prop: <code>onClose</code>,
+      type: <code>{'() => void'}</code>,
+      default: <code>-</code>,
+      description: 'Called when fully hidden',
+    },
+    {
+      prop: <code>autoHideDuration</code>,
+      type: <code>number | null</code>,
+      default: <code>4000</code>,
+      description: 'Dismiss after N ms',
+    },
+    {
+      prop: <code>message</code>,
+      type: <code>React.ReactNode</code>,
+      default: <code>-</code>,
+      description: 'Convenience message',
+    },
+    {
+      prop: <code>noStack</code>,
+      type: <code>boolean</code>,
+      default: <code>false</code>,
+      description: 'Disable flex layout',
+    },
+    {
+      prop: <code>preset</code>,
+      type: <code>string | string[]</code>,
+      default: <code>-</code>,
+      description: 'Apply style presets',
+    },
+  ];
+
   return (
     <Surface>
       <NavDrawer />
@@ -48,71 +104,79 @@ export default function SnackbarDemoPage() {
           Snackbar Showcase
         </Typography>
 
-        {/* 1. Uncontrolled auto-hide -------------------------------------- */}
-        <Typography variant="h3">1. Uncontrolled (auto-hide)</Typography>
-        <Button
-          size="sm"
-          onClick={() => setAutoOpen(true)}
-          style={{ alignSelf: 'flex-start' }}
-        >
-          Trigger auto-hide snackbar
-        </Button>
-        {autoOpen && (
-          <Snackbar
-            message="Profile saved successfully!"
-            onClose={() => setAutoOpen(false)}
-          />
-        )}
+        <Tabs>
+          <Tabs.Tab label="Usage" />
+          <Tabs.Panel>
+            {/* 1. Uncontrolled auto-hide -------------------------------------- */}
+            <Typography variant="h3">1. Uncontrolled (auto-hide)</Typography>
+            <Button
+              size="sm"
+              onClick={() => setAutoOpen(true)}
+              style={{ alignSelf: 'flex-start' }}
+            >
+              Trigger auto-hide snackbar
+            </Button>
+            {autoOpen && (
+              <Snackbar
+                message="Profile saved successfully!"
+                onClose={() => setAutoOpen(false)}
+              />
+            )}
 
-        {/* 2. Controlled snackbar ---------------------------------------- */}
-        <Typography variant="h3">2. Controlled (manual dismiss)</Typography>
-        <Button
-          size="sm"
-          variant="outlined"
-          onClick={() => setCtrlOpen(true)}
-          style={{ alignSelf: 'flex-start' }}
-        >
-          Trigger controlled snackbar
-        </Button>
-        <Snackbar
-          open={ctrlOpen}
-          onClose={() => setCtrlOpen(false)}
-        >
-          <Stack direction="row" wrap={false}>
-            <Typography variant="body" autoSize>
-              Draft saved – click to dismiss
-            </Typography>
-            <DismissBtn />
-          </Stack>
-        </Snackbar>
+            {/* 2. Controlled snackbar ---------------------------------------- */}
+            <Typography variant="h3">2. Controlled (manual dismiss)</Typography>
+            <Button
+              size="sm"
+              variant="outlined"
+              onClick={() => setCtrlOpen(true)}
+              style={{ alignSelf: 'flex-start' }}
+            >
+              Trigger controlled snackbar
+            </Button>
+            <Snackbar open={ctrlOpen} onClose={() => setCtrlOpen(false)}>
+              <Stack direction="row" wrap={false}>
+                <Typography variant="body" autoSize>
+                  Draft saved – click to dismiss
+                </Typography>
+                <DismissBtn />
+              </Stack>
+            </Snackbar>
 
-        {/* 3. noStack layout --------------------------------------------- */}
-        <Typography variant="h3">3. Custom layout (noStack)</Typography>
-        <Button
-          size="sm"
-          variant="outlined"
-          onClick={() => setNoStackOpen(true)}
-          style={{ alignSelf: 'flex-start' }}
-        >
-          Trigger noStack snackbar
-        </Button>
-        <Snackbar
-          open={noStackOpen}
-          noStack
-          autoHideDuration={8000}
-          onClose={() => setNoStackOpen(false)}
-        >
-          {/* Custom free-form children */}
-          <Typography variant="body" autoSize bold>
-            Free-form layout – no internal flex
-          </Typography>
-        </Snackbar>
+            {/* 3. noStack layout --------------------------------------------- */}
+            <Typography variant="h3">3. Custom layout (noStack)</Typography>
+            <Button
+              size="sm"
+              variant="outlined"
+              onClick={() => setNoStackOpen(true)}
+              style={{ alignSelf: 'flex-start' }}
+            >
+              Trigger noStack snackbar
+            </Button>
+            <Snackbar
+              open={noStackOpen}
+              noStack
+              autoHideDuration={8000}
+              onClose={() => setNoStackOpen(false)}
+            >
+              {/* Custom free-form children */}
+              <Typography variant="body" autoSize bold>
+                Free-form layout – no internal flex
+              </Typography>
+            </Snackbar>
 
-        {/* 4. Theme coupling --------------------------------------------- */}
-        <Typography variant="h3">4. Theme coupling</Typography>
-        <Button variant="outlined" onClick={toggleMode}>
-          Toggle light / dark mode
-        </Button>
+            {/* 4. Theme coupling --------------------------------------------- */}
+            <Typography variant="h3">4. Theme coupling</Typography>
+            <Button variant="outlined" onClick={toggleMode}>
+              Toggle light / dark mode
+            </Button>
+          </Tabs.Panel>
+
+          <Tabs.Tab label="Reference" />
+          <Tabs.Panel>
+            <Typography variant="h3">Prop reference</Typography>
+            <Table data={data} columns={columns} constrainHeight={false} />
+          </Tabs.Panel>
+        </Tabs>
 
         {/* Back nav -------------------------------------------------------- */}
         <Button

--- a/docs/src/pages/SpeedDialDemo.tsx
+++ b/docs/src/pages/SpeedDialDemo.tsx
@@ -1,5 +1,17 @@
 // src/pages/SpeedDialDemo.tsx
-import { Surface, Stack, Typography, Button, SpeedDial, Icon, useTheme } from '@archway/valet';
+import {
+  Surface,
+  Stack,
+  Typography,
+  Button,
+  SpeedDial,
+  Icon,
+  Tabs,
+  Table,
+  useTheme,
+} from '@archway/valet';
+import type { TableColumn } from '@archway/valet';
+import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import NavDrawer from '../components/NavDrawer';
 
@@ -13,6 +25,47 @@ export default function SpeedDialDemoPage() {
     { icon: <Icon icon="mdi:delete" />, label: 'Delete', onClick: () => alert('Delete') },
   ];
 
+  interface Row {
+    prop: ReactNode;
+    type: ReactNode;
+    default: ReactNode;
+    description: ReactNode;
+  }
+
+  const columns: TableColumn<Row>[] = [
+    { header: 'Prop', accessor: 'prop' },
+    { header: 'Type', accessor: 'type' },
+    { header: 'Default', accessor: 'default' },
+    { header: 'Description', accessor: 'description' },
+  ];
+
+  const data: Row[] = [
+    {
+      prop: <code>icon</code>,
+      type: <code>React.ReactNode</code>,
+      default: <code>-</code>,
+      description: 'Main floating action button icon',
+    },
+    {
+      prop: <code>actions</code>,
+      type: <code>SpeedDialAction[]</code>,
+      default: <code>-</code>,
+      description: 'Array of action buttons',
+    },
+    {
+      prop: <code>direction</code>,
+      type: <code>'up' | 'down' | 'left' | 'right'</code>,
+      default: <code>'up'</code>,
+      description: 'Expansion direction',
+    },
+    {
+      prop: <code>preset</code>,
+      type: <code>string | string[]</code>,
+      default: <code>-</code>,
+      description: 'Apply style presets',
+    },
+  ];
+
   return (
     <Surface>
       <NavDrawer />
@@ -20,14 +73,31 @@ export default function SpeedDialDemoPage() {
         <Typography variant="h2" bold>SpeedDial Showcase</Typography>
         <Typography variant="subtitle">Floating action button</Typography>
 
-        <Typography variant="h3">Example</Typography>
-        <Typography variant="body">Click the fab to reveal actions.</Typography>
-        <SpeedDial icon={<Icon icon="mdi:plus" />} actions={actions} />
+        <Tabs>
+          <Tabs.Tab label="Usage" />
+          <Tabs.Panel>
+            <Stack>
+              <Typography variant="h3">Example</Typography>
+              <Typography variant="body">Click the fab to reveal actions.</Typography>
+              <SpeedDial icon={<Icon icon="mdi:plus" />} actions={actions} />
+              <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
+            </Stack>
+          </Tabs.Panel>
 
-        <Stack direction="row">
-          <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
-          <Button onClick={() => navigate(-1)}>← Back</Button>
-        </Stack>
+          <Tabs.Tab label="Reference" />
+          <Tabs.Panel>
+            <Typography variant="h3">Prop reference</Typography>
+            <Table data={data} columns={columns} constrainHeight={false} />
+          </Tabs.Panel>
+        </Tabs>
+
+        <Button
+          size="lg"
+          onClick={() => navigate(-1)}
+          style={{ marginTop: theme.spacing(1) }}
+        >
+          ← Back
+        </Button>
       </Stack>
     </Surface>
   );

--- a/docs/src/pages/StepperDemo.tsx
+++ b/docs/src/pages/StepperDemo.tsx
@@ -1,6 +1,17 @@
 // src/pages/StepperDemo.tsx
 import { useState } from 'react';
-import { Surface, Stack, Typography, Button, Stepper, useTheme } from '@archway/valet';
+import {
+  Surface,
+  Stack,
+  Typography,
+  Button,
+  Stepper,
+  useTheme,
+  Tabs,
+  Table,
+} from '@archway/valet';
+import type { TableColumn } from '@archway/valet';
+import type { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import NavDrawer from '../components/NavDrawer';
 
@@ -11,6 +22,41 @@ export default function StepperDemoPage() {
 
   const steps = ['First', 'Second', 'Third'];
 
+  interface Row {
+    prop: ReactNode;
+    type: ReactNode;
+    default: ReactNode;
+    description: ReactNode;
+  }
+
+  const columns: TableColumn<Row>[] = [
+    { header: 'Prop', accessor: 'prop' },
+    { header: 'Type', accessor: 'type' },
+    { header: 'Default', accessor: 'default' },
+    { header: 'Description', accessor: 'description' },
+  ];
+
+  const data: Row[] = [
+    {
+      prop: <code>steps</code>,
+      type: <code>React.ReactNode[]</code>,
+      default: <code>-</code>,
+      description: 'Labels for each step',
+    },
+    {
+      prop: <code>active</code>,
+      type: <code>number</code>,
+      default: <code>0</code>,
+      description: 'Index of the active step',
+    },
+    {
+      prop: <code>preset</code>,
+      type: <code>string | string[]</code>,
+      default: <code>-</code>,
+      description: 'Apply style presets',
+    },
+  ];
+
   return (
     <Surface>
       <NavDrawer />
@@ -18,16 +64,35 @@ export default function StepperDemoPage() {
         <Typography variant="h2" bold>Stepper Showcase</Typography>
         <Typography variant="subtitle">Simple progress indicator</Typography>
 
-        <Stepper steps={steps} active={active} />
-        <Stack direction="row">
-          <Button onClick={() => setActive((a) => Math.max(0, a - 1))}>Back</Button>
-          <Button onClick={() => setActive((a) => Math.min(steps.length - 1, a + 1))}>Next</Button>
-        </Stack>
+        <Tabs>
+          <Tabs.Tab label="Usage" />
+          <Tabs.Panel>
+            <Stack>
+              <Stepper steps={steps} active={active} />
+              <Stack direction="row">
+                <Button onClick={() => setActive((a) => Math.max(0, a - 1))}>Back</Button>
+                <Button onClick={() => setActive((a) => Math.min(steps.length - 1, a + 1))}>Next</Button>
+              </Stack>
+              <Button variant="outlined" onClick={toggleMode}>
+                Toggle light / dark
+              </Button>
+            </Stack>
+          </Tabs.Panel>
 
-        <Stack direction="row">
-          <Button variant="outlined" onClick={toggleMode}>Toggle light / dark</Button>
-          <Button onClick={() => navigate(-1)}>← Back</Button>
-        </Stack>
+          <Tabs.Tab label="Reference" />
+          <Tabs.Panel>
+            <Typography variant="h3">Prop reference</Typography>
+            <Table data={data} columns={columns} constrainHeight={false} />
+          </Tabs.Panel>
+        </Tabs>
+
+        <Button
+          size="lg"
+          onClick={() => navigate(-1)}
+          style={{ marginTop: theme.spacing(1) }}
+        >
+          ← Back
+        </Button>
       </Stack>
     </Surface>
   );

--- a/src/components/widgets/Stepper.tsx
+++ b/src/components/widgets/Stepper.tsx
@@ -29,7 +29,8 @@ const StepItem = styled('div')<{ $active: boolean; $primary: string }>`
   align-items: center;
   gap: 0.25rem;
   font-size: 0.875rem;
-  color: ${({ $active, $primary }) => ($active ? $primary : 'inherit')};
+  font-weight: ${({ $active }) => ($active ? 'bold' : 'normal')};
+  color: inherit;
 
   &::before {
     counter-increment: step;


### PR DESCRIPTION
## Summary
- highlight the active step by font weight instead of colour
- expand Stepper demo with Usage and Reference tabs

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68892b616af4832086086d6c9e136d2f