### PR TITLE
Remove CodeBlock fullWidth prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file. The format 
 - Lower `CodeBlock` copy button for better alignment
 - Promote `CodeBlock` to core widget
 - Document `CodeBlock` widget with dedicated docs page
+- Remove `fullWidth` prop from `CodeBlock`
 
 ## [0.25.1]
 

--- a/docs/src/pages/BoxDemo.tsx
+++ b/docs/src/pages/BoxDemo.tsx
@@ -259,7 +259,6 @@ export default function BoxDemoPage() {
                 Example:
               </Typography>
               <CodeBlock
-                fullWidth
                 code={`<Box
   id="hero"
   role="region"

--- a/docs/src/pages/CodeBlockDemo.tsx
+++ b/docs/src/pages/CodeBlockDemo.tsx
@@ -9,7 +9,6 @@ import {
   Tabs,
   Table,
   Select,
-  Switch,
   TextField,
   CodeBlock,
   type TableColumn,
@@ -21,7 +20,6 @@ import NavDrawer from '../components/NavDrawer';
 export default function CodeBlockDemoPage() {
   const [language, setLanguage] = useState<'typescript' | 'javascript' | 'css'>('typescript');
   const [code, setCode] = useState<string>("const hello = 'world';\nconsole.log(hello);");
-  const [fullWidth, setFullWidth] = useState(false);
 
   interface Row {
     prop: ReactNode;
@@ -49,12 +47,6 @@ export default function CodeBlockDemoPage() {
       type: <code>string</code>,
       default: <code>'typescript'</code>,
       description: 'Highlight.js language key',
-    },
-    {
-      prop: <code>fullWidth</code>,
-      type: <code>boolean</code>,
-      default: <code>false</code>,
-      description: 'Stretch block to fill its container',
     },
     {
       prop: <code>ariaLabel</code>,
@@ -99,37 +91,18 @@ export default function CodeBlockDemoPage() {
           <Tabs.Tab label='Playground' />
           <Tabs.Panel>
             <Stack gap={1}>
-              <Stack
-                direction='row'
-                gap={1}
-                wrap={false}
-              >
-                <Stack gap={0.25}>
-                  <Typography variant='subtitle'>language</Typography>
-                  <Select
-                    placeholder='language'
-                    value={language}
-                    onChange={(v) => setLanguage(v as 'typescript' | 'javascript' | 'css')}
-                    style={{ width: 160 }}
-                  >
-                    <Select.Option value='typescript'>typescript</Select.Option>
-                    <Select.Option value='javascript'>javascript</Select.Option>
-                    <Select.Option value='css'>css</Select.Option>
-                  </Select>
-                </Stack>
-                <Stack
-                  direction='row'
-                  gap={1}
-                  wrap={false}
-                  style={{ alignItems: 'center' }}
+              <Stack gap={0.25}>
+                <Typography variant='subtitle'>language</Typography>
+                <Select
+                  placeholder='language'
+                  value={language}
+                  onChange={(v) => setLanguage(v as 'typescript' | 'javascript' | 'css')}
+                  style={{ width: 160 }}
                 >
-                  <Typography variant='subtitle'>fullWidth</Typography>
-                  <Switch
-                    checked={fullWidth}
-                    onChange={setFullWidth}
-                    aria-label='Toggle fullWidth'
-                  />
-                </Stack>
+                  <Select.Option value='typescript'>typescript</Select.Option>
+                  <Select.Option value='javascript'>javascript</Select.Option>
+                  <Select.Option value='css'>css</Select.Option>
+                </Select>
               </Stack>
               <TextField
                 as='textarea'
@@ -143,7 +116,6 @@ export default function CodeBlockDemoPage() {
               <CodeBlock
                 code={code}
                 language={language}
-                fullWidth={fullWidth}
               />
             </Stack>
           </Tabs.Panel>

--- a/docs/src/pages/ListDemoPage.tsx
+++ b/docs/src/pages/ListDemoPage.tsx
@@ -192,7 +192,6 @@ const data: Person[] = [
 
               <Typography variant='h3'>2. Code</Typography>
               <CodeBlock
-                fullWidth
                 code={usage}
               />
             </Stack>

--- a/src/components/widgets/CodeBlock.tsx
+++ b/src/components/widgets/CodeBlock.tsx
@@ -11,7 +11,6 @@ import { useTheme } from '../../system/themeStore';
 export interface CodeBlockProps {
   code: string;
   language?: string;
-  fullWidth?: boolean;
   ariaLabel?: string;
   title?: string;
 }
@@ -19,7 +18,6 @@ export interface CodeBlockProps {
 export const CodeBlock: React.FC<CodeBlockProps> = ({
   code,
   language = 'typescript',
-  fullWidth,
   ariaLabel,
   title,
 }) => {
@@ -41,7 +39,7 @@ export const CodeBlock: React.FC<CodeBlockProps> = ({
       style={{
         display: 'flex',
         alignItems: 'flex-start',
-        width: fullWidth ? '100%' : 'fit-content',
+        width: '100%',
       }}
     >
       <Markdown


### PR DESCRIPTION
## Summary
- drop `fullWidth` prop from `CodeBlock`
- update CodeBlock demo to remove `fullWidth` toggle and table entry
- scrub docs of `fullWidth` usages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 55 errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689c99c6b27883208b1895267f89430d