### PR TITLE
Add optional form hook for field components

### DIFF
--- a/src/components/fields/Checkbox.tsx
+++ b/src/components/fields/Checkbox.tsx
@@ -7,7 +7,7 @@ import React, { forwardRef, useCallback, useId, useState, ChangeEvent, ReactNode
 import { styled } from '../../css/createStyled';
 import { useTheme } from '../../system/themeStore';
 import { preset } from '../../css/stylePresets';
-import { useForm } from './FormControl';
+import { useOptionalForm } from './FormControl';
 import { toRgb, mix, toHex } from '../../helpers/color';
 import type { Theme } from '../../system/themeStore';
 import type { Presettable } from '../../types';
@@ -172,10 +172,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     );
 
     /* Optional FormControl binding -------------------------------------- */
-    let form: ReturnType<typeof useForm<any>> | null = null;
-    try {
-      form = useForm<any>();
-    } catch {}
+    const form = useOptionalForm<Record<string, unknown>>();
 
     /* Controlled vs uncontrolled logic ---------------------------------- */
     const controlled = checkedProp !== undefined;
@@ -199,7 +196,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
       (e: ChangeEvent<HTMLInputElement>) => {
         const next = e.target.checked;
         if (!controlled && !formBound) setInternal(next);
-        form?.setField(name as any, next);
+        if (form && name) form.setField(name as keyof Record<string, unknown>, next as unknown);
         onChange?.(next, e);
       },
       [controlled, formBound, form, name, onChange],

--- a/src/components/fields/DateSelector.tsx
+++ b/src/components/fields/DateSelector.tsx
@@ -8,7 +8,7 @@ import { useTheme } from '../../system/themeStore';
 import { preset } from '../../css/stylePresets';
 import { IconButton } from './IconButton';
 import { Select } from './Select';
-import { useForm } from './FormControl';
+import { useOptionalForm } from './FormControl';
 import { toRgb, mix, toHex } from '../../helpers/color';
 import type { Presettable } from '../../types';
 
@@ -131,13 +131,7 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
   const { theme } = useTheme();
 
   /* optional FormControl binding --------------------------- */
-  type StringForm = ReturnType<typeof useForm<Record<string, string | undefined>>>;
-  let form: StringForm | null = null;
-  try {
-    form = useForm<Record<string, string | undefined>>();
-  } catch {
-    /* No FormControl context available */
-  }
+  const form = useOptionalForm<Record<string, string | undefined>>();
 
   const formVal = form && name ? (form.values[name] as string | undefined) : undefined;
   const controlled = value !== undefined || formVal !== undefined;
@@ -176,7 +170,7 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
   const commit = (d: number) => {
     const iso = new Date(viewYear, viewMonth, d).toISOString().slice(0, 10);
     if (!controlled) setStartInt(new Date(viewYear, viewMonth, d));
-    if (form && name) form.setField(name as any, iso);
+    if (form && name) form.setField(name as keyof Record<string, string | undefined>, iso);
     onChange?.(iso);
   };
 

--- a/src/components/fields/FormControl.tsx
+++ b/src/components/fields/FormControl.tsx
@@ -9,7 +9,7 @@ import type { FormStore } from '../../system/createFormStore';
 import type { StoreApi, UseBoundStore } from 'zustand';
 
 /*───────────────────────────────────────────────────────────────*/
-/* Context & public hook (store erased to avoid invariance issues) */
+/* Context & hooks (store erased to avoid invariance issues) */
 const FormCtx = createContext<unknown | null>(null);
 
 export const useForm = <
@@ -20,6 +20,13 @@ export const useForm = <
     throw new Error('useForm must be used inside a <FormControl> component');
   }
   return ctx as FormStore<T>;
+};
+
+export const useOptionalForm = <
+  T extends Record<string, unknown> = Record<string, unknown>,
+>(): FormStore<T> | null => {
+  const ctx = useContext(FormCtx);
+  return ctx as FormStore<T> | null;
 };
 
 /*───────────────────────────────────────────────────────────────*/

--- a/src/components/fields/Select.tsx
+++ b/src/components/fields/Select.tsx
@@ -7,7 +7,7 @@ import React, { forwardRef, useCallback, useId, useMemo, useRef, useState } from
 import { styled } from '../../css/createStyled';
 import { useTheme } from '../../system/themeStore';
 import { preset } from '../../css/stylePresets';
-import { useForm } from './FormControl';
+import { useOptionalForm } from './FormControl';
 import type { Presettable } from '../../types';
 import type { Theme } from '../../system/themeStore';
 
@@ -151,12 +151,6 @@ const Item = styled('li')<{
 const eq = (a: Primitive, b: Primitive) => String(a) === String(b);
 const array = <T,>(v: T | T[]) => (Array.isArray(v) ? v : [v]);
 
-/* Minimal FormControl subset for typing */
-interface MinimalForm {
-  values: Record<string, unknown>;
-  setField: (name: string, value: unknown) => void;
-}
-
 /*───────────────────────────────────────────────────────────*/
 /* JSX helper component                                      */
 export const Option: React.FC<OptionProps> = ({ children }) => <>{children}</>;
@@ -203,12 +197,7 @@ const Inner = (props: SelectProps, ref: React.Ref<HTMLDivElement>) => {
   const primary = theme.colors.primary;
 
   /* optional FormControl hook ------------------------------ */
-  let form: MinimalForm | null = null;
-  try {
-    form = useForm<Record<string, unknown>>() as unknown as MinimalForm;
-  } catch {
-    /* No FormControl context available */
-  }
+  const form = useOptionalForm<Record<string, unknown>>();
 
   /* value management --------------------------------------- */
   const formVal =
@@ -222,7 +211,7 @@ const Inner = (props: SelectProps, ref: React.Ref<HTMLDivElement>) => {
   const commit = useCallback(
     (next: Primitive | Primitive[]) => {
       if (!controlled) setSelf(next);
-      if (form && name) form.setField(name, next);
+      if (form && name) form.setField(name as keyof Record<string, unknown>, next as unknown);
       onChange?.(next);
     },
     [controlled, form, name, onChange],

--- a/src/components/fields/Slider.tsx
+++ b/src/components/fields/Slider.tsx
@@ -19,7 +19,7 @@ import React, {
 import { styled } from '../../css/createStyled';
 import { useTheme } from '../../system/themeStore';
 import { preset } from '../../css/stylePresets';
-import { useForm } from './FormControl';
+import { useOptionalForm } from './FormControl';
 import type { Presettable } from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
@@ -193,12 +193,6 @@ export interface SliderProps
   disabled?: boolean;
 }
 
-/* Minimal form shape we rely on (values + optional setField) */
-type NumForm = {
-  values: Record<string, number | undefined>;
-  setField?: (name: string, value: number) => void;
-};
-
 /*───────────────────────────────────────────────────────────*/
 /* Component                                                 */
 export const Slider = forwardRef<HTMLDivElement, SliderProps>(
@@ -255,12 +249,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
 
     /* optional FormControl binding --------------------------- */
     // We only rely on `values` and an optional `setField`.
-    let form: NumForm | null = null;
-    try {
-      form = useForm<Record<string, number | undefined>>() as unknown as NumForm;
-    } catch {
-      /* No FormControl context available */
-    }
+    const form = useOptionalForm<Record<string, number | undefined>>();
 
     /* controlled hierarchy ---------------------------------- */
     const formVal = name ? form?.values[name] : undefined;
@@ -320,7 +309,7 @@ export const Slider = forwardRef<HTMLDivElement, SliderProps>(
         const rounded = roundTo(snapped, precision);
 
         if (!controlled) setSelf(rounded);
-        if (name && form?.setField) form.setField(name, rounded);
+        if (name && form) form.setField(name as keyof Record<string, number | undefined>, rounded);
         onChange?.(rounded);
         renderVisual(rounded);
       },

--- a/src/components/fields/Switch.tsx
+++ b/src/components/fields/Switch.tsx
@@ -7,7 +7,7 @@ import React, { forwardRef, useCallback, useId, useState, MouseEventHandler } fr
 import { styled } from '../../css/createStyled';
 import { useTheme } from '../../system/themeStore';
 import { preset } from '../../css/stylePresets';
-import { useForm } from './FormControl';
+import { useOptionalForm } from './FormControl';
 import type { Presettable } from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
@@ -28,26 +28,6 @@ const createSizeMap = (): Record<SwitchSize, SizeTokens> => ({
 });
 
 /*───────────────────────────────────────────────────────────*/
-/* Form helper (safe in/out of provider)                     */
-interface MinimalForm {
-  values: Record<string, unknown>;
-  setField?: (field: string, value: unknown) => void;
-}
-
-/** Custom hook that returns a form API if inside a provider, otherwise `null`. */
-function useOptionalForm(): MinimalForm | null {
-  try {
-    /* eslint-disable react-hooks/rules-of-hooks */
-    // Always call the hook; if not within a provider, the implementation may throw.
-    // We intentionally catch that to fall back to uncontrolled behavior.
-    const f = useForm<Record<string, unknown>>() as unknown as MinimalForm;
-    /* eslint-enable react-hooks/rules-of-hooks */
-    return f;
-  } catch {
-    return null;
-  }
-}
-
 /*───────────────────────────────────────────────────────────*/
 /* Styled primitives                                         */
 const Track = styled('button')<{
@@ -159,7 +139,7 @@ export const Switch = forwardRef<HTMLButtonElement, SwitchProps>(
         /* update uncontrolled state */
         if (!controlled) setSelf(next);
         /* notify FormControl */
-        if (name && form?.setField) form.setField(name, next);
+        if (name && form) form.setField(name as keyof Record<string, unknown>, next as unknown);
         /* fire user callback */
         onChange?.(next);
         /* propagate native click */

--- a/src/components/fields/TextField.tsx
+++ b/src/components/fields/TextField.tsx
@@ -12,7 +12,7 @@ import React, {
 import { styled } from '../../css/createStyled';
 import { useTheme } from '../../system/themeStore';
 import { preset } from '../../css/stylePresets';
-import { useForm } from './FormControl';
+import { useOptionalForm } from './FormControl';
 import type { Theme } from '../../system/themeStore';
 import type { Presettable } from '../../types';
 
@@ -112,18 +112,8 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
     const id = useId();
     const { theme } = useTheme();
 
-    /** Optional FormControl wiring (safe-cast to a minimal interface) */
-    type FormApi = {
-      values: Record<string, unknown>;
-      setField: (field: string, value: unknown) => void;
-    } | null;
-
-    let form: FormApi = null;
-    try {
-      form = useForm() as unknown as FormApi;
-    } catch {
-      /* No FormControl context available */
-    }
+    /** Optional FormControl wiring */
+    const form = useOptionalForm<Record<string, unknown>>();
 
     const presetClasses = presetName ? preset(presetName) : '';
     const wrapperStyle = fullWidth ? { flex: 1, width: '100%', ...styleProp } : styleProp;
@@ -150,7 +140,8 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
                 | undefined;
 
               const handleChange: ChangeEventHandler<HTMLTextAreaElement> = (e) => {
-                if (form?.setField) form.setField(name, e.target.value);
+                if (form && name)
+                  form.setField(name as keyof Record<string, unknown>, e.target.value);
                 onChangeTextarea?.(e);
               };
 
@@ -180,7 +171,8 @@ export const TextField = forwardRef<HTMLInputElement | HTMLTextAreaElement, Text
                 | undefined;
 
               const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
-                if (form?.setField) form.setField(name, e.target.value);
+                if (form && name)
+                  form.setField(name as keyof Record<string, unknown>, e.target.value);
                 onChangeInput?.(e);
               };
 


### PR DESCRIPTION
## Summary
- expose `useOptionalForm` for safe FormControl access outside providers
- refactor field components to use the new hook and remove conditional calls

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899dbe7e55c8320b31b3bec94a716f1