### PR TITLE
chore(release): lockfile-sync gate in check-pins + RELEASING.md trap …

### DIFF
--- a/dx/RELEASING.md
+++ b/dx/RELEASING.md
@@ -159,31 +159,49 @@ The CHANGELOG is the source of truth for what each version shipped;
 
 ## 3. Version bumps + pin updates
 
+> ⚠️ **PRE-SYNC EVERYTHING ONCE, THEN PUBLISH PLAIN.** Bump **all four**
+> packages to the same `$NEW` here in §3. At publish time (§4) use the **plain**
+> commands — `npm publish` and `npm run mcp:server:publish` (no suffix). Do
+> **NOT** run `npm version` / `mcp:server:publish:patch|minor|major` during
+> §4: the packages are already at `$NEW`, so a second bump double-counts
+> (0.35.0 → 0.36.0). This bit both `valet-mcp` and `create-valet-app` during
+> the 0.35.x releases. The `:patch|:minor|:major` variants are only for a
+> package versioning **independently** of the synchronized set.
+
 Pin skew is a **hard** failure at release (`check-pins.mjs`): `docs/` and the
-three CVA templates (`hybrid`/`js`/`ts`) must pin `@archway/valet` at the new
-version before publish.
+three CVA templates (`hybrid`/`js`/`ts`) must pin `@archway/valet` at `$NEW`,
+**and `docs/package-lock.json` must RESOLVE it** (a matching pin with a stale
+lockfile passes the pin check but breaks `npm ci` — it failed the Amplify docs
+deploy after 0.35.x).
 
 ```sh
-# 3.1 Bump the library version (no tag yet — we tag once at the end).
+# 3.1 Bump ALL FOUR to the same version (no tag yet — we tag once at the end).
 npm version <patch|minor|major> --no-git-tag-version
 NEW=$(node -p "require('./package.json').version")
+( cd packages/valet-mcp        && npm version "$NEW" --no-git-tag-version --allow-same-version )
+( cd packages/create-valet-app && npm version "$NEW" --no-git-tag-version --allow-same-version )
 
 # 3.2 Update the docs pin and every CVA template pin to ^$NEW.
-#     (Edit these files; then re-run check-pins to confirm zero skew.)
 #       docs/package.json
-#       packages/create-valet-app/templates/hybrid/package.json
-#       packages/create-valet-app/templates/js/package.json
-#       packages/create-valet-app/templates/ts/package.json
-node scripts/release/check-pins.mjs   # MUST pass (no --warn) after editing
+#       packages/create-valet-app/templates/{hybrid,js,ts}/package.json
 
 # 3.3 Move the CHANGELOG Unreleased section to [$NEW] (see §2), then:
-npm run release:check                 # changelog + pins both green
+npm run release:check   # changelog + pins; the docs-lockfile half is checked too
 ```
+
+`release:check`'s lockfile gate will still flag `docs/package-lock.json` as
+stale here — that is expected and resolved in §4.1b, because the lockfile can
+only resolve `@archway/valet@$NEW` **after** valet is published. (On
+non-release branches CI runs `check-pins --warn`, so the stale lockfile only
+warns.)
 
 CVA templates also carry the `@fontsource` font deps and self-host theme config
 (`injectRemote:false`, `mode:'system'`, `persistMode:true`); bumping the valet
 pin is the moment to confirm the templates still install and `cva:validate`
-passes (§1.7).
+passes (§1.7). Note `cva:validate` is heavy (scaffolds + installs + builds +
+`vite preview` for 13 scenarios) and also runs inside `create-valet-app`'s
+`prepublishOnly`; if a `vite preview` step flakes, clear any stragglers with
+`pkill -f "cva-validate.*vite preview"` and retry.
 
 ---
 
@@ -199,21 +217,24 @@ data and the templates bake in, so it goes first; docs deploy last.
 #     by the release integrator) re-runs the §1 gate. Publish from the root.
 npm publish --access public
 
-# 4.2 valet-mcp. The wrapper rebuilds mcp-data (captures the just-published
-#     valet version), schema-checks, freshness-checks, then bumps + publishes.
-#     mcp:server:publish:* chains mcp:server:preflight (mcp:build + schema:check
-#     + check) first, so a stale corpus cannot ship.
-npm run mcp:server:publish:<patch|minor|major>
+# 4.1b RESYNC the docs lockfile now that valet@$NEW is on the registry, then
+#      the hard pin+lockfile gate passes (this step was the 0.35.x Amplify gap).
+npm --prefix docs install
+node scripts/release/check-pins.mjs   # MUST pass (no --warn): pins AND lockfile
+git add docs/package-lock.json        # commit with the release (§5)
 
-# 4.3 create-valet-app. Validate, bump, publish from the package dir.
-npm run cva:validate
-cd packages/create-valet-app
-npm version <patch|minor|major>
-npm publish --access public
-cd ../..
+# 4.2 valet-mcp — PLAIN (already at $NEW per §3.1). The wrapper rebuilds
+#     mcp-data (capturing the just-published valet version), schema-checks, and
+#     freshness-checks via mcp:server:preflight before publishing. NOT :minor.
+npm run mcp:server:publish
 
-# 4.4 docs. Bump is already done (§3.2); ensure regenerated mcp-data is staged,
-#     then build. Production docs deploy on merge to `main` (AWS Amplify).
+# 4.3 create-valet-app — PLAIN (already at $NEW). prepublishOnly runs
+#     pack.test + cva:validate. Do NOT `npm version` here.
+( cd packages/create-valet-app && npm publish --access public )
+
+# 4.4 docs. Pin + lockfile done (§3.2/§4.1b); ensure regenerated mcp-data is
+#     staged, then build. Production docs deploy on merge to `main` (Amplify),
+#     which runs `npm ci` in docs/ — hence the §4.1b lockfile resync is load-bearing.
 npm --prefix docs run build
 ```
 

--- a/scripts/release/check-pins.mjs
+++ b/scripts/release/check-pins.mjs
@@ -3,6 +3,13 @@
 // Release gate: docs/package.json and the create-valet-app template
 // package.json files must pin @archway/valet at the root version
 // (audit found docs at ^0.33.0 and templates at ^0.31.1 vs 0.34.1).
+//
+// ALSO verifies that any sibling package-lock.json actually RESOLVES
+// @archway/valet at the root version — a matching package.json pin with a
+// stale lockfile passes the pin check but breaks `npm ci` (EUSAGE: "lock
+// file's @archway/valet@X does not satisfy Y"), which is what failed the
+// Amplify docs deploy after 0.35.x. A pin string check alone cannot catch it.
+//
 // CLI: node scripts/release/check-pins.mjs [--warn] [--root <dir>]
 // (--warn reports problems without failing, for non-release CI)
 // ─────────────────────────────────────────────────────────────
@@ -55,6 +62,59 @@ export function collectPins(root) {
   return pins;
 }
 
+/**
+ * The version a package-lock.json actually resolves @archway/valet to.
+ * Handles npm lockfileVersion 2/3 (`packages`) with a v1 (`dependencies`)
+ * fallback. Returns null when the lock does not contain the package.
+ */
+export function lockedValetVersion(lock) {
+  if (!lock || typeof lock !== 'object') return null;
+  const fromPackages = lock.packages?.[`node_modules/${PKG_NAME}`]?.version;
+  if (fromPackages) return fromPackages;
+  return lock.dependencies?.[PKG_NAME]?.version ?? null;
+}
+
+/**
+ * Gather every package-lock.json that sits beside a pinned package.json
+ * (today: docs — the templates ship no lockfile). Returns
+ * [{ label, file, locked|null }].
+ */
+export function collectLockfiles(root) {
+  const out = [];
+  const add = (label, rel) => {
+    const file = path.join(root, rel);
+    if (!fs.existsSync(file)) return; // no lockfile beside this pin → nothing to verify
+    out.push({
+      label,
+      file: rel,
+      locked: lockedValetVersion(JSON.parse(fs.readFileSync(file, 'utf8'))),
+    });
+  };
+  add('docs', 'docs/package-lock.json');
+  return out;
+}
+
+/**
+ * Pure gate: a lockfile beside a pinned package.json must RESOLVE
+ * @archway/valet at the root version, or `npm ci` will refuse it.
+ */
+export function checkLockfiles({ rootVersion, lockfiles }) {
+  const problems = [];
+  for (const lf of lockfiles) {
+    if (lf.locked === null) {
+      problems.push(`${lf.label}: ${lf.file} has no resolved "${PKG_NAME}" entry`);
+      continue;
+    }
+    if (lf.locked !== rootVersion) {
+      problems.push(
+        `${lf.label}: ${lf.file} resolves ${PKG_NAME}@${lf.locked} but the root package is ${rootVersion} — ` +
+          `run \`npm install\` in its directory to resync the lockfile (else \`npm ci\` fails)`,
+      );
+    }
+  }
+  return problems;
+}
+
 /** Pure gate: returns a list of problem strings (empty array = pass). */
 export function checkPins({ rootVersion, pins }) {
   const problems = [];
@@ -94,9 +154,15 @@ export function main(argv = process.argv.slice(2)) {
   const { warn, root } = parseArgs(argv);
   const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
   const pins = collectPins(root);
-  const problems = checkPins({ rootVersion: pkg.version, pins });
+  const lockfiles = collectLockfiles(root);
+  const problems = [
+    ...checkPins({ rootVersion: pkg.version, pins }),
+    ...checkLockfiles({ rootVersion: pkg.version, lockfiles }),
+  ];
   if (problems.length === 0) {
-    console.log(`check-pins: OK — ${pins.length} pin(s) match ${PKG_NAME}@${pkg.version}`);
+    console.log(
+      `check-pins: OK — ${pins.length} pin(s) + ${lockfiles.length} lockfile(s) match ${PKG_NAME}@${pkg.version}`,
+    );
     return 0;
   }
   for (const p of problems) console.error(`check-pins: ${warn ? 'WARN' : 'ERROR'} — ${p}`);

--- a/scripts/release/release-checks.test.mjs
+++ b/scripts/release/release-checks.test.mjs
@@ -16,7 +16,14 @@ import {
   checkChangelog,
   main as changelogMain,
 } from './check-changelog.mjs';
-import { pinTargetVersion, collectPins, checkPins, main as pinsMain } from './check-pins.mjs';
+import {
+  pinTargetVersion,
+  collectPins,
+  checkPins,
+  lockedValetVersion,
+  checkLockfiles,
+  main as pinsMain,
+} from './check-pins.mjs';
 
 const REPO_ROOT = path.resolve(fileURLToPath(import.meta.url), '../../..');
 
@@ -196,6 +203,41 @@ describe('checkPins', () => {
     expect(problems[0]).toContain('not found');
     expect(problems[1]).toContain('no "@archway/valet" dependency');
     expect(problems[2]).toContain('unparsable');
+  });
+});
+
+// ── check-pins: lockfile-sync gate (the Amplify npm-ci failure) ──
+describe('lockedValetVersion', () => {
+  it('reads the resolved version from lockfileVersion 2/3 `packages`', () => {
+    const lock = { packages: { 'node_modules/@archway/valet': { version: '0.35.1' } } };
+    expect(lockedValetVersion(lock)).toBe('0.35.1');
+  });
+  it('falls back to lockfileVersion 1 `dependencies`', () => {
+    expect(lockedValetVersion({ dependencies: { '@archway/valet': { version: '0.35.1' } } })).toBe(
+      '0.35.1',
+    );
+  });
+  it('returns null when the lock lacks the package', () => {
+    expect(lockedValetVersion({ packages: {} })).toBeNull();
+    expect(lockedValetVersion(null)).toBeNull();
+  });
+});
+
+describe('checkLockfiles', () => {
+  it('passes when the lockfile resolves the root version', () => {
+    const lockfiles = [{ label: 'docs', file: 'docs/package-lock.json', locked: '0.35.1' }];
+    expect(checkLockfiles({ rootVersion: '0.35.1', lockfiles })).toEqual([]);
+  });
+  it('catches a stale lockfile (the 0.33.0-vs-0.35.1 Amplify break)', () => {
+    const lockfiles = [{ label: 'docs', file: 'docs/package-lock.json', locked: '0.33.0' }];
+    const problems = checkLockfiles({ rootVersion: '0.35.1', lockfiles });
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain('0.33.0');
+    expect(problems[0]).toContain('npm install');
+  });
+  it('flags a lockfile with no resolved valet entry', () => {
+    const lockfiles = [{ label: 'docs', file: 'docs/package-lock.json', locked: null }];
+    expect(checkLockfiles({ rootVersion: '0.35.1', lockfiles })[0]).toContain('no resolved');
   });
 });
 


### PR DESCRIPTION
…fixes

Prevents a recurrence of the two traps the 0.35.x releases exposed:

1. check-pins now also verifies that a pinned package's sibling lockfile RESOLVES @archway/valet at the root version (docs/package-lock.json) — not just that package.json's pin string matches. A matching pin with a stale lockfile passed the old check but breaks `npm ci` (the Amplify docs deploy failure). New pure fns lockedValetVersion/collectLockfiles/ checkLockfiles + tests (incl. the exact 0.33.0-vs-0.35.1 regression).

2. RELEASING.md §3/§4 rewritten: PRE-SYNC all four packages to one version up front, then PUBLISH PLAIN — never `npm version` / `:patch|:minor` at publish time (double-bump trap that hit valet-mcp + cva). Added the §4.1b docs-lockfile resync step (can only resolve the new version after valet publishes) so the hard pin+lockfile gate passes before the Amplify deploy. Noted the heavy cva:validate-in-prepublishOnly + the preview-flake recovery.

release-checks: 26/26; lint + typecheck clean.