### PR TITLE
Refine pagination underline animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Refine `Pagination` underline animation with stretch-and-snap elastic bounce
+
 ## [0.25.4]
 - Improved vertically aligned `Tabs` styling.
 - Improved `Accordion` styling. 


### PR DESCRIPTION
## Summary
- add stretch-and-snap animation for Pagination underline
- document refined animation in changelog

## Testing
- `npm run lint:fix`
- `npm run build`
- `cd docs && npm link @archway/valet && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e3bf39b8c8320af0ee1f20bba3c78