### PR TITLE
feat: add centered tab headings option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Added optional `centered` prop to `Tabs` for full-area heading centering
+
 ## [0.22.2]
 - Improved visual bug involving skrinking / resizing for `Table` and `Accordion`
 

--- a/docs/src/pages/TabsDemo.tsx
+++ b/docs/src/pages/TabsDemo.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────────────────────
-// src/pages/TabsDemoPage.tsx | valet
+// src/pages/TabsDemo.tsx | valet
 // Demonstrates placement-aware <Tabs/> with varied panel content.
 // ─────────────────────────────────────────────────────────────────────────────
 import { useState } from 'react';
@@ -130,8 +130,29 @@ export default function TabsDemoPage() {
           <Tabs.Panel>{'Settings → ' + THREE}</Tabs.Panel>
         </Tabs>
 
+        {/* 7. Centered headings ------------------------------------------- */}
+        <Typography variant="h3">7. Centered headings</Typography>
+        <Tabs centered>
+          <Tabs.Tab label={<Icon icon="mdi:home" />} aria-label="Home" />
+          <Tabs.Panel>{'Home → ' + ONE}</Tabs.Panel>
+
+          <Tabs.Tab label={<Icon icon="mdi:account" />} aria-label="Profile" />
+          <Tabs.Panel>{'Profile → ' + TWO}</Tabs.Panel>
+
+          <Tabs.Tab label={<Icon icon="mdi:cog" />} aria-label="Settings" />
+          <Tabs.Panel>{'Settings → ' + THREE}</Tabs.Panel>
+        </Tabs>
+
+        <Tabs centered orientation="vertical" style={{ height: 200 }}>
+          <Tabs.Tab label="Left" />
+          <Tabs.Panel>{'Left → ' + FOUR}</Tabs.Panel>
+
+          <Tabs.Tab label="Right" />
+          <Tabs.Panel>{'Right → ' + FIVE}</Tabs.Panel>
+        </Tabs>
+
         {/* Theme switcher -------------------------------------------------- */}
-        <Typography variant="h3">7. Theme coupling</Typography>
+        <Typography variant="h3">8. Theme coupling</Typography>
         <Button variant="outlined" onClick={toggleMode}>
           Toggle light / dark
         </Button>

--- a/src/components/layout/Tabs.tsx
+++ b/src/components/layout/Tabs.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/widgets/Tabs.tsx | valet
+// src/components/layout/Tabs.tsx  | valet
 // Grid-based valet <Tabs> — bullet-proof placement: top / bottom / left / right
 // ─────────────────────────────────────────────────────────────
 import React, {
@@ -73,6 +73,7 @@ const Root = styled('div')<{
 /*───────────────────────────────────────────────────────────*/
 const TabList = styled('div')<{
   $orientation: 'horizontal' | 'vertical';
+  $center     : boolean;
 }>`
   display: flex;
   flex-direction: ${({ $orientation }) =>
@@ -81,6 +82,13 @@ const TabList = styled('div')<{
 
   ${({ $orientation }) =>
     $orientation === 'vertical' && 'width: max-content;'}
+
+  ${({ $center, $orientation }) =>
+    $center
+      ? $orientation === 'horizontal'
+        ? 'justify-content: center;'
+        : 'justify-content: center; align-self: stretch;'
+      : ''}
 `;
 
 /*───────────────────────────────────────────────────────────*/
@@ -150,6 +158,7 @@ export interface TabsProps
   onTabChange?: (i: number) => void;
   orientation?: 'horizontal' | 'vertical';
   placement?: 'top' | 'bottom' | 'left' | 'right';
+  centered?: boolean;
 }
 export interface TabProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -174,6 +183,7 @@ export const Tabs: React.FC<TabsProps> & {
   orientation = 'horizontal',
   placement: placementProp,
   onTabChange,
+  centered = false,
   preset: p,
   className,
   children,
@@ -242,11 +252,19 @@ export const Tabs: React.FC<TabsProps> & {
         $gap={gap}
         className={cls}
       >
-        {stripFirst && <TabList $orientation={orientation}>{tabs}</TabList>}
+        {stripFirst && (
+          <TabList $orientation={orientation} $center={centered}>
+            {tabs}
+          </TabList>
+        )}
 
         <Panel>{panels}</Panel>
 
-        {!stripFirst && <TabList $orientation={orientation}>{tabs}</TabList>}
+        {!stripFirst && (
+          <TabList $orientation={orientation} $center={centered}>
+            {tabs}
+          </TabList>
+        )}
       </Root>
     </TabsCtx.Provider>
   );


### PR DESCRIPTION
## Summary
- allow `Tabs` headings to center across the full content area via new `centered` prop
- document centered examples for both orientations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `cd docs && npm test` *(fails: Missing script: "test")*
- `cd docs && npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_688b91642b8483208b02abfb0a39500b