### PR TITLE
Add tab tooltip option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Add optional `tooltip` prop to `Tabs.Tab` for hover hints
+
 ## [0.22.3]
 - Add `centered` prop to `Tabs` to center tab headings
 

--- a/docs/src/pages/TabsDemo.tsx
+++ b/docs/src/pages/TabsDemo.tsx
@@ -120,13 +120,13 @@ export default function TabsDemoPage() {
         {/* 6. Icon headings ----------------------------------------------- */}
         <Typography variant="h3">6. Icon headings</Typography>
         <Tabs>
-          <Tabs.Tab label={<Icon icon="mdi:home" />} aria-label="Home" />
+          <Tabs.Tab label={<Icon icon="mdi:home" />} aria-label="Home" tooltip="Home" />
           <Tabs.Panel>{'Home → ' + ONE}</Tabs.Panel>
 
-          <Tabs.Tab label={<Icon icon="mdi:account" />} aria-label="Profile" />
+          <Tabs.Tab label={<Icon icon="mdi:account" />} aria-label="Profile" tooltip="Profile" />
           <Tabs.Panel>{'Profile → ' + TWO}</Tabs.Panel>
 
-          <Tabs.Tab label={<Icon icon="mdi:cog" />} aria-label="Settings" />
+          <Tabs.Tab label={<Icon icon="mdi:cog" />} aria-label="Settings" tooltip="Settings" />
           <Tabs.Panel>{'Settings → ' + THREE}</Tabs.Panel>
         </Tabs>
 
@@ -167,13 +167,13 @@ export default function TabsDemoPage() {
         {/* 8. Vertical - left centered ---------------------------------- */}
         <Typography variant="h3">8. Vertical – left centered</Typography>
         <Tabs orientation="vertical" centered style={{ height: 200 }}>
-          <Tabs.Tab label={<Icon icon="mdi:home" />} aria-label="Home" />
+          <Tabs.Tab label={<Icon icon="mdi:home" />} aria-label="Home" tooltip="Home" />
           <Tabs.Panel>{'Home → ' + ONE}</Tabs.Panel>
 
-          <Tabs.Tab label={<Icon icon="mdi:account" />} aria-label="Profile" />
+          <Tabs.Tab label={<Icon icon="mdi:account" />} aria-label="Profile" tooltip="Profile" />
           <Tabs.Panel>{'Profile → ' + TWO}</Tabs.Panel>
 
-          <Tabs.Tab label={<Icon icon="mdi:cog" />} aria-label="Settings" />
+          <Tabs.Tab label={<Icon icon="mdi:cog" />} aria-label="Settings" tooltip="Settings" />
           <Tabs.Panel>{'Settings → ' + THREE}</Tabs.Panel>
         </Tabs>
 

--- a/src/components/layout/Tabs.tsx
+++ b/src/components/layout/Tabs.tsx
@@ -1,6 +1,6 @@
 // ─────────────────────────────────────────────────────────────
 // src/components/layout/Tabs.tsx | valet
-// Grid-based <Tabs>; optional heading centering
+// Grid-based <Tabs>; optional heading centering + tab tooltips
 // ─────────────────────────────────────────────────────────────
 import React, {
   createContext,
@@ -17,6 +17,7 @@ import React, {
 import { styled }           from '../../css/createStyled';
 import { useTheme }         from '../../system/themeStore';
 import { preset }           from '../../css/stylePresets';
+import { Tooltip }          from '../widgets/Tooltip';
 import type { Presettable } from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
@@ -163,6 +164,7 @@ export interface TabProps
     Presettable {
   index?: number;
   label?: ReactNode;
+  tooltip?: ReactNode;
 }
 export interface TabPanelProps
   extends React.HTMLAttributes<HTMLDivElement>,
@@ -270,7 +272,7 @@ export const Tabs: React.FC<TabsProps> & {
 
 /*───────────────────────────────────────────────────────────*/
 const Tab: React.FC<TabProps> = forwardRef<HTMLButtonElement, TabProps>(
-  ({ index = 0, label, preset: p, className, onKeyDown, onClick, ...rest }, ref) => {
+  ({ index = 0, label, tooltip, preset: p, className, onKeyDown, onClick, ...rest }, ref) => {
     const { theme } = useTheme();
     const { active, setActive, orientation, registerTab, totalTabs } = useTabs();
     const selected = active === index;
@@ -286,10 +288,10 @@ const Tab: React.FC<TabProps> = forwardRef<HTMLButtonElement, TabProps>(
       onKeyDown?.(e);
     };
 
-    return (
+    const btn = (
       <TabBtn
         {...rest}
-          ref={(el: HTMLButtonElement | null) => {
+        ref={(el: HTMLButtonElement | null) => {
           registerTab(index, el);
           if (typeof ref === 'function') ref(el);
           else if (ref) (ref as any).current = el;
@@ -299,7 +301,7 @@ const Tab: React.FC<TabProps> = forwardRef<HTMLButtonElement, TabProps>(
         aria-selected={selected}
         aria-controls={`panel-${index}`}
         tabIndex={selected ? 0 : -1}
-          onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+        onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
           setActive(index);
           onClick?.(e);
         }}
@@ -312,6 +314,8 @@ const Tab: React.FC<TabProps> = forwardRef<HTMLButtonElement, TabProps>(
         {label ?? rest.children}
       </TabBtn>
     );
+
+    return tooltip ? <Tooltip title={tooltip}>{btn}</Tooltip> : btn;
   },
 );
 Tab.displayName = 'Tabs.Tab';


### PR DESCRIPTION
## Summary
- allow `Tabs.Tab` to show an optional tooltip on hover
- document tab tooltips in Tabs demo
- note tooltip support in changelog

## Testing
- `npm run build`
- `cd docs && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ba4b712a48320b3d38cc3fd21cf12