### PR TITLE
Add optional loading icon to Skeleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Allow `Skeleton` to display optional icon while loading
+
 ## [0.23.3]
 - Added `Skeleton` component
 - Prevent `Image` dragging to avoid ghost cursor

--- a/docs/src/pages/SkeletonDemo.tsx
+++ b/docs/src/pages/SkeletonDemo.tsx
@@ -12,6 +12,7 @@ import {
   Button,
   Tabs,
   Table,
+  Icon,
   useTheme,
 } from '@archway/valet';
 import type { TableColumn } from '@archway/valet';
@@ -52,6 +53,12 @@ export default function SkeletonDemoPage() {
       type: <code>'text' | 'rect' | 'circle'</code>,
       default: <code>-</code>,
       description: 'Override inferred placeholder shape',
+    },
+    {
+      prop: <code>icon</code>,
+      type: <code>ReactNode</code>,
+      default: <code>-</code>,
+      description: 'Optional icon shown while loading',
     },
     {
       prop: <code>preset</code>,
@@ -119,6 +126,16 @@ export default function SkeletonDemoPage() {
                       background: theme.colors['backgroundAlt'],
                     }}
                   />
+                </Skeleton>
+              </Stack>
+
+              <Stack compact>
+                <Typography variant="subtitle">With icon</Typography>
+                <Skeleton
+                  loading={loading}
+                  icon={<Icon icon="mdi:clock-outline" />}
+                >
+                  <Typography variant="body">Loading with icon…</Typography>
                 </Skeleton>
               </Stack>
 

--- a/src/components/primitives/Skeleton.tsx
+++ b/src/components/primitives/Skeleton.tsx
@@ -17,6 +17,8 @@ export interface SkeletonProps
   loading?: boolean;
   /** Override detected placeholder shape */
   variant?: SkeletonVariant;
+  /** Optional icon rendered while loading */
+  icon?: React.ReactNode;
 }
 
 /*───────────────────────────────────────────────────────────*/
@@ -41,6 +43,9 @@ const Placeholder = styled('span')<{
   $radius: string;
   $loading: boolean;
 }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
   position: absolute;
   top: 0;
   left: 0;
@@ -89,6 +94,7 @@ export const Skeleton = forwardRef<HTMLSpanElement, SkeletonProps>(
     {
       loading = true,
       variant,
+      icon,
       preset: p,
       className,
       children,
@@ -143,7 +149,9 @@ export const Skeleton = forwardRef<HTMLSpanElement, SkeletonProps>(
               transition: `opacity ${fadeMs}ms ease`,
               willChange: 'opacity',
             }}
-          />
+          >
+            {loading && icon}
+          </Placeholder>
         )}
         {el &&
           React.cloneElement(el, {


### PR DESCRIPTION
## Summary
- allow Skeleton to render an optional icon while loading
- document Skeleton icon usage in demo
- note feature in changelog

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6895ac6f52388320b41ce49942f2ed98