### PR TITLE
Add optional icon centering for tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Tabs: add `centerIcons` prop to optionally center tab icons
+
 ## [0.22.2]
 - Improved visual bug involving skrinking / resizing for `Table` and `Accordion`
 

--- a/docs/src/pages/TabsDemo.tsx
+++ b/docs/src/pages/TabsDemo.tsx
@@ -43,7 +43,7 @@ export default function TabsDemoPage() {
 
         {/* 1. Horizontal - top (default) ---------------------------------- */}
         <Typography variant="h3">1. Horizontal – top (default)</Typography>
-        <Tabs>
+          <Tabs>
           <Tabs.Tab label="One"   />
           <Tabs.Panel>{ONE}</Tabs.Panel>
 
@@ -119,7 +119,7 @@ export default function TabsDemoPage() {
 
         {/* 6. Icon headings ----------------------------------------------- */}
         <Typography variant="h3">6. Icon headings</Typography>
-        <Tabs>
+        <Tabs centerIcons>
           <Tabs.Tab label={<Icon icon="mdi:home" />} aria-label="Home" />
           <Tabs.Panel>{'Home → ' + ONE}</Tabs.Panel>
 

--- a/src/components/layout/Tabs.tsx
+++ b/src/components/layout/Tabs.tsx
@@ -1,6 +1,7 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/widgets/Tabs.tsx | valet
+// src/components/layout/Tabs.tsx | valet
 // Grid-based valet <Tabs> — bullet-proof placement: top / bottom / left / right
+// patched with optional icon centring
 // ─────────────────────────────────────────────────────────────
 import React, {
   createContext,
@@ -27,6 +28,7 @@ interface Ctx {
   orientation : 'horizontal' | 'vertical';
   registerTab : (i: number, el: HTMLButtonElement | null) => void;
   totalTabs   : number;
+  centerIcons : boolean;
 }
 const TabsCtx = createContext<Ctx | null>(null);
 const useTabs = () => {
@@ -89,6 +91,7 @@ const TabBtn = styled('button')<{
   $active  : boolean;
   $primary : string;
   $orient  : 'horizontal' | 'vertical';
+  $center  : boolean;
 }>`
   background: transparent;
   border: none;
@@ -105,7 +108,12 @@ const TabBtn = styled('button')<{
     $orient === 'vertical' ? 'width: 100%;' : 'min-width: 4rem;'}
 
   position: relative;
-  text-align: center;
+  display: flex;
+  justify-content: ${({ $orient, $center }) =>
+    $orient === 'horizontal' ? ($center ? 'center' : 'flex-start') : 'center'};
+  align-items: ${({ $orient, $center }) =>
+    $orient === 'vertical' ? ($center ? 'center' : 'flex-start') : 'center'};
+  text-align: left;
 
   &:focus-visible {
     outline: 2px solid ${({ $primary }) => $primary};
@@ -150,6 +158,7 @@ export interface TabsProps
   onTabChange?: (i: number) => void;
   orientation?: 'horizontal' | 'vertical';
   placement?: 'top' | 'bottom' | 'left' | 'right';
+  centerIcons?: boolean;
 }
 export interface TabProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -174,6 +183,7 @@ export const Tabs: React.FC<TabsProps> & {
   orientation = 'horizontal',
   placement: placementProp,
   onTabChange,
+  centerIcons = false,
   preset: p,
   className,
   children,
@@ -223,8 +233,9 @@ export const Tabs: React.FC<TabsProps> & {
       orientation,
       registerTab,
       totalTabs: tabs.length,
+      centerIcons,
     }),
-    [active, orientation, setActive, tabs.length],
+    [active, orientation, setActive, tabs.length, centerIcons],
   );
 
   const cls = [p ? preset(p) : '', className].filter(Boolean).join(' ');
@@ -256,7 +267,8 @@ export const Tabs: React.FC<TabsProps> & {
 const Tab: React.FC<TabProps> = forwardRef<HTMLButtonElement, TabProps>(
   ({ index = 0, label, preset: p, className, onKeyDown, onClick, ...rest }, ref) => {
     const { theme } = useTheme();
-    const { active, setActive, orientation, registerTab, totalTabs } = useTabs();
+    const { active, setActive, orientation, registerTab, totalTabs, centerIcons } =
+      useTabs();
     const selected = active === index;
 
     const nav = (e: KeyboardEvent<HTMLButtonElement>) => {
@@ -291,6 +303,7 @@ const Tab: React.FC<TabProps> = forwardRef<HTMLButtonElement, TabProps>(
         $active={selected}
         $primary={theme.colors.primary}
         $orient={orientation}
+        $center={centerIcons}
         className={[p ? preset(p) : '', className].filter(Boolean).join(' ')}
       >
         {label ?? rest.children}


### PR DESCRIPTION
## Summary
- add `centerIcons` prop so tab icons can default to start or be centered
- document `centerIcons` usage in the Tabs demo
- record the new option in the changelog

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688aec1e488883209658b6e560aa4d19