### PR TITLE
Add disabled style for MetroSelect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+## [0.23.1]
 - Add disabled style for MetroSelect options
 
 ## [0.23.0]
@@ -328,6 +329,8 @@ responsive logic uses the selected `Surface` element to handle persistent margin
 ## [v0.2.1]
 ### Other
 - vibe coded
+
+[v0.23.1]: https://github.com/off-court-creations/valet/releases/tag/v0.23.1
 [v0.23.0]: https://github.com/off-court-creations/valet/releases/tag/v0.23.0
 [v0.22.5]: https://github.com/off-court-creations/valet/releases/tag/v0.22.5
 [v0.22.4]: https://github.com/off-court-creations/valet/releases/tag/v0.22.4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Add disabled style for MetroSelect options
+
 ## [0.23.0]
 - Add `left` and `right` slots to `AppBar` for flexible placement
   - **Migration**: replace `icon`/`iconAlign` with `left`/`right`

--- a/docs/src/pages/MetroSelectDemo.tsx
+++ b/docs/src/pages/MetroSelectDemo.tsx
@@ -118,7 +118,7 @@ export default function MetroSelectDemoPage() {
   // Sample option lists -------------------------------------------------
   const basic = [
     { icon: 'mdi:home', label: 'Home', value: 'home' },
-    { icon: 'mdi:briefcase', label: 'Work', value: 'work' },
+    { icon: 'mdi:briefcase', label: 'Work', value: 'work', disabled: true },
     { icon: 'mdi:airplane', label: 'Travel', value: 'travel' },
   ];
 

--- a/src/components/fields/MetroSelect.tsx
+++ b/src/components/fields/MetroSelect.tsx
@@ -15,6 +15,7 @@ import { Icon } from '../primitives/Icon';
 import { Typography } from '../primitives/Typography';
 import { useTheme } from '../../system/themeStore';
 import { preset } from '../../css/stylePresets';
+import { toHex, toRgb, mix } from '../../helpers/color';
 import type { Presettable } from '../../types';
 
 export type Primitive = string | number;
@@ -60,12 +61,24 @@ export const Option: React.FC<MetroOptionProps> = ({
   className,
   ...rest
 }) => {
-  const { theme } = useTheme();
+  const { theme, mode } = useTheme();
   const { value: sel, setValue } = useMetro();
 
   const selected = sel !== null && String(sel) === String(value);
 
   const presetCls = p ? preset(p) : '';
+
+  const disabledColor = useMemo(
+    () =>
+      toHex(
+        mix(
+          toRgb(theme.colors.text),
+          toRgb(mode === 'dark' ? '#000' : '#fff'),
+          0.4,
+        ),
+      ),
+    [theme, mode],
+  );
 
   const innerStyle: React.CSSProperties = {
     paddingTop: theme.spacing(3),
@@ -95,9 +108,15 @@ export const Option: React.FC<MetroOptionProps> = ({
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        borderColor: selected ? theme.colors.primary : undefined,
-        background: selected ? theme.colors.primary : undefined,
-        color: selected ? theme.colors.primaryText : undefined,
+        borderColor:
+          selected && !disabled
+            ? theme.colors.primary
+            : disabled
+            ? disabledColor
+            : undefined,
+        background: selected && !disabled ? theme.colors.primary : undefined,
+        color: disabled ? disabledColor : selected ? theme.colors.primaryText : undefined,
+        opacity: disabled ? 0.45 : 1,
         ...style,
       }}
       className={[presetCls, className].filter(Boolean).join(' ')}


### PR DESCRIPTION
## Summary
- style MetroSelect options when disabled
- show disabled option in MetroSelect docs

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894b78a0cdc8320a641ea1f6c428c4f