### PR TITLE
Guard Slider against missing FormControl context

### DIFF
--- a/src/components/fields/Slider.tsx
+++ b/src/components/fields/Slider.tsx
@@ -253,12 +253,15 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
       };
     }
 
-    /* optional FormControl binding (always call hook) -------- */
+    /* optional FormControl binding --------------------------- */
     // We only rely on `values` and an optional `setField`.
-    const form = useForm<Record<string, number | undefined>>() as unknown as NumForm;
+    let form: NumForm | null = null;
+    try {
+      form = useForm<Record<string, number | undefined>>() as unknown as NumForm;
+    } catch {}
 
     /* controlled hierarchy ---------------------------------- */
-    const formVal = form && name ? form.values[name] : undefined;
+    const formVal = name ? form?.values[name] : undefined;
     const controlled = formVal !== undefined || valueProp !== undefined;
     const [self, setSelf] = useState(defaultValue);
     const current = controlled ? (formVal !== undefined ? formVal : (valueProp as number)) : self;


### PR DESCRIPTION
## Summary
- allow Slider to mount outside FormControl without crashing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: eslint reported 342 problems)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68982d9505a08320bd8ed72935166688