### PR TITLE
feat: center tabs optionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Add optional `centered` prop to `Tabs` for centered tab icons
+
 ## [0.22.2]
 - Improved visual bug involving skrinking / resizing for `Table` and `Accordion`
 

--- a/docs/src/pages/TabsDemo.tsx
+++ b/docs/src/pages/TabsDemo.tsx
@@ -1,6 +1,6 @@
 // ─────────────────────────────────────────────────────────────────────────────
-// src/pages/TabsDemoPage.tsx | valet
-// Demonstrates placement-aware <Tabs/> with varied panel content.
+// docs/src/pages/TabsDemo.tsx | valet
+// add center alignment example
 // ─────────────────────────────────────────────────────────────────────────────
 import { useState } from 'react';
 import {
@@ -130,8 +130,21 @@ export default function TabsDemoPage() {
           <Tabs.Panel>{'Settings → ' + THREE}</Tabs.Panel>
         </Tabs>
 
+        {/* 7. Centered tabs ----------------------------------------------- */}
+        <Typography variant="h3">7. Centered tabs</Typography>
+        <Tabs centered>
+          <Tabs.Tab label={<Icon icon="mdi:home" />} aria-label="Home" />
+          <Tabs.Panel>{'Home → ' + ONE}</Tabs.Panel>
+
+          <Tabs.Tab label={<Icon icon="mdi:account" />} aria-label="Profile" />
+          <Tabs.Panel>{'Profile → ' + TWO}</Tabs.Panel>
+
+          <Tabs.Tab label={<Icon icon="mdi:cog" />} aria-label="Settings" />
+          <Tabs.Panel>{'Settings → ' + THREE}</Tabs.Panel>
+        </Tabs>
+
         {/* Theme switcher -------------------------------------------------- */}
-        <Typography variant="h3">7. Theme coupling</Typography>
+        <Typography variant="h3">8. Theme coupling</Typography>
         <Button variant="outlined" onClick={toggleMode}>
           Toggle light / dark
         </Button>

--- a/src/components/layout/Tabs.tsx
+++ b/src/components/layout/Tabs.tsx
@@ -1,6 +1,6 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/widgets/Tabs.tsx | valet
-// Grid-based valet <Tabs> — bullet-proof placement: top / bottom / left / right
+// src/components/layout/Tabs.tsx | valet
+// add optional centered tab alignment
 // ─────────────────────────────────────────────────────────────
 import React, {
   createContext,
@@ -73,6 +73,7 @@ const Root = styled('div')<{
 /*───────────────────────────────────────────────────────────*/
 const TabList = styled('div')<{
   $orientation: 'horizontal' | 'vertical';
+  $centered?: boolean;
 }>`
   display: flex;
   flex-direction: ${({ $orientation }) =>
@@ -81,6 +82,14 @@ const TabList = styled('div')<{
 
   ${({ $orientation }) =>
     $orientation === 'vertical' && 'width: max-content;'}
+
+  justify-content: ${({ $centered }) =>
+    $centered ? 'center' : 'flex-start'};
+
+  ${({ $centered, $orientation }) =>
+    $centered &&
+    $orientation === 'vertical' &&
+    'align-self: stretch; height: 100%;'}
 `;
 
 /*───────────────────────────────────────────────────────────*/
@@ -150,6 +159,7 @@ export interface TabsProps
   onTabChange?: (i: number) => void;
   orientation?: 'horizontal' | 'vertical';
   placement?: 'top' | 'bottom' | 'left' | 'right';
+  centered?: boolean;
 }
 export interface TabProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -173,6 +183,7 @@ export const Tabs: React.FC<TabsProps> & {
   defaultActive = 0,
   orientation = 'horizontal',
   placement: placementProp,
+  centered = false,
   onTabChange,
   preset: p,
   className,
@@ -242,11 +253,19 @@ export const Tabs: React.FC<TabsProps> & {
         $gap={gap}
         className={cls}
       >
-        {stripFirst && <TabList $orientation={orientation}>{tabs}</TabList>}
+        {stripFirst && (
+          <TabList $orientation={orientation} $centered={centered}>
+            {tabs}
+          </TabList>
+        )}
 
         <Panel>{panels}</Panel>
 
-        {!stripFirst && <TabList $orientation={orientation}>{tabs}</TabList>}
+        {!stripFirst && (
+          <TabList $orientation={orientation} $centered={centered}>
+            {tabs}
+          </TabList>
+        )}
       </Root>
     </TabsCtx.Provider>
   );


### PR DESCRIPTION
## Summary
- allow tab strips to be centered with new `centered` prop
- document centered tabs in the demo
- record addition in changelog

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `cd docs && npm test` *(fails: Missing script: "test")*
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688aec1e488883209658b6e560aa4d19