### PR TITLE
Add centered option for Tabs headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Added `centered` option to `Tabs` to center tab headings
 ## [0.22.2]
 - Improved visual bug involving skrinking / resizing for `Table` and `Accordion`
 

--- a/docs/src/pages/TabsDemo.tsx
+++ b/docs/src/pages/TabsDemo.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────────────────────
-// src/pages/TabsDemoPage.tsx | valet
+// src/pages/TabsDemo.tsx | valet
 // Demonstrates placement-aware <Tabs/> with varied panel content.
 // ─────────────────────────────────────────────────────────────────────────────
 import { useState } from 'react';
@@ -77,11 +77,12 @@ export default function TabsDemoPage() {
           <Tabs.Panel>{'Cherry → ' + THREE}</Tabs.Panel>
         </Tabs>
 
-        {/* 4. Vertical - right ------------------------------------------- */}
-        <Typography variant="h3">4. Vertical – right</Typography>
+        {/* 4. Vertical - right (centered) -------------------------------- */}
+        <Typography variant="h3">4. Vertical – right (centered)</Typography>
         <Tabs
           orientation="vertical"
           placement="right"
+          centered
           style={{ height: 200 }}
         >
           <Tabs.Tab label="Left Brain"  />
@@ -117,9 +118,9 @@ export default function TabsDemoPage() {
           <Tabs.Panel>{'Third → ' + SIX}</Tabs.Panel>
         </Tabs>
 
-        {/* 6. Icon headings ----------------------------------------------- */}
-        <Typography variant="h3">6. Icon headings</Typography>
-        <Tabs>
+        {/* 6. Icon headings (centered) ------------------------------------ */}
+        <Typography variant="h3">6. Icon headings (centered)</Typography>
+        <Tabs centered>
           <Tabs.Tab label={<Icon icon="mdi:home" />} aria-label="Home" />
           <Tabs.Panel>{'Home → ' + ONE}</Tabs.Panel>
 

--- a/src/components/layout/Tabs.tsx
+++ b/src/components/layout/Tabs.tsx
@@ -1,6 +1,6 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/widgets/Tabs.tsx | valet
-// Grid-based valet <Tabs> — bullet-proof placement: top / bottom / left / right
+// src/components/layout/Tabs.tsx  | valet
+// Grid-based <Tabs> — bullet-proof placement & optional centered headings
 // ─────────────────────────────────────────────────────────────
 import React, {
   createContext,
@@ -73,6 +73,7 @@ const Root = styled('div')<{
 /*───────────────────────────────────────────────────────────*/
 const TabList = styled('div')<{
   $orientation: 'horizontal' | 'vertical';
+  $center?: boolean;
 }>`
   display: flex;
   flex-direction: ${({ $orientation }) =>
@@ -81,6 +82,12 @@ const TabList = styled('div')<{
 
   ${({ $orientation }) =>
     $orientation === 'vertical' && 'width: max-content;'}
+
+  ${({ $center, $orientation }) =>
+    $center &&
+    ($orientation === 'horizontal'
+      ? 'justify-content: center; width: 100%;'
+      : 'justify-content: center; height: 100%; align-self: stretch;')}
 `;
 
 /*───────────────────────────────────────────────────────────*/
@@ -150,6 +157,7 @@ export interface TabsProps
   onTabChange?: (i: number) => void;
   orientation?: 'horizontal' | 'vertical';
   placement?: 'top' | 'bottom' | 'left' | 'right';
+  centered?: boolean;
 }
 export interface TabProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -173,6 +181,7 @@ export const Tabs: React.FC<TabsProps> & {
   defaultActive = 0,
   orientation = 'horizontal',
   placement: placementProp,
+  centered = false,
   onTabChange,
   preset: p,
   className,
@@ -242,11 +251,19 @@ export const Tabs: React.FC<TabsProps> & {
         $gap={gap}
         className={cls}
       >
-        {stripFirst && <TabList $orientation={orientation}>{tabs}</TabList>}
+        {stripFirst && (
+          <TabList $orientation={orientation} $center={centered}>
+            {tabs}
+          </TabList>
+        )}
 
         <Panel>{panels}</Panel>
 
-        {!stripFirst && <TabList $orientation={orientation}>{tabs}</TabList>}
+        {!stripFirst && (
+          <TabList $orientation={orientation} $center={centered}>
+            {tabs}
+          </TabList>
+        )}
       </Root>
     </TabsCtx.Provider>
   );


### PR DESCRIPTION
## Summary
- allow Tabs headings to be centered relative to full content area
- document centered headings for vertical and icon examples
- log Tabs centered prop in changelog

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `cd docs && npm test` *(fails: Missing script "test")*
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b91642b8483208b02abfb0a39500b