### PR TITLE
Add optional noSelect prop for Typography

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Add `noSelect` prop to `Typography` to disable text selection
+- Use `Typography` `noSelect` for `Accordion` headers, `Tabs` labels, and `MetroSelect` options
+
 ## [0.22.4]
 - Add optional `tooltip` prop to `Tabs.Tab` for hover hints
 

--- a/src/components/fields/MetroSelect.tsx
+++ b/src/components/fields/MetroSelect.tsx
@@ -108,7 +108,7 @@ export const Option: React.FC<MetroOptionProps> = ({
         ) : (
           <Icon size="lg">{icon}</Icon>
         )}
-        <Typography variant="h6" centered>
+        <Typography variant="h6" centered noSelect>
           {label}
         </Typography>
       </div>

--- a/src/components/layout/Accordion.tsx
+++ b/src/components/layout/Accordion.tsx
@@ -26,6 +26,7 @@ import { toRgb, mix, toHex }    from '../../helpers/color';
 import { useSurface }           from '../../system/surfaceStore';
 import { shallow }              from 'zustand/shallow';
 import type { Presettable }     from '../../types';
+import { Typography }          from '../primitives/Typography';
 
 /*───────────────────────────────────────────────────────────*/
 /* Context                                                   */
@@ -91,11 +92,8 @@ const HeaderBtn = styled('button')<{
   margin-inline-start: -${({ $shift }) => $shift};
   margin-inline-end  : -${({ $shift }) => $shift};
 
-  /* Disable blue tap-highlight & text selection on mobile */
+  /* Disable blue tap-highlight on mobile */
   -webkit-tap-highlight-color: transparent;
-  user-select               : none;
-  -webkit-user-select       : none;
-  -ms-user-select           : none;
 
   transition: background 200ms ease;
 
@@ -490,7 +488,13 @@ const AccordionItem: React.FC<AccordionItemProps> = ({
           $shift={shift}
           $skipHover={skipHover}
         >
-          {header}
+          {typeof header === 'string' || typeof header === 'number' ? (
+            <Typography variant="subtitle" noSelect style={{ font: 'inherit' }}>
+              {header}
+            </Typography>
+          ) : (
+            header
+          )}
           <Chevron aria-hidden $open={isOpen} viewBox="0 0 24 24">
             <path
               d="M6 9l6 6 6-6"

--- a/src/components/layout/Tabs.tsx
+++ b/src/components/layout/Tabs.tsx
@@ -19,6 +19,7 @@ import { useTheme }         from '../../system/themeStore';
 import { preset }           from '../../css/stylePresets';
 import { Tooltip }          from '../widgets/Tooltip';
 import type { Presettable } from '../../types';
+import { Typography }       from '../primitives/Typography';
 
 /*───────────────────────────────────────────────────────────*/
 /* Context                                                   */
@@ -288,6 +289,8 @@ const Tab: React.FC<TabProps> = forwardRef<HTMLButtonElement, TabProps>(
       onKeyDown?.(e);
     };
 
+    const content = label ?? rest.children;
+
     const btn = (
       <TabBtn
         {...rest}
@@ -311,7 +314,13 @@ const Tab: React.FC<TabProps> = forwardRef<HTMLButtonElement, TabProps>(
         $orient={orientation}
         className={[p ? preset(p) : '', className].filter(Boolean).join(' ')}
       >
-        {label ?? rest.children}
+        {typeof content === 'string' || typeof content === 'number' ? (
+          <Typography variant="button" noSelect>
+            {content}
+          </Typography>
+        ) : (
+          content
+        )}
       </TabBtn>
     );
 

--- a/src/components/primitives/Typography.tsx
+++ b/src/components/primitives/Typography.tsx
@@ -1,6 +1,6 @@
 // ─────────────────────────────────────────────────────────────
 // src/components/primitives/Typography.tsx | valet
-// patch: force text wrapping – 2025‑07‑17
+// patch: force text wrapping; add noSelect prop – 2025‑07‑17
 // ─────────────────────────────────────────────────────────────
 import React from 'react';
 import type { JSX } from 'react';
@@ -29,6 +29,7 @@ export interface TypographyProps
   bold?: boolean;
   italic?: boolean;
   centered?: boolean;
+  noSelect?: boolean;
   fontSize?: string;
   scale?: number;
   autoSize?: boolean;
@@ -61,6 +62,7 @@ export const Typography: React.FC<TypographyProps> = ({
   family,
   fontFamily,
   centered,
+  noSelect = false,
   preset: p,
   className,
   children,
@@ -88,6 +90,7 @@ export const Typography: React.FC<TypographyProps> = ({
         $bold: boolean;
         $italic: boolean;
         $center?: boolean;
+        $noSelect: boolean;
       }>`
         margin: 0;
         color: ${({ $color }) => $color || 'var(--valet-text-color, inherit)'};
@@ -113,15 +116,14 @@ export const Typography: React.FC<TypographyProps> = ({
             align-self: center;
             margin-inline: auto;
           `};
-        ${({ $variant }) =>
-          $variant === 'button'
-            ? `
-          user-select: none;
-          -webkit-user-select: none;
-          -ms-user-select: none;
-          -webkit-touch-callout: none;
-        `
-            : ''};
+        ${({ $noSelect }) =>
+          $noSelect &&
+          `
+            user-select: none;
+            -webkit-user-select: none;
+            -ms-user-select: none;
+            -webkit-touch-callout: none;
+          `};
 
         /* Newline & wrapping guards */
         white-space: normal;
@@ -143,6 +145,7 @@ export const Typography: React.FC<TypographyProps> = ({
       $bold={bold}
       $italic={italic}
       $center={centered}
+      $noSelect={noSelect}
       className={[presetClasses, className].filter(Boolean).join(' ')}
     >
       {children}


### PR DESCRIPTION
## Summary
- add `noSelect` prop to Typography for optional text selection disabling
- wire Accordion headers to Typography `noSelect` for plain string titles
- make Tab labels and MetroSelect option text unselectable via Typography

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688bba928504832083453e4e418b9903