### PR TITLE
Add desaturated hover to DateSelector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Add subtle hover to `DateSelector` dates
+
 ## [0.24.0]
 - Setup ESLint and Prettier
 - linted valet and docs

--- a/docs/vite.config.ts
+++ b/docs/vite.config.ts
@@ -1,7 +1,21 @@
+// valet/docs/vite.config.ts
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-// https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true, // or '0.0.0.0' to listen on all interfaces
+    
+    // put a new ngrok link here if your free plan changes yours
+    // allowedHosts: ['6c910f0d2e31.ngrok-free.app'],
+
+    // If you're viewing the site via HTTPS on ngrok and HMR can't connect,
+    // uncomment this block so the client uses WSS through the tunnel:
+    // hmr: {
+    //   host: '2a9971f3ac6b.ngrok-free.app',
+    //   protocol: 'wss',
+    //   clientPort: 443,
+    // },
+  },
 });

--- a/src/components/fields/DateSelector.tsx
+++ b/src/components/fields/DateSelector.tsx
@@ -89,6 +89,7 @@ const Cell = styled('button')<{
   font: inherit;
   font-weight: ${({ $start, $end }) => ($start || $end ? 'bold' : 'inherit')};
   height: 2rem;
+  transition: background-color 120ms ease; /* ← add this */
   &:hover:not(:disabled) {
     background: ${({
       $start,
@@ -236,7 +237,8 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
   const cls = [presetCls, className].filter(Boolean).join(' ') || undefined;
 
   const rangeBg = toHex(mix(toRgb(theme.colors.primary), toRgb(theme.colors.background), 0.25));
-  const hoverDefault = toHex(mix(toRgb(theme.colors.text), toRgb(theme.colors.background), 0.1));
+  // Use the wrapper's background (backgroundAlt) and nudge ~4% toward text
+  const hoverDefault = toHex(mix(toRgb(theme.colors.backgroundAlt), toRgb(theme.colors.text), 0.04));
   const hoverStart = toHex(mix(toRgb(theme.colors.primary), toRgb(theme.colors.text), 0.3));
   const hoverEnd = toHex(mix(toRgb(theme.colors.secondary), toRgb(theme.colors.text), 0.3));
   const hoverRange = toHex(mix(toRgb(rangeBg), toRgb(theme.colors.text), 0.2));

--- a/src/components/fields/DateSelector.tsx
+++ b/src/components/fields/DateSelector.tsx
@@ -74,6 +74,10 @@ const Cell = styled('button')<{
   $primary: string;
   $secondary: string;
   $rangeBg: string;
+  $hoverStart: string;
+  $hoverEnd: string;
+  $hoverRange: string;
+  $hoverDefault: string;
 }>`
   padding: 0.25rem 0;
   border: none;
@@ -86,7 +90,15 @@ const Cell = styled('button')<{
   font-weight: ${({ $start, $end }) => ($start || $end ? 'bold' : 'inherit')};
   height: 2rem;
   &:hover:not(:disabled) {
-    filter: brightness(1.2);
+    background: ${({
+      $start,
+      $end,
+      $inRange,
+      $hoverStart,
+      $hoverEnd,
+      $hoverRange,
+      $hoverDefault,
+    }) => ($start ? $hoverStart : $end ? $hoverEnd : $inRange ? $hoverRange : $hoverDefault)};
   }
   &:disabled {
     opacity: 0.4;
@@ -224,6 +236,10 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
   const cls = [presetCls, className].filter(Boolean).join(' ') || undefined;
 
   const rangeBg = toHex(mix(toRgb(theme.colors.primary), toRgb(theme.colors.background), 0.25));
+  const hoverDefault = toHex(mix(toRgb(theme.colors.text), toRgb(theme.colors.background), 0.1));
+  const hoverStart = toHex(mix(toRgb(theme.colors.primary), toRgb(theme.colors.text), 0.3));
+  const hoverEnd = toHex(mix(toRgb(theme.colors.secondary), toRgb(theme.colors.text), 0.3));
+  const hoverRange = toHex(mix(toRgb(rangeBg), toRgb(theme.colors.text), 0.2));
 
   return (
     <Wrapper
@@ -359,6 +375,10 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
               $primary={theme.colors.primary}
               $secondary={theme.colors.secondary}
               $rangeBg={rangeBg}
+              $hoverStart={hoverStart}
+              $hoverEnd={hoverEnd}
+              $hoverRange={hoverRange}
+              $hoverDefault={hoverDefault}
               onClick={() => !disabled && (range ? commitRange(day) : commit(day))}
               disabled={disabled}
             >


### PR DESCRIPTION
## Summary
- soften DateSelector hover with muted tones
- document DateSelector hover refinement

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899ec71c66c8320a942b0a9c1758b75