### PR TITLE
feat: add optional centered alignment for Tabs icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-
+- Added optional `centered` prop to `Tabs` for icon alignment
 ## [0.22.2]
 - Improved visual bug involving skrinking / resizing for `Table` and `Accordion`
 

--- a/docs/src/pages/TabsDemo.tsx
+++ b/docs/src/pages/TabsDemo.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────────────────────
-// src/pages/TabsDemoPage.tsx | valet
+// docs/src/pages/TabsDemo.tsx | valet
 // Demonstrates placement-aware <Tabs/> with varied panel content.
 // ─────────────────────────────────────────────────────────────────────────────
 import { useState } from 'react';
@@ -117,9 +117,9 @@ export default function TabsDemoPage() {
           <Tabs.Panel>{'Third → ' + SIX}</Tabs.Panel>
         </Tabs>
 
-        {/* 6. Icon headings ----------------------------------------------- */}
+        {/* 6. Icon headings (centered) ----------------------------------- */}
         <Typography variant="h3">6. Icon headings</Typography>
-        <Tabs>
+        <Tabs centered>
           <Tabs.Tab label={<Icon icon="mdi:home" />} aria-label="Home" />
           <Tabs.Panel>{'Home → ' + ONE}</Tabs.Panel>
 

--- a/src/components/layout/Tabs.tsx
+++ b/src/components/layout/Tabs.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/widgets/Tabs.tsx | valet
+// src/components/layout/Tabs.tsx | valet
 // Grid-based valet <Tabs> — bullet-proof placement: top / bottom / left / right
 // ─────────────────────────────────────────────────────────────
 import React, {
@@ -73,14 +73,21 @@ const Root = styled('div')<{
 /*───────────────────────────────────────────────────────────*/
 const TabList = styled('div')<{
   $orientation: 'horizontal' | 'vertical';
+  $centered : boolean;
 }>`
   display: flex;
   flex-direction: ${({ $orientation }) =>
     $orientation === 'vertical' ? 'column' : 'row'};
   gap: 0;
+  justify-content: ${({ $centered }) =>
+    $centered ? 'center' : 'flex-start'};
 
   ${({ $orientation }) =>
     $orientation === 'vertical' && 'width: max-content;'}
+
+  ${({ $orientation, $centered }) =>
+    $orientation === 'vertical' && $centered &&
+    'align-self: stretch; height: 100%;'}
 `;
 
 /*───────────────────────────────────────────────────────────*/
@@ -150,6 +157,7 @@ export interface TabsProps
   onTabChange?: (i: number) => void;
   orientation?: 'horizontal' | 'vertical';
   placement?: 'top' | 'bottom' | 'left' | 'right';
+  centered?: boolean;
 }
 export interface TabProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -174,6 +182,7 @@ export const Tabs: React.FC<TabsProps> & {
   orientation = 'horizontal',
   placement: placementProp,
   onTabChange,
+  centered = false,
   preset: p,
   className,
   children,
@@ -242,11 +251,19 @@ export const Tabs: React.FC<TabsProps> & {
         $gap={gap}
         className={cls}
       >
-        {stripFirst && <TabList $orientation={orientation}>{tabs}</TabList>}
+        {stripFirst && (
+          <TabList $orientation={orientation} $centered={centered}>
+            {tabs}
+          </TabList>
+        )}
 
         <Panel>{panels}</Panel>
 
-        {!stripFirst && <TabList $orientation={orientation}>{tabs}</TabList>}
+        {!stripFirst && (
+          <TabList $orientation={orientation} $centered={centered}>
+            {tabs}
+          </TabList>
+        )}
       </Root>
     </TabsCtx.Provider>
   );


### PR DESCRIPTION
## Summary
- allow Tabs to center tab icons with a `centered` prop
- document centered tab usage in Tabs demo
- note new option in changelog

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688aec1e488883209658b6e560aa4d19