### PR TITLE
Normalize WebKit button styles in Pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Pagination: normalize WebKit button appearance with transparent background
+
 ## [0.28.2]
 - DateSelector: auto-compact mode for narrow containers
 

--- a/src/components/widgets/Pagination.tsx
+++ b/src/components/widgets/Pagination.tsx
@@ -51,7 +51,10 @@ const Root = styled('nav')<{
   gap: ${({ $gap }) => $gap};
 
   button {
+    -webkit-appearance: none;
+    appearance: none;
     background: none;
+    background-color: transparent;
     border: none;
     padding: ${({ $padV, $padH }) => `${$padV} ${$padH}`};
     cursor: pointer;


### PR DESCRIPTION
## Summary
- neutralize native WebKit button styles for Pagination nav buttons
- document change in changelog

## Testing
- `npm run lint:fix`
- `npm run build`
- `cd docs && npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3684a34b883208f1004c2db02ed47