### PR TITLE
feat: add syntax highlighting to Markdown code blocks

### DIFF
--- a/docs/src/components/CodeBlock.tsx
+++ b/docs/src/components/CodeBlock.tsx
@@ -1,21 +1,23 @@
 // ─────────────────────────────────────────────────────────────
 // src/components/CodeBlock.tsx  | valet-docs
-// Reusable code block with Panel, mono text, pre wrap, copy button, and snackbar feedback
+// Reusable code block with syntax highlighting, copy button, and snackbar feedback
 // ─────────────────────────────────────────────────────────────
-import { Panel, Stack, Typography, IconButton, Snackbar } from '@archway/valet';
+import { Panel, Stack, IconButton, Snackbar, Markdown } from '@archway/valet';
 import { useState } from 'react';
 
 export interface CodeBlockProps {
   code: string;
+  language?: string;
   fullWidth?: boolean;
   ariaLabel?: string;
   title?: string;
 }
 
-export default function CodeBlock({ code, fullWidth, ariaLabel, title }: CodeBlockProps) {
+export default function CodeBlock({ code, language, fullWidth, ariaLabel, title }: CodeBlockProps) {
   const [copied, setCopied] = useState(false);
   const isMultiline = code.includes('\n');
   const displayCode = isMultiline ? code.replace(/\n+$/, '') : code;
+  const markdown = '```' + (language ?? '') + '\n' + displayCode + '\n```';
 
   const handleCopy = () => {
     navigator.clipboard.writeText(code).then(
@@ -34,12 +36,10 @@ export default function CodeBlock({ code, fullWidth, ariaLabel, title }: CodeBlo
           alignItems: isMultiline ? 'flex-start' : 'center',
         }}
       >
-        <Typography
-          family='mono'
-          whitespace='pre'
-        >
-          <code>{displayCode}</code>
-        </Typography>
+        <Markdown
+          data={markdown}
+          codeBackground='transparent'
+        />
         <IconButton
           variant='outlined'
           size='sm'

--- a/docs/src/pages/Quickstart.tsx
+++ b/docs/src/pages/Quickstart.tsx
@@ -39,11 +39,13 @@ export default function QuickstartPage() {
         </Typography>
         <CodeBlock
           code={`npm create vite@latest my-app -- --template react-ts`}
+          language='bash'
           ariaLabel='Copy create-app command'
         />
         <Typography>Then install valet in your app folder:</Typography>
         <CodeBlock
           code={`cd my-app && npm install @archway/valet`}
+          language='bash'
           ariaLabel='Copy install command'
         />
 
@@ -73,6 +75,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   </React.StrictMode>,
 );
 `}
+          language='tsx'
           ariaLabel='Copy main.tsx snippet'
         />
 
@@ -90,7 +93,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
           code={`// src/App.tsx
   import { useInitialTheme } from '@archway/valet';
   import brandonUrl from './assets/fonts/BrandonGrotesque.otf';
-  
+
   export function App() {
     useInitialTheme(
       {
@@ -106,6 +109,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     // ...
   }
   `}
+          language='tsx'
           ariaLabel='Copy App.tsx snippet'
         />
 
@@ -122,7 +126,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
         <CodeBlock
           code={`import { Routes, Route } from 'react-router-dom';
   import { Surface, Stack, Typography, Button } from '@archway/valet';
-  
+
   function Home() {
     return (
       <Surface>
@@ -133,7 +137,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       </Surface>
     );
   }
-  
+
   export function App() {
     return (
       <Routes>
@@ -142,6 +146,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     );
   }
   `}
+          language='tsx'
           ariaLabel='Copy first screen snippet'
         />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@iconify/react": "^6.0.0",
+        "highlight.js": "^11.10.0",
         "marked": "^16.1.1",
+        "marked-highlight": "^2.2.2",
         "react-dropzone": "^14.2.3",
         "siphash": "^1.2.0",
         "zustand": "^4.5.7"
@@ -5378,6 +5380,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -6185,6 +6196,15 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/marked-highlight": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/marked-highlight/-/marked-highlight-2.2.2.tgz",
+      "integrity": "sha512-KlHOP31DatbtPPXPaI8nx1KTrG3EW0Z5zewCwpUj65swbtKOTStteK3sNAjBqV75Pgo3fNEVNHeptg18mDuWgw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "marked": ">=4 <17"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.0",
+    "highlight.js": "^11.10.0",
+    "marked-highlight": "^2.2.2",
     "marked": "^16.1.1",
     "react-dropzone": "^14.2.3",
     "siphash": "^1.2.0",

--- a/src/components/widgets/Markdown.tsx
+++ b/src/components/widgets/Markdown.tsx
@@ -4,9 +4,11 @@
 // ─────────────────────────────────────────────────────────────
 import React from 'react';
 import { marked } from 'marked';
+import { markedHighlight } from 'marked-highlight';
+import hljs from 'highlight.js';
+import 'highlight.js/styles/github.css';
 import type { TokensList, Token, Tokens } from 'marked';
 import Stack from '../layout/Stack';
-import Panel from '../layout/Panel';
 import Typography, { type Variant } from '../primitives/Typography';
 import Image from '../primitives/Image';
 import Table, { type TableColumn } from './Table';
@@ -60,6 +62,16 @@ const renderInline = (tokens?: Token[]): React.ReactNode => {
   });
 };
 
+marked.use(
+  markedHighlight({
+    langPrefix: 'hljs language-',
+    highlight(code, lang) {
+      const language = hljs.getLanguage(lang ?? '') ? lang : 'plaintext';
+      return hljs.highlight(code, { language }).value;
+    },
+  }),
+);
+
 const renderTokens = (tokens: TokensList, codeBg?: string): React.ReactNode =>
   tokens.map((t: Token, i: number) => {
     switch (t.type) {
@@ -103,14 +115,19 @@ const renderTokens = (tokens: TokensList, codeBg?: string): React.ReactNode =>
       case 'code': {
         const code = t as Tokens.Code;
         return (
-          <Panel
+          <pre
             key={i}
-            preset='codePanel'
-            background={codeBg}
-            style={{ margin: '0.5rem 0' }}
+            style={{
+              margin: '0.5rem 0',
+              overflowX: 'auto',
+            }}
           >
-            <code>{code.text}</code>
-          </Panel>
+            <code
+              className={code.lang ? `hljs language-${code.lang}` : 'hljs'}
+              style={{ background: codeBg }}
+              dangerouslySetInnerHTML={{ __html: code.text }}
+            />
+          </pre>
         );
       }
       case 'table': {


### PR DESCRIPTION
## Summary
- add `marked-highlight` and `highlight.js` for syntax-highlighted Markdown
- allow CodeBlock to declare a language and render via Markdown
- document Quickstart examples with explicit languages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any in src/components/widgets/Snackbar.tsx)*
- `npx eslint src/components/widgets/Markdown.tsx docs/src/components/CodeBlock.tsx docs/src/pages/Quickstart.tsx`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689c82c661b08320a10617e026e85593