### PR TITLE
Guard Slider and DateSelector against missing FormControl context

### DIFF
--- a/src/components/fields/DateSelector.tsx
+++ b/src/components/fields/DateSelector.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/widgets/DateSelector.tsx | valet
+// src/components/fields/DateSelector.tsx | valet
 // interactive month calendar for picking dates
 // ─────────────────────────────────────────────────────────────
 import React, { useState } from 'react';
@@ -129,9 +129,12 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
   ...rest
 }) => {
   const { theme } = useTheme();
-  let form: ReturnType<typeof useForm<any>> | null = null;
+
+  /* optional FormControl binding --------------------------- */
+  type StringForm = ReturnType<typeof useForm<Record<string, string | undefined>>>;
+  let form: StringForm | null = null;
   try {
-    form = useForm<any>();
+    form = useForm<Record<string, string | undefined>>();
   } catch {}
 
   const formVal = form && name ? (form.values[name] as string | undefined) : undefined;

--- a/src/components/fields/Select.tsx
+++ b/src/components/fields/Select.tsx
@@ -203,7 +203,10 @@ const Inner = (props: SelectProps, ref: React.Ref<HTMLDivElement>) => {
   const primary = theme.colors.primary;
 
   /* optional FormControl hook ------------------------------ */
-  const form = useForm<Record<string, unknown>>() as unknown as MinimalForm | null;
+  let form: MinimalForm | null = null;
+  try {
+    form = useForm<Record<string, unknown>>() as unknown as MinimalForm;
+  } catch {}
 
   /* value management --------------------------------------- */
   const formVal =

--- a/src/components/fields/Slider.tsx
+++ b/src/components/fields/Slider.tsx
@@ -253,12 +253,15 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
       };
     }
 
-    /* optional FormControl binding (always call hook) -------- */
+    /* optional FormControl binding --------------------------- */
     // We only rely on `values` and an optional `setField`.
-    const form = useForm<Record<string, number | undefined>>() as unknown as NumForm;
+    let form: NumForm | null = null;
+    try {
+      form = useForm<Record<string, number | undefined>>() as unknown as NumForm;
+    } catch {}
 
     /* controlled hierarchy ---------------------------------- */
-    const formVal = form && name ? form.values[name] : undefined;
+    const formVal = name ? form?.values[name] : undefined;
     const controlled = formVal !== undefined || valueProp !== undefined;
     const [self, setSelf] = useState(defaultValue);
     const current = controlled ? (formVal !== undefined ? formVal : (valueProp as number)) : self;


### PR DESCRIPTION
## Summary
- allow Slider and DateSelector to mount outside FormControl without crashing
- make Select's form hook optional so internal DateSelector dropdowns don't break

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: React Hook "useForm" is called conditionally, 340 errors total)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68982d9505a08320bd8ed72935166688