### PR TITLE
fix(docs): sync package-lock with the ^0.35.1 valet pin (Amplify npm ci)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,7 +8,7 @@
       "name": "valet-docs",
       "version": "0.31.1",
       "dependencies": {
-        "@archway/valet": "^0.33.0",
+        "@archway/valet": "^0.35.1",
         "@babel/standalone": "^7.26.0",
         "@fontsource/inter": "^5.2.8",
         "@fontsource/jetbrains-mono": "^5.2.8",
@@ -78,24 +78,25 @@
       }
     },
     "node_modules/@archway/valet": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@archway/valet/-/valet-0.33.0.tgz",
-      "integrity": "sha512-P47+WkJWIsS1HGbODQ5Buo7wHuqa2YdCWzgTdbxWl6eJWc20k4KwkzIZ5Js50nOuf9kHsNpixhWHOlQpJdbb6g==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/@archway/valet/-/valet-0.35.1.tgz",
+      "integrity": "sha512-+0vDYJ6VE141pzB9MutFCRFz+tu5a/HsI4hCvE4c8vJ2+/QypBT0Qx/Y06pXX3pYr7TdyvW4u/i3UD4dT5F+nQ==",
       "license": "MIT",
       "dependencies": {
         "@iconify/react": "^6.0.0",
         "highlight.js": "^11.11.1",
         "marked": "^16.1.1",
-        "marked-highlight": "^2.2.2",
-        "react-dropzone": "^14.2.3",
-        "zustand": "^4.5.7"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+        "react-dropzone": "^14.2.3"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
+        "react-dom": "^18.0.0 || ^19.0.0",
+        "zustand": "^4.5.7 || ^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zustand": {
+          "optional": false
+        }
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1608,24 +1609,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-16.3.0.tgz",
-      "integrity": "sha512-K3UxuKu6l6bmA5FUwYho8CfJBlsUWAooKtdGgMcERSpF7gcBUrCGsLH7wDaaNOzwq18JzSUDyoEb/YsrqMac3w==",
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
         "node": ">= 20"
-      }
-    },
-    "node_modules/marked-highlight": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/marked-highlight/-/marked-highlight-2.2.2.tgz",
-      "integrity": "sha512-KlHOP31DatbtPPXPaI8nx1KTrG3EW0Z5zewCwpUj65swbtKOTStteK3sNAjBqV75Pgo3fNEVNHeptg18mDuWgw==",
-      "license": "MIT",
-      "peerDependencies": {
-        "marked": ">=4 <17"
       }
     },
     "node_modules/ms": {
@@ -1999,6 +1991,7 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
       "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -2118,6 +2111,7 @@
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
       "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "use-sync-external-store": "^1.2.2"
       },


### PR DESCRIPTION
Release prep bumped docs/package.json to @archway/valet ^0.35.1 but never regenerated docs/package-lock.json, which still resolved 0.33.0 (+ stale marked 16.3.0). Amplify's `npm ci` in docs/ refuses an out-of-sync lockfile (EUSAGE: "lock file's @archway/valet@0.33.0 does not satisfy 0.35.1"), failing the production docs deploy.

Regenerated the lockfile (valet 0.35.1, marked 16.4.2 — now that 0.35.1 is published, ^0.35.1 resolves cleanly). `npm ci --dry-run` in docs is back in sync; docs build green.