### PR TITLE
Add marked-highlight and improve CodeBlock highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Highlight Markdown code blocks with language-aware `CodeBlock`
+
 ## [0.25.1]
 - Improved docs
 

--- a/docs/src/components/CodeBlock.tsx
+++ b/docs/src/components/CodeBlock.tsx
@@ -1,21 +1,23 @@
 // ─────────────────────────────────────────────────────────────
 // src/components/CodeBlock.tsx  | valet-docs
-// Reusable code block with Panel, mono text, pre wrap, copy button, and snackbar feedback
+// Reusable code block with Markdown highlighting, copy button, and snackbar feedback
 // ─────────────────────────────────────────────────────────────
-import { Panel, Stack, Typography, IconButton, Snackbar } from '@archway/valet';
+import { Markdown, IconButton, Snackbar } from '@archway/valet';
 import { useState } from 'react';
 
 export interface CodeBlockProps {
   code: string;
+  language?: string;
   fullWidth?: boolean;
   ariaLabel?: string;
   title?: string;
 }
 
-export default function CodeBlock({ code, fullWidth, ariaLabel, title }: CodeBlockProps) {
+export default function CodeBlock({ code, language = 'typescript', fullWidth, ariaLabel, title }: CodeBlockProps) {
   const [copied, setCopied] = useState(false);
   const isMultiline = code.includes('\n');
   const displayCode = isMultiline ? code.replace(/\n+$/, '') : code;
+  const markdown = `\`\`\`${language}\n${displayCode}\n\`\`\``;
 
   const handleCopy = () => {
     navigator.clipboard.writeText(code).then(
@@ -25,36 +27,31 @@ export default function CodeBlock({ code, fullWidth, ariaLabel, title }: CodeBlo
   };
 
   return (
-    <Panel fullWidth={fullWidth ?? false}>
-      <Stack
-        direction='row'
-        wrap={false}
-        style={{
-          justifyContent: 'space-between',
-          alignItems: isMultiline ? 'flex-start' : 'center',
-        }}
-      >
-        <Typography
-          family='mono'
-          whitespace='pre'
-        >
-          <code>{displayCode}</code>
-        </Typography>
-        <IconButton
-          variant='outlined'
-          size='sm'
-          icon='mdi:content-copy'
-          aria-label={ariaLabel ?? 'Copy code snippet'}
-          title={title ?? 'Copy'}
-          onClick={handleCopy}
-        />
-      </Stack>
+    <div
+      style={{
+        position: 'relative',
+        width: fullWidth ? '100%' : 'fit-content',
+      }}
+    >
+      <Markdown
+        data={markdown}
+        style={{ margin: 0 }}
+      />
+      <IconButton
+        variant='outlined'
+        size='sm'
+        icon='mdi:content-copy'
+        aria-label={ariaLabel ?? 'Copy code snippet'}
+        title={title ?? 'Copy'}
+        onClick={handleCopy}
+        style={{ position: 'absolute', top: '0.75rem', right: '0.75rem' }}
+      />
       {copied && (
         <Snackbar
           message='copied'
           onClose={() => setCopied(false)}
         />
       )}
-    </Panel>
+    </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@iconify/react": "^6.0.0",
+        "highlight.js": "^11.11.1",
         "marked": "^16.1.1",
+        "marked-highlight": "^2.2.2",
         "react-dropzone": "^14.2.3",
         "siphash": "^1.2.0",
         "zustand": "^4.5.7"
@@ -5378,6 +5380,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -6185,6 +6196,15 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/marked-highlight": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/marked-highlight/-/marked-highlight-2.2.2.tgz",
+      "integrity": "sha512-KlHOP31DatbtPPXPaI8nx1KTrG3EW0Z5zewCwpUj65swbtKOTStteK3sNAjBqV75Pgo3fNEVNHeptg18mDuWgw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "marked": ">=4 <17"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
   },
   "dependencies": {
     "@iconify/react": "^6.0.0",
+    "highlight.js": "^11.11.1",
     "marked": "^16.1.1",
+    "marked-highlight": "^2.2.2",
     "react-dropzone": "^14.2.3",
     "siphash": "^1.2.0",
     "zustand": "^4.5.7"

--- a/src/components/widgets/Markdown.tsx
+++ b/src/components/widgets/Markdown.tsx
@@ -4,12 +4,25 @@
 // ─────────────────────────────────────────────────────────────
 import React from 'react';
 import { marked } from 'marked';
+import { markedHighlight } from 'marked-highlight';
+import hljs from 'highlight.js';
+import 'highlight.js/styles/github.css';
 import type { TokensList, Token, Tokens } from 'marked';
 import Stack from '../layout/Stack';
 import Panel from '../layout/Panel';
 import Typography, { type Variant } from '../primitives/Typography';
 import Image from '../primitives/Image';
 import Table, { type TableColumn } from './Table';
+
+marked.use(
+  markedHighlight({
+    langPrefix: 'hljs language-',
+    highlight(code, lang) {
+      const language = hljs.getLanguage(lang) ? lang : 'plaintext';
+      return hljs.highlight(code, { language }).value;
+    },
+  }),
+);
 
 export interface MarkdownProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Raw markdown text */
@@ -102,6 +115,9 @@ const renderTokens = (tokens: TokensList, codeBg?: string): React.ReactNode =>
       }
       case 'code': {
         const code = t as Tokens.Code;
+        const lang = code.lang ?? 'plaintext';
+        const validLang = hljs.getLanguage(lang) ? lang : 'plaintext';
+        const html = hljs.highlight(code.text, { language: validLang }).value;
         return (
           <Panel
             key={i}
@@ -109,7 +125,10 @@ const renderTokens = (tokens: TokensList, codeBg?: string): React.ReactNode =>
             background={codeBg}
             style={{ margin: '0.5rem 0' }}
           >
-            <code>{code.text}</code>
+            <code
+              className={`hljs language-${validLang}`}
+              dangerouslySetInnerHTML={{ __html: html }}
+            />
           </Panel>
         );
       }


### PR DESCRIPTION
## Summary
- add marked-highlight and highlight.js dependencies
- highlight Markdown code blocks
- allow CodeBlock to specify language and render with Markdown

## Testing
- `npm run build`
- `npm run lint` *(fails: Unexpected any in unrelated files)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689c828a08e083208f4b48a1aa66c378