### PR TITLE
Add adaptive Skeleton component with pulsing placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. The format 
 ## Unreleased
 
 - Add versatile `Skeleton` component with pulsing placeholder
+- Improve `Skeleton` fade transition and content-wrapping width
 
 ## [0.23.2]
 - Add `fontFamily` prop to `TextField` and `RichChat` for custom input fonts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. The format 
 
 - Add versatile `Skeleton` component with pulsing placeholder
 - Improve `Skeleton` fade transition and content-wrapping width
+- Fix `Skeleton` placeholder stretching to full container width
 
 ## [0.23.2]
 - Add `fontFamily` prop to `TextField` and `RichChat` for custom input fonts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Add versatile `Skeleton` component with pulsing placeholder
+
 ## [0.23.2]
 - Add `fontFamily` prop to `TextField` and `RichChat` for custom input fonts
 

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -42,6 +42,7 @@ const AccordionConstrainedDemoPage = page(() => import('./pages/AccordionConstra
 const TabsDemoPage          = page(() => import('./pages/TabsDemo'));
 const SliderDemoPage        = page(() => import('./pages/SliderDemo'));
 const ProgressDemoPage      = page(() => import('./pages/ProgressDemo'));
+const SkeletonDemoPage      = page(() => import('./pages/SkeletonDemo'));
 const SelectDemoPage        = page(() => import('./pages/SelectDemo'));
 const TablePlaygroundPage   = page(() => import('./pages/TableDemo'));
 const ListDemoPage          = page(() => import('./pages/ListDemoPage'));
@@ -121,6 +122,7 @@ export function App() {
         <Route path="/tabs-demo"       element={<TabsDemoPage />} />
         <Route path="/slider-demo"     element={<SliderDemoPage />} />
         <Route path="/progress-demo"   element={<ProgressDemoPage />} />
+        <Route path="/skeleton-demo"   element={<SkeletonDemoPage />} />
         <Route path="/select-demo"     element={<SelectDemoPage />} />
         <Route path="/table-demo"      element={<TablePlaygroundPage />} />
         <Route path="/list-demo"       element={<ListDemoPage />} />

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -21,6 +21,7 @@ const primitives: [string, string][] = [
   ['Icon', '/icon-demo'],
   ['Image', '/image-demo'],
   ['Progress', '/progress-demo'],
+  ['Skeleton', '/skeleton-demo'],
   ['Typography', '/typography'],
   ['Video', '/video-demo'],
 ];

--- a/docs/src/pages/ImageDemo.tsx
+++ b/docs/src/pages/ImageDemo.tsx
@@ -23,7 +23,7 @@ export default function ImageDemoPage() {
 
         <Typography variant="h3">1. Basic usage</Typography>
         <Image
-          src="https://placecats.com/800/400"
+          src="https://picsum.photos/400/300"
           alt="Kitten"
           width="100%"
           height="auto"
@@ -32,7 +32,7 @@ export default function ImageDemoPage() {
 
         <Typography variant="h3">2. Lazy loaded</Typography>
         <Image
-          src="https://placecats.com/600/400"
+          src="https://picsum.photos/400/300"
           alt="Lazy kitten"
           width="100%"
           height="300px"
@@ -42,7 +42,7 @@ export default function ImageDemoPage() {
 
         <Typography variant="h3">3. Contain fit</Typography>
         <Image
-          src="https://placecats.com/400/500"
+          src="https://picsum.photos/400/300"
           alt="Contained kitten"
           width="100%"
           height="300px"

--- a/docs/src/pages/SkeletonDemo.tsx
+++ b/docs/src/pages/SkeletonDemo.tsx
@@ -91,7 +91,7 @@ export default function SkeletonDemoPage() {
 
               <Skeleton loading={loading}>
                 <Image
-                  src="https://placecats.com/160/80"
+                  src="https://picsum.photos/400/300"
                   alt="Loading kitten"
                   width={160}
                   height={80}

--- a/docs/src/pages/SkeletonDemo.tsx
+++ b/docs/src/pages/SkeletonDemo.tsx
@@ -1,0 +1,114 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/SkeletonDemo.tsx | valet
+// Showcase of Skeleton component
+// ─────────────────────────────────────────────────────────────
+import { 
+  Surface,
+  Stack,
+  Typography,
+  Skeleton,
+  Avatar,
+  Button,
+  Tabs,
+  Table,
+  useTheme,
+} from '@archway/valet';
+import type { TableColumn } from '@archway/valet';
+import type { ReactNode } from 'react';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../components/NavDrawer';
+
+export default function SkeletonDemoPage() {
+  const { theme } = useTheme();
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(true);
+
+  interface Row {
+    prop: ReactNode;
+    type: ReactNode;
+    default: ReactNode;
+    description: ReactNode;
+  }
+
+  const columns: TableColumn<Row>[] = [
+    { header: 'Prop', accessor: 'prop' },
+    { header: 'Type', accessor: 'type' },
+    { header: 'Default', accessor: 'default' },
+    { header: 'Description', accessor: 'description' },
+  ];
+
+  const data: Row[] = [
+    {
+      prop: <code>loading</code>,
+      type: <code>boolean</code>,
+      default: <code>true</code>,
+      description: 'Show placeholder while true',
+    },
+    {
+      prop: <code>variant</code>,
+      type: <code>'text' | 'rect' | 'circle'</code>,
+      default: <code>-</code>,
+      description: 'Override inferred placeholder shape',
+    },
+    {
+      prop: <code>preset</code>,
+      type: <code>string | string[]</code>,
+      default: <code>-</code>,
+      description: 'Apply style presets',
+    },
+  ];
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack>
+        <Typography variant="h2">Skeleton</Typography>
+
+        <Tabs>
+          <Tabs.Tab label="Usage" />
+          <Tabs.Panel>
+            <Typography variant="subtitle">
+              Adaptive placeholder with pulsing animation
+            </Typography>
+
+            <Button
+              onClick={() => setLoading((l) => !l)}
+              style={{ alignSelf: 'flex-start', marginTop: theme.spacing(1) }}
+            >
+              {loading ? 'Show content' : 'Show skeleton'}
+            </Button>
+
+            <Stack spacing={1} style={{ marginTop: theme.spacing(1) }}>
+              <Skeleton loading={loading}>
+                <Typography variant="body">Text loads in…</Typography>
+              </Skeleton>
+
+              <Skeleton loading={loading}>
+                <Avatar email="support@gravatar.com" size="l" />
+              </Skeleton>
+
+              <Skeleton loading={loading} variant="rect">
+                <div style={{ width: 160, height: 80, background: theme.colors['backgroundAlt'] }} />
+              </Skeleton>
+            </Stack>
+          </Tabs.Panel>
+
+          <Tabs.Tab label="Reference" />
+          <Tabs.Panel>
+            <Typography variant="h3">Prop reference</Typography>
+            <Table data={data} columns={columns} constrainHeight={false} />
+          </Tabs.Panel>
+        </Tabs>
+
+        <Button
+          size="lg"
+          onClick={() => navigate(-1)}
+          style={{ marginTop: theme.spacing(1) }}
+        >
+          ← Back
+        </Button>
+      </Stack>
+    </Surface>
+  );
+}

--- a/docs/src/pages/SkeletonDemo.tsx
+++ b/docs/src/pages/SkeletonDemo.tsx
@@ -8,6 +8,7 @@ import {
   Typography,
   Skeleton,
   Avatar,
+  Image,
   Button,
   Tabs,
   Table,
@@ -86,6 +87,16 @@ export default function SkeletonDemoPage() {
 
               <Skeleton loading={loading}>
                 <Avatar email="support@gravatar.com" size="l" />
+              </Skeleton>
+
+              <Skeleton loading={loading}>
+                <Image
+                  src="https://placecats.com/160/80"
+                  alt="Loading kitten"
+                  width={160}
+                  height={80}
+                  rounded={4}
+                />
               </Skeleton>
 
               <Skeleton loading={loading} variant="rect">

--- a/src/components/primitives/Skeleton.tsx
+++ b/src/components/primitives/Skeleton.tsx
@@ -99,10 +99,11 @@ export const Skeleton = forwardRef<HTMLSpanElement, SkeletonProps>(
     const { theme } = useTheme();
     const bg = theme.colors.backgroundAlt;
 
+    const fadeMs = 400;
     const [show, setShow] = useState(loading);
     useEffect(() => {
       if (!loading) {
-        const t = setTimeout(() => setShow(false), 250);
+        const t = setTimeout(() => setShow(false), fadeMs);
         return () => clearTimeout(t);
       }
       setShow(true);
@@ -125,7 +126,11 @@ export const Skeleton = forwardRef<HTMLSpanElement, SkeletonProps>(
             aria-hidden="true"
             $bg={bg}
             $radius={radius}
-            style={{ opacity: loading ? 1 : 0, transition: 'opacity 0.25s ease' }}
+            style={{
+              opacity: loading ? 1 : 0,
+              transform: loading ? 'none' : 'scale(0.98)',
+              transition: `opacity ${fadeMs}ms ease, transform ${fadeMs}ms ease`,
+            }}
           />
         )}
         {el &&
@@ -133,9 +138,12 @@ export const Skeleton = forwardRef<HTMLSpanElement, SkeletonProps>(
             'aria-hidden': loading,
             style: {
               ...el.props.style,
+              ...(loading && resolved === 'text'
+                ? { display: 'inline-block', width: 'fit-content' }
+                : null),
               visibility: loading ? 'hidden' : undefined,
               opacity: loading ? 0 : 1,
-              transition: 'opacity 0.25s ease',
+              transition: `opacity ${fadeMs}ms ease`,
             },
           } as any)}
       </Wrapper>

--- a/src/components/primitives/Skeleton.tsx
+++ b/src/components/primitives/Skeleton.tsx
@@ -1,0 +1,147 @@
+// ─────────────────────────────────────────────────────────────
+// src/components/primitives/Skeleton.tsx  | valet
+// Adaptive skeleton placeholder with content-aware sizing
+// ─────────────────────────────────────────────────────────────
+import React, { useEffect, useState, forwardRef } from 'react';
+import { styled, keyframes } from '../../css/createStyled';
+import { useTheme } from '../../system/themeStore';
+import { preset } from '../../css/stylePresets';
+import type { Presettable } from '../../types';
+
+export type SkeletonVariant = 'text' | 'rect' | 'circle';
+
+export interface SkeletonProps
+  extends React.HTMLAttributes<HTMLSpanElement>,
+    Presettable {
+  /** Show placeholder while true */
+  loading?: boolean;
+  /** Override detected placeholder shape */
+  variant?: SkeletonVariant;
+}
+
+/*───────────────────────────────────────────────────────────*/
+/* Animation                                                  */
+const pulse = keyframes`
+  0%   { opacity: 0.6; }
+  50%  { opacity: 1;   }
+  100% { opacity: 0.6; }
+`;
+
+/*───────────────────────────────────────────────────────────*/
+/* Styled primitives                                         */
+const Wrapper = styled('span')`
+  display: inline-block;
+  position: relative;
+`;
+
+const Placeholder = styled('span')<{
+  $bg: string;
+  $radius: string;
+}>`
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: ${({ $radius }) => $radius};
+  background: ${({ $bg }) => $bg};
+  animation: ${pulse} 1.5s ease-in-out infinite;
+  pointer-events: none;
+`;
+
+/*───────────────────────────────────────────────────────────*/
+/* Helpers                                                   */
+function inferVariant(child: React.ReactNode): SkeletonVariant {
+  if (!child) return 'rect';
+  if (typeof child === 'string') return 'text';
+  if (React.isValidElement(child)) {
+    const t: any = child.type;
+    const name =
+      typeof t === 'string'
+        ? t
+        : t.displayName || t.name || '';
+    if (/avatar|icon|img/i.test(name)) return 'circle';
+    if (/typography|span|p|h[1-6]|text/i.test(name)) return 'text';
+  }
+  return 'rect';
+}
+
+function radiusFor(v: SkeletonVariant): string {
+  switch (v) {
+    case 'circle':
+      return '50%';
+    case 'text':
+      return '0.125rem';
+    default:
+      return '0.25rem';
+  }
+}
+
+/*───────────────────────────────────────────────────────────*/
+/* Component                                                 */
+export const Skeleton = forwardRef<HTMLSpanElement, SkeletonProps>(
+  (
+    {
+      loading = true,
+      variant,
+      preset: p,
+      className,
+      children,
+      style,
+      ...rest
+    },
+    ref,
+  ) => {
+    const child = React.Children.count(children) === 1 ? children : null;
+    const resolved = variant || inferVariant(child);
+    const radius = radiusFor(resolved);
+
+    const { theme } = useTheme();
+    const bg = theme.colors.backgroundAlt;
+
+    const [show, setShow] = useState(loading);
+    useEffect(() => {
+      if (!loading) {
+        const t = setTimeout(() => setShow(false), 250);
+        return () => clearTimeout(t);
+      }
+      setShow(true);
+    }, [loading]);
+
+    const presetCls = p ? preset(p) : '';
+
+    const el = child as React.ReactElement<any> | null;
+
+    return (
+      <Wrapper
+        {...rest}
+        ref={ref}
+        style={style}
+        className={[presetCls, className].filter(Boolean).join(' ')}
+        aria-busy={loading}
+      >
+        {show && (
+          <Placeholder
+            aria-hidden="true"
+            $bg={bg}
+            $radius={radius}
+            style={{ opacity: loading ? 1 : 0, transition: 'opacity 0.25s ease' }}
+          />
+        )}
+        {el &&
+          React.cloneElement(el, {
+            'aria-hidden': loading,
+            style: {
+              ...el.props.style,
+              visibility: loading ? 'hidden' : undefined,
+              opacity: loading ? 0 : 1,
+              transition: 'opacity 0.25s ease',
+            },
+          } as any)}
+      </Wrapper>
+    );
+  },
+);
+
+Skeleton.displayName = 'Skeleton';
+export default Skeleton;

--- a/src/components/primitives/Skeleton.tsx
+++ b/src/components/primitives/Skeleton.tsx
@@ -32,6 +32,8 @@ const pulse = keyframes`
 const Wrapper = styled('span')`
   display: inline-block;
   position: relative;
+  align-self: flex-start;
+  width: fit-content;
 `;
 
 const Placeholder = styled('span')<{

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export * from './components/layout/Modal';
 export * from './components/primitives/Progress';
 export * from './components/primitives/Video';
 export * from './components/primitives/Image';
+export * from './components/primitives/Skeleton';
 
 // ─── Layout Primitives ──────────────────────────────────────
 export * from './components/layout/Grid';


### PR DESCRIPTION
## Summary
- add content-aware Skeleton with animated pulse
- export Skeleton from package index
- note new Skeleton component in changelog

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68957c3601c4832081256e9828c34894