### PR TITLE
Guard inputs against missing FormControl context

### DIFF
--- a/src/components/fields/DateSelector.tsx
+++ b/src/components/fields/DateSelector.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────
-// src/components/widgets/DateSelector.tsx | valet
+// src/components/fields/DateSelector.tsx | valet
 // interactive month calendar for picking dates
 // ─────────────────────────────────────────────────────────────
 import React, { useState } from 'react';
@@ -129,10 +129,15 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
   ...rest
 }) => {
   const { theme } = useTheme();
-  let form: ReturnType<typeof useForm<any>> | null = null;
+
+  /* optional FormControl binding --------------------------- */
+  type StringForm = ReturnType<typeof useForm<Record<string, string | undefined>>>;
+  let form: StringForm | null = null;
   try {
-    form = useForm<any>();
-  } catch {}
+    form = useForm<Record<string, string | undefined>>();
+  } catch {
+    /* No FormControl context available */
+  }
 
   const formVal = form && name ? (form.values[name] as string | undefined) : undefined;
   const controlled = value !== undefined || formVal !== undefined;

--- a/src/components/fields/Select.tsx
+++ b/src/components/fields/Select.tsx
@@ -203,7 +203,12 @@ const Inner = (props: SelectProps, ref: React.Ref<HTMLDivElement>) => {
   const primary = theme.colors.primary;
 
   /* optional FormControl hook ------------------------------ */
-  const form = useForm<Record<string, unknown>>() as unknown as MinimalForm | null;
+  let form: MinimalForm | null = null;
+  try {
+    form = useForm<Record<string, unknown>>() as unknown as MinimalForm;
+  } catch {
+    /* No FormControl context available */
+  }
 
   /* value management --------------------------------------- */
   const formVal =

--- a/src/components/fields/Slider.tsx
+++ b/src/components/fields/Slider.tsx
@@ -253,12 +253,17 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
       };
     }
 
-    /* optional FormControl binding (always call hook) -------- */
+    /* optional FormControl binding --------------------------- */
     // We only rely on `values` and an optional `setField`.
-    const form = useForm<Record<string, number | undefined>>() as unknown as NumForm;
+    let form: NumForm | null = null;
+    try {
+      form = useForm<Record<string, number | undefined>>() as unknown as NumForm;
+    } catch {
+      /* No FormControl context available */
+    }
 
     /* controlled hierarchy ---------------------------------- */
-    const formVal = form && name ? form.values[name] : undefined;
+    const formVal = name ? form?.values[name] : undefined;
     const controlled = formVal !== undefined || valueProp !== undefined;
     const [self, setSelf] = useState(defaultValue);
     const current = controlled ? (formVal !== undefined ? formVal : (valueProp as number)) : self;

--- a/src/components/fields/TextField.tsx
+++ b/src/components/fields/TextField.tsx
@@ -118,8 +118,12 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
       setField: (field: string, value: unknown) => void;
     } | null;
 
-    // Call unconditionally to satisfy hooks rule; provider-less usage should be handled by the hook.
-    const form = useForm() as unknown as FormApi;
+    let form: FormApi = null;
+    try {
+      form = useForm() as unknown as FormApi;
+    } catch {
+      /* No FormControl context available */
+    }
 
     const presetClasses = presetName ? preset(presetName) : '';
     const wrapperStyle = fullWidth ? { flex: 1, width: '100%', ...styleProp } : styleProp;


### PR DESCRIPTION
## Summary
- allow Slider, DateSelector, and TextField to mount outside FormControl without crashing
- annotate optional FormControl catches in Slider, DateSelector, and Select

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: React Hook "useForm" is called conditionally, 338 errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68982d9505a08320bd8ed72935166688