### PR TITLE
Add fontFamily support to TextField and RichChat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Add `fontFamily` prop to `TextField` and `RichChat` for custom input fonts
+
 ## [0.23.1]
 - Add disabled style for MetroSelect options
 

--- a/src/components/fields/TextField.tsx
+++ b/src/components/fields/TextField.tsx
@@ -1,6 +1,6 @@
 // ─────────────────────────────────────────────────────────────
 // src/components/fields/TextField.tsx  | valet
-// controlled text input integrating with FormControl
+// controlled text input integrating with FormControl; add fontFamily prop
 // ─────────────────────────────────────────────────────────────
 import React, {
   forwardRef,
@@ -29,6 +29,8 @@ interface FieldCommon extends Presettable {
   error?: boolean;
   /** Stretch the wrapper to fill available width */
   fullWidth?: boolean;
+  /** Override input font */
+  fontFamily?: string;
 }
 
 export type TextFieldProps =
@@ -97,6 +99,7 @@ export const TextField = forwardRef<
     helperText,
     error = false,
     fullWidth = false,
+    fontFamily,
     preset: presetName,
     className,
     rows,
@@ -167,6 +170,7 @@ export const TextField = forwardRef<
         value={controlledValue}
         defaultValue={defaultValue}
         onChange={handleChange}
+        style={fontFamily ? { fontFamily } : undefined}
       />
 
       {helperText && (

--- a/src/components/widgets/RichChat.tsx
+++ b/src/components/widgets/RichChat.tsx
@@ -1,6 +1,6 @@
 // ─────────────────────────────────────────────────────────────
 // src/components/widgets/RichChat.tsx  | valet
-// Local chat component with embeddable content
+// Local chat component with embeddable content; add fontFamily prop
 // ─────────────────────────────────────────────────────────────
 import React, {
   useState,
@@ -47,6 +47,8 @@ export interface RichChatProps
   placeholder?: string;
   disableInput?: boolean;
   constrainHeight?: boolean;
+  /** Override input font */
+  fontFamily?: string;
 }
 
 /*───────────────────────────────────────────────────────────*/
@@ -111,6 +113,7 @@ export const RichChat: React.FC<RichChatProps> = ({
   placeholder = 'Message…',
   disableInput = false,
   constrainHeight = true,
+  fontFamily,
   preset: p,
   className,
   style,
@@ -322,6 +325,7 @@ export const RichChat: React.FC<RichChatProps> = ({
                 rows={1}
                 placeholder={placeholder}
                 fullWidth
+                fontFamily={fontFamily}
               />
               <IconButton icon="carbon:send" type="submit" aria-label="Send" />
             </Stack>


### PR DESCRIPTION
## Summary
- allow TextField to override its input font via new `fontFamily` prop
- expose `fontFamily` on RichChat and forward it to the message field
- document new option in changelog

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689556f904348320b0f3e6f373420626