### PR TITLE
Add optional icon centering to Tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Add optional `centered` prop to `Tabs` for opt-in icon centring
+
 ## [0.22.2]
 - Improved visual bug involving skrinking / resizing for `Table` and `Accordion`
 

--- a/docs/src/pages/TabsDemo.tsx
+++ b/docs/src/pages/TabsDemo.tsx
@@ -1,6 +1,6 @@
 // ─────────────────────────────────────────────────────────────────────────────
-// src/pages/TabsDemoPage.tsx | valet
-// Demonstrates placement-aware <Tabs/> with varied panel content.
+// src/pages/TabsDemo.tsx | valet
+// Demonstrates placement-aware <Tabs/> with varied panel content + icon centring.
 // ─────────────────────────────────────────────────────────────────────────────
 import { useState } from 'react';
 import {
@@ -130,8 +130,21 @@ export default function TabsDemoPage() {
           <Tabs.Panel>{'Settings → ' + THREE}</Tabs.Panel>
         </Tabs>
 
-        {/* Theme switcher -------------------------------------------------- */}
-        <Typography variant="h3">7. Theme coupling</Typography>
+        {/* 7. Centred icons ----------------------------------------------- */}
+        <Typography variant="h3">7. Centred icons</Typography>
+        <Tabs centered>
+          <Tabs.Tab label={<Icon icon="mdi:home" />} aria-label="Home" />
+          <Tabs.Panel>{'Home → ' + ONE}</Tabs.Panel>
+
+          <Tabs.Tab label={<Icon icon="mdi:account" />} aria-label="Profile" />
+          <Tabs.Panel>{'Profile → ' + TWO}</Tabs.Panel>
+
+          <Tabs.Tab label={<Icon icon="mdi:cog" />} aria-label="Settings" />
+          <Tabs.Panel>{'Settings → ' + THREE}</Tabs.Panel>
+        </Tabs>
+
+        {/* 8. Theme switcher -------------------------------------------------- */}
+        <Typography variant="h3">8. Theme coupling</Typography>
         <Button variant="outlined" onClick={toggleMode}>
           Toggle light / dark
         </Button>

--- a/src/components/layout/Tabs.tsx
+++ b/src/components/layout/Tabs.tsx
@@ -1,6 +1,6 @@
 // ─────────────────────────────────────────────────────────────
 // src/components/widgets/Tabs.tsx | valet
-// Grid-based valet <Tabs> — bullet-proof placement: top / bottom / left / right
+// Grid-based valet <Tabs> — bullet-proof placement + optional icon centring
 // ─────────────────────────────────────────────────────────────
 import React, {
   createContext,
@@ -27,6 +27,7 @@ interface Ctx {
   orientation : 'horizontal' | 'vertical';
   registerTab : (i: number, el: HTMLButtonElement | null) => void;
   totalTabs   : number;
+  centered    : boolean;
 }
 const TabsCtx = createContext<Ctx | null>(null);
 const useTabs = () => {
@@ -89,6 +90,7 @@ const TabBtn = styled('button')<{
   $active  : boolean;
   $primary : string;
   $orient  : 'horizontal' | 'vertical';
+  $center  : boolean;
 }>`
   background: transparent;
   border: none;
@@ -105,7 +107,14 @@ const TabBtn = styled('button')<{
     $orient === 'vertical' ? 'width: 100%;' : 'min-width: 4rem;'}
 
   position: relative;
-  text-align: center;
+  display: flex;
+  flex-direction: ${({ $orient }) =>
+    $orient === 'vertical' ? 'column' : 'row'};
+  align-items: center;
+  justify-content: ${({ $center }) =>
+    $center ? 'center' : 'flex-start'};
+  text-align: ${({ $orient, $center }) =>
+    $orient === 'vertical' || $center ? 'center' : 'left'};
 
   &:focus-visible {
     outline: 2px solid ${({ $primary }) => $primary};
@@ -150,6 +159,7 @@ export interface TabsProps
   onTabChange?: (i: number) => void;
   orientation?: 'horizontal' | 'vertical';
   placement?: 'top' | 'bottom' | 'left' | 'right';
+  centered?: boolean;
 }
 export interface TabProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -173,6 +183,7 @@ export const Tabs: React.FC<TabsProps> & {
   defaultActive = 0,
   orientation = 'horizontal',
   placement: placementProp,
+  centered = false,
   onTabChange,
   preset: p,
   className,
@@ -223,8 +234,9 @@ export const Tabs: React.FC<TabsProps> & {
       orientation,
       registerTab,
       totalTabs: tabs.length,
+      centered,
     }),
-    [active, orientation, setActive, tabs.length],
+    [active, orientation, setActive, tabs.length, centered],
   );
 
   const cls = [p ? preset(p) : '', className].filter(Boolean).join(' ');
@@ -256,7 +268,8 @@ export const Tabs: React.FC<TabsProps> & {
 const Tab: React.FC<TabProps> = forwardRef<HTMLButtonElement, TabProps>(
   ({ index = 0, label, preset: p, className, onKeyDown, onClick, ...rest }, ref) => {
     const { theme } = useTheme();
-    const { active, setActive, orientation, registerTab, totalTabs } = useTabs();
+    const { active, setActive, orientation, registerTab, totalTabs, centered } =
+      useTabs();
     const selected = active === index;
 
     const nav = (e: KeyboardEvent<HTMLButtonElement>) => {
@@ -291,6 +304,7 @@ const Tab: React.FC<TabProps> = forwardRef<HTMLButtonElement, TabProps>(
         $active={selected}
         $primary={theme.colors.primary}
         $orient={orientation}
+        $center={centered}
         className={[p ? preset(p) : '', className].filter(Boolean).join(' ')}
       >
         {label ?? rest.children}


### PR DESCRIPTION
## Summary
- add `centered` prop to Tabs for optional icon centering
- document centered icon usage in Tabs demo
- note new prop in changelog

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`
- `cd docs && npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688aec1e488883209658b6e560aa4d19