### PR TITLE
Smooth Skeleton fade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. The format 
 - Add versatile `Skeleton` component with pulsing placeholder
 - Improve `Skeleton` fade transition and content-wrapping width
 - Fix `Skeleton` placeholder stretching to full container width
+- Smooth `Skeleton` fade by dropping scale transform and waiting for transition end
 - Prevent `Image` dragging to avoid ghost cursor
 
 ## [0.23.2]

--- a/src/components/primitives/Skeleton.tsx
+++ b/src/components/primitives/Skeleton.tsx
@@ -2,7 +2,7 @@
 // src/components/primitives/Skeleton.tsx  | valet
 // Adaptive skeleton placeholder with content-aware sizing
 // ─────────────────────────────────────────────────────────────
-import React, { useEffect, useState, forwardRef } from 'react';
+import React, { useEffect, useState, forwardRef, useRef } from 'react';
 import { styled, keyframes } from '../../css/createStyled';
 import { useTheme } from '../../system/themeStore';
 import { preset } from '../../css/stylePresets';
@@ -103,12 +103,17 @@ export const Skeleton = forwardRef<HTMLSpanElement, SkeletonProps>(
 
     const fadeMs = 400;
     const [show, setShow] = useState(loading);
+    const phRef = useRef<HTMLSpanElement>(null);
     useEffect(() => {
       if (!loading) {
-        const t = setTimeout(() => setShow(false), fadeMs);
-        return () => clearTimeout(t);
+        const node = phRef.current;
+        if (node) {
+          const handler = () => setShow(false);
+          node.addEventListener('transitionend', handler, { once: true });
+        }
+      } else {
+        setShow(true);
       }
-      setShow(true);
     }, [loading]);
 
     const presetCls = p ? preset(p) : '';
@@ -125,13 +130,14 @@ export const Skeleton = forwardRef<HTMLSpanElement, SkeletonProps>(
       >
         {show && (
           <Placeholder
+            ref={phRef}
             aria-hidden="true"
             $bg={bg}
             $radius={radius}
             style={{
               opacity: loading ? 1 : 0,
-              transform: loading ? 'none' : 'scale(0.98)',
-              transition: `opacity ${fadeMs}ms ease, transform ${fadeMs}ms ease`,
+              transition: `opacity ${fadeMs}ms ease`,
+              willChange: 'opacity',
             }}
           />
         )}
@@ -146,6 +152,7 @@ export const Skeleton = forwardRef<HTMLSpanElement, SkeletonProps>(
               visibility: loading ? 'hidden' : undefined,
               opacity: loading ? 0 : 1,
               transition: `opacity ${fadeMs}ms ease`,
+              willChange: 'opacity',
             },
           } as any)}
       </Wrapper>


### PR DESCRIPTION
## Summary
- smooth skeleton fade with `transitionend`
- drop scale transform and hint opacity animations
- document improved skeleton fade

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68959dd2ca3c8320aad7e695645f7f71