### PR TITLE
Add left/right slots to AppBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file. The format 
 ## Unreleased
 
 - Add `left` and `right` slots to `AppBar` for flexible placement
+- **Migration**: replace `icon`/`iconAlign` with `left`/`right`
+  - before: `<AppBar icon={<Icon />} iconAlign="left" />`
+  - after: `<AppBar left={<Icon />} right={<Button />} />`
 
 ## [0.22.5]
 - Add `noSelect` prop to `Typography` to disable text selection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Add `left` and `right` slots to `AppBar` for flexible placement
+
 ## [0.22.5]
 - Add `noSelect` prop to `Typography` to disable text selection
 - Use `Typography` `noSelect` for `Accordion` headers, `Tabs` labels, and `MetroSelect` options

--- a/docs/src/pages/AppBarDemo.tsx
+++ b/docs/src/pages/AppBarDemo.tsx
@@ -1,5 +1,5 @@
 // src/pages/AppBarDemo.tsx
-import { Surface, Stack, Typography, Button, AppBar, Box, Icon, useTheme } from '@archway/valet';
+import { Surface, Stack, Typography, Button, AppBar, Icon, useTheme } from '@archway/valet';
 import { useNavigate } from 'react-router-dom';
 import NavDrawer from '../components/NavDrawer';
 
@@ -10,9 +10,15 @@ export default function AppBarDemoPage() {
   return (
     <Surface>
       <NavDrawer />
-      <AppBar icon={<Icon icon="mdi:car" />}>
-        <Typography fontFamily="Cabin">AppBar with Icon</Typography>
-      </AppBar>
+      <AppBar
+        left={
+          <>
+            <Icon icon="mdi:car" />
+            <Typography fontFamily="Cabin">AppBar Slots</Typography>
+          </>
+        }
+        right={<Button variant="outlined" onClick={toggleMode}>Toggle</Button>}
+      />
       <Stack>
         <Typography variant="h2" bold>
           AppBar Showcase

--- a/src/components/layout/AppBar.tsx
+++ b/src/components/layout/AppBar.tsx
@@ -1,8 +1,8 @@
 // ─────────────────────────────────────────────────────────────
 // src/components/layout/AppBar.tsx  | valet
-// minimal top navigation bar
+// left/right parking slots
 // ─────────────────────────────────────────────────────────────
-import React, { ReactElement, useLayoutEffect, useRef, useId } from 'react';
+import React, { useLayoutEffect, useRef, useId } from 'react';
 import { createPortal } from 'react-dom';
 import { styled } from '../../css/createStyled';
 import { useTheme } from '../../system/themeStore';
@@ -10,7 +10,6 @@ import { useSurface } from '../../system/surfaceStore';
 import { shallow } from 'zustand/shallow';
 import { preset } from '../../css/stylePresets';
 import type { Presettable } from '../../types';
-import type { IconProps } from '../primitives/Icon';
 
 /*───────────────────────────────────────────────────────────*/
 export type AppBarToken = 'primary' | 'secondary' | 'tertiary';
@@ -20,8 +19,8 @@ export interface AppBarProps
     Presettable {
   color?: AppBarToken | string;
   textColor?: AppBarToken | string;
-  icon?: ReactElement<IconProps>;
-  iconPlacement?: 'left' | 'right';
+  left?: React.ReactNode;
+  right?: React.ReactNode;
 }
 
 /*───────────────────────────────────────────────────────────*/
@@ -65,8 +64,8 @@ const RightWrap = styled('div')`
 export const AppBar: React.FC<AppBarProps> = ({
   color,
   textColor,
-  icon,
-  iconPlacement = 'left',
+  left,
+  right,
   preset: p,
   className,
   style,
@@ -137,10 +136,9 @@ export const AppBar: React.FC<AppBarProps> = ({
     >
       <BarBg $bg={bg} />
       <LeftWrap $gap={gap}>
-        {iconPlacement === 'left' && icon}
-        {children}
+        {left ?? children}
       </LeftWrap>
-      {iconPlacement === 'right' && icon && <RightWrap>{icon}</RightWrap>}
+      {right && <RightWrap>{right}</RightWrap>}
     </Bar>
   );
 


### PR DESCRIPTION
## Summary
- allow arbitrary `left` and `right` content in AppBar
- demonstrate new slots in docs AppBar demo
- document AppBar slot props in changelog

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688f81b4c6d083209a4290e93d773803