### PR TITLE
Add centered tab headings option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Add `centered` prop to `Tabs` to center tab headings
+
 ## [0.22.2]
 - Improved visual bug involving skrinking / resizing for `Table` and `Accordion`
 

--- a/docs/src/pages/TabsDemo.tsx
+++ b/docs/src/pages/TabsDemo.tsx
@@ -130,8 +130,21 @@ export default function TabsDemoPage() {
           <Tabs.Panel>{'Settings → ' + THREE}</Tabs.Panel>
         </Tabs>
 
+        {/* 7. Centered headings ------------------------------------------- */}
+        <Typography variant="h3">7. Centered headings</Typography>
+        <Tabs centered>
+          <Tabs.Tab label={<Icon icon="mdi:home" />} aria-label="Home" />
+          <Tabs.Panel>{'Home → ' + ONE}</Tabs.Panel>
+
+          <Tabs.Tab label={<Icon icon="mdi:account" />} aria-label="Profile" />
+          <Tabs.Panel>{'Profile → ' + TWO}</Tabs.Panel>
+
+          <Tabs.Tab label={<Icon icon="mdi:cog" />} aria-label="Settings" />
+          <Tabs.Panel>{'Settings → ' + THREE}</Tabs.Panel>
+        </Tabs>
+
         {/* Theme switcher -------------------------------------------------- */}
-        <Typography variant="h3">7. Theme coupling</Typography>
+        <Typography variant="h3">8. Theme coupling</Typography>
         <Button variant="outlined" onClick={toggleMode}>
           Toggle light / dark
         </Button>

--- a/src/components/layout/Tabs.tsx
+++ b/src/components/layout/Tabs.tsx
@@ -1,6 +1,6 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/widgets/Tabs.tsx | valet
-// Grid-based valet <Tabs> — bullet-proof placement: top / bottom / left / right
+// src/components/layout/Tabs.tsx | valet
+// Grid-based <Tabs>; optional heading centering
 // ─────────────────────────────────────────────────────────────
 import React, {
   createContext,
@@ -73,14 +73,20 @@ const Root = styled('div')<{
 /*───────────────────────────────────────────────────────────*/
 const TabList = styled('div')<{
   $orientation: 'horizontal' | 'vertical';
+  $center?: boolean;
 }>`
   display: flex;
   flex-direction: ${({ $orientation }) =>
     $orientation === 'vertical' ? 'column' : 'row'};
   gap: 0;
 
-  ${({ $orientation }) =>
-    $orientation === 'vertical' && 'width: max-content;'}
+  ${({ $orientation, $center }) => {
+    if ($orientation === 'vertical')
+      return $center
+        ? 'align-self: stretch; height: 100%; justify-content: center;'
+        : 'width: max-content;';
+    return $center ? 'justify-content: center;' : '';
+  }}
 `;
 
 /*───────────────────────────────────────────────────────────*/
@@ -150,6 +156,7 @@ export interface TabsProps
   onTabChange?: (i: number) => void;
   orientation?: 'horizontal' | 'vertical';
   placement?: 'top' | 'bottom' | 'left' | 'right';
+  centered?: boolean;
 }
 export interface TabProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -174,6 +181,7 @@ export const Tabs: React.FC<TabsProps> & {
   orientation = 'horizontal',
   placement: placementProp,
   onTabChange,
+  centered = false,
   preset: p,
   className,
   children,
@@ -242,11 +250,19 @@ export const Tabs: React.FC<TabsProps> & {
         $gap={gap}
         className={cls}
       >
-        {stripFirst && <TabList $orientation={orientation}>{tabs}</TabList>}
+        {stripFirst && (
+          <TabList $orientation={orientation} $center={centered}>
+            {tabs}
+          </TabList>
+        )}
 
         <Panel>{panels}</Panel>
 
-        {!stripFirst && <TabList $orientation={orientation}>{tabs}</TabList>}
+        {!stripFirst && (
+          <TabList $orientation={orientation} $center={centered}>
+            {tabs}
+          </TabList>
+        )}
       </Root>
     </TabsCtx.Provider>
   );


### PR DESCRIPTION
## Summary
- allow `Tabs` to center tab headings via new `centered` prop
- document centered tabs in demo page
- note new property in changelog

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b91642b8483208b02abfb0a39500b