### PR TITLE
docs: link RadioGroup demo in nav drawer

### DIFF
--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -40,6 +40,7 @@ const fields: [string, string][] = [
   ['Checkbox', '/checkbox-demo'],
   ['Date Selector', '/dateselector-demo'],
   ['Icon Button', '/icon-button-demo'],
+  ['Radio Group', '/radio-demo'],
   ['Select', '/select-demo'],
   ['Metro Select', '/metroselect-demo'],
   ['Iterator', '/iterator-demo'],


### PR DESCRIPTION
## Summary
- add Radio Group demo entry to docs navigation drawer

## Testing
- `npm run lint` *(fails: 151 problems)*

------
https://chatgpt.com/codex/tasks/task_e_689932932c288320afce596a2ee72c77