### PR TITLE
feat(spacing)!: compact = zero + cascade; rename density tier compact…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+### Added
+
+- Spacing (`compact` cascade): new `src/system/compactContext.ts` exporting `CompactCtx` and `useCompact(own?) → own ?? inherited`. A container with `compact` now zeros its own layout spacing **and** propagates the flag to every spacing-aware descendant via React context (it crosses portals by tree position, so `Modal`/`Select` menus inherit). `compact={false}` on any descendant opts its subtree back out. Seeded at `<Surface>`, provided by `Box`/`Stack`/`Panel`/`Grid`/`Tabs`/`Modal`/`Accordion`, consumed by `Divider`, and relayed by the field/widget containers (`MetroSelect`/`LLMChat`/`RichChat`/`DateSelector`).
+- Spacing (density scales a subtree): `density` on `Stack`/`Panel`/`Grid`/`Tabs` now sets `--valet-space` locally when explicitly provided, so `<Panel density="comfortable">` genuinely loosens its subtree and `density="tight"` tightens it (0.9 / 1.0 / 1.15 × the spacing unit) — mirroring `<Surface>`. Previously `density` on these components was inert apart from the (now removed) compact conflation.
+
+### Changed
+
+- Spacing (**BREAKING**, density value rename): the density tier `'compact'` is renamed to `'tight'` across the `Density` union (`themeStore.ts`) and `SpacingProps.density` (`types.ts`) — now `'tight' | 'standard' | 'comfortable'`. Hard rename, **no alias** (pre-1.0 policy). **Migration:** replace every `density="compact"` / `density: 'compact'` with `'tight'`. This frees the word `compact` for the boolean prop and removes its overlap with the density tier.
+- Spacing (**BREAKING**, `compact` semantics): the boolean `compact` is now a **hard zero of layout spacing that cascades**, fully decoupled from the density scale. It zeros container `pad`/`gap`/spacing-margins on the component and all spacing-aware descendants; it no longer shrinks the density scale to 0.9 (that is now `density="tight"`). It deliberately **preserves** control-internal padding, structural geometry (e.g. Tree indentation/connectors), border-radius, glyph sizes, alignment/centering margins, safe-area insets, and `sx`-supplied padding (the explicit author escape hatch). The `compact || density === 'compact'` conflation is removed from `Stack`/`Panel`/`Grid`/`Tabs`/`Surface`.
+- Spacing (DateSelector): its small/"compact" visual mode (icon sizes, cell height, single-letter weekday + 3-letter month labels, the block/inline layout switch) now follows `density="tight"` instead of `compact`, so the spacing and visual-scale axes are independent. `compact` on `<DateSelector>` is retained as a cascade relay (no visual effect of its own). **Migration:** use `density="tight"` for the compact-looking calendar.
+
+### Fixed
+
+- `Panel`/`Grid`/`Tabs`: `density` was spread onto the rendered DOM element as an invalid HTML attribute (it was never destructured) — now consumed and dropped.
+- `Tabs`/`Modal`/`Accordion`: a `compact = false` destructure default made these components silently opt **out** of an inherited compact, so the cascade from a compact ancestor never reached them; the default is dropped so an absent prop inherits (`undefined`), while an explicit `compact={false}` still opts out.
+- `MetroSelect`: the inner `<Stack compact>` was hardcoded, permanently dead-zeroing the public `gap` prop; it now reflects the field's effective compact, so `gap` takes effect when not compact.
+- `RichChat`: the outer `<Panel>` misused `compact={portrait}` as an orientation flag immediately before setting an explicit `pad`, silently zeroing the intended bottom padding in portrait; orientation now drives `pad` directly and `compact` is no longer abused.
+
 ## [0.35.1] — 2026-06-13
 
 ### Fixed

--- a/docs/src/App.tsx
+++ b/docs/src/App.tsx
@@ -73,6 +73,7 @@ const ThemeEnginePage = page(() => import('./pages/getting-started/ThemeEngine')
 const MigrateFromMUIPage = page(() => import('./pages/getting-started/MigrateFromMUI'));
 const SurfaceExplainerPage = page(() => import('./pages/components/layout/Surface'));
 const PropPatternsPage = page(() => import('./pages/getting-started/PropPatterns'));
+const SpacingPage = page(() => import('./pages/getting-started/Spacing'));
 const ComplicatedDashboardPage = page(() => import('./pages/examples/ComplicatedDashboard'));
 const ComponentQCLabPage = page(() => import('./pages/examples/ComponentQCLab'));
 const MCPGuidePage = page(() => import('./pages/getting-started/MCP'));
@@ -163,6 +164,10 @@ export function App() {
         <Route
           path='/theme-engine'
           element={<ThemeEnginePage />}
+        />
+        <Route
+          path='/spacing'
+          element={<SpacingPage />}
         />
         <Route
           path='/surface'

--- a/docs/src/components/NavDrawer.tsx
+++ b/docs/src/components/NavDrawer.tsx
@@ -106,6 +106,7 @@ const treeData: TreeNode<Item>[] = [
         data: { label: 'Prop Patterns', path: '/prop-patterns' },
       },
       { id: '/theme-engine', data: { label: 'Theme Engine', path: '/theme-engine' } },
+      { id: '/spacing', data: { label: 'Spacing (Density & Compact)', path: '/spacing' } },
       { id: '/fonts-privacy', data: { label: 'Fonts & Privacy', path: '/fonts-privacy' } },
     ],
   },

--- a/docs/src/pages/MainPage.tsx
+++ b/docs/src/pages/MainPage.tsx
@@ -46,7 +46,7 @@ export default function MainPage() {
   // ── Theme Playground: density toggle
   const nextDensity = () =>
     setDensity(
-      density === 'comfortable' ? 'compact' : density === 'compact' ? 'standard' : 'comfortable',
+      density === 'comfortable' ? 'tight' : density === 'tight' ? 'standard' : 'comfortable',
     );
 
   // ── Live demo state

--- a/docs/src/pages/components/field/DateSelectorDemo.tsx
+++ b/docs/src/pages/components/field/DateSelectorDemo.tsx
@@ -62,9 +62,9 @@ export default function DateSelectorDemoPage() {
         gap={1}
       >
         <Stack>
-          <Typography variant='subtitle'>Compact</Typography>
+          <Typography variant='subtitle'>Tight</Typography>
           <DateSelector
-            density='compact'
+            density='tight'
             value={selected}
             onValueChange={(v) => setSelected(v as string)}
           />

--- a/docs/src/pages/getting-started/Glossary.tsx
+++ b/docs/src/pages/getting-started/Glossary.tsx
@@ -78,6 +78,30 @@ export const GLOSSARY: GlossaryEntry[] = [
     seeAlso: ['styled', 'style preset'],
   },
   {
+    term: 'density',
+    aliases: ['density prop', 'tight', 'standard', 'comfortable', 'spacing scale'],
+    category: 'css',
+    definition:
+      "The spacing SCALE axis. A tier — 'tight' (0.9×), 'standard' (1×), or 'comfortable' (1.15×) — that multiplies the spacing unit by setting the --valet-space CSS var. Set it on a <Surface> to re-rhythm a whole screen, or on any layout container (Stack/Panel/Grid/Tabs) to scale just that subtree; every theme.spacing(n) inside follows automatically. The former density tier 'compact' was renamed to 'tight' (hard rename, no alias) so the word 'compact' is free for the boolean. Orthogonal to compact: density scales spacing, it never zeros it.",
+    seeAlso: ['compact', '--valet-space', 'Surface', 'theme'],
+  },
+  {
+    term: 'compact',
+    aliases: ['compact prop', 'zero spacing', 'cascade'],
+    category: 'css',
+    definition:
+      "The spacing-ZERO axis. A boolean that hard-zeros a container's LAYOUT spacing (pad, gap, spacing-margins) and CASCADES to every spacing-aware descendant via React context — so one <Panel compact> flattens its whole subtree. Reach for it where regions must sit flush: dense toolbars, embedded chrome, tight cards. compact={false} on a descendant opts that subtree back out. It deliberately PRESERVES what isn't whitespace: control-internal padding (field/Select/Chip insets), alignment and centering, structural geometry (e.g. Tree indentation and connector lines), border-radius, glyph/icon sizes, and any spacing set via sx. It removes spacing, never structure — and is independent of density (zero, not scale).",
+    seeAlso: ['density', '--valet-space', 'Surface'],
+  },
+  {
+    term: '--valet-space',
+    aliases: ['valet space', 'spacing unit', 'spacing token'],
+    category: 'css',
+    definition:
+      'The CSS custom property behind every valet spacing value: theme.spacing(n) resolves to calc(var(--valet-space) * n). density scales this variable (per-Surface or per-subtree); compact bypasses it, forcing spacing to 0. Setting it on a container re-rhythms that subtree without touching component code.',
+    seeAlso: ['density', 'compact', 'theme'],
+  },
+  {
     term: 'Semantic Interface Layer',
     aliases: ['semantic layer', 'component semantics'],
     category: 'ai',

--- a/docs/src/pages/getting-started/PropPatterns.tsx
+++ b/docs/src/pages/getting-started/PropPatterns.tsx
@@ -78,8 +78,14 @@ export default function UsagePage() {
     },
     {
       prop: <code>compact</code>,
-      purpose: 'Remove container pad/gap; in Modal also zeros internal sections',
-      components: 'Stack, Grid, Tabs, Box, Panel, Accordion, Modal',
+      purpose: (
+        <>
+          Hard-zero of layout pad/gap that <b>cascades</b> to descendants;{' '}
+          <code>compact={'{false}'}</code> opts a subtree out. Preserves control insets &amp;
+          alignment. See the <b>Spacing</b> page.
+        </>
+      ),
+      components: 'Stack, Grid, Tabs, Box, Panel, Accordion, Modal, Surface (+ all descendants)',
     },
     {
       prop: <code>centerContent</code>,
@@ -95,12 +101,12 @@ export default function UsagePage() {
       prop: <code>density</code>,
       purpose: (
         <>
-          Controls <code>--valet-space</code> on <code>&lt;Surface&gt;</code> to scale numeric
-          spacing across the subtree: <code>comfortable</code>, <code>compact</code>,
-          <code> tight</code>, <code>zero</code>.
+          Scale spacing via <code>--valet-space</code>: <code>tight</code> (0.9×),{' '}
+          <code>standard</code> (1×), <code>comfortable</code> (1.15×). Set on{' '}
+          <code>&lt;Surface&gt;</code> or any layout container. See the <b>Spacing</b> page.
         </>
       ),
-      components: 'Surface (prop), all children (effect)',
+      components: 'Surface, Stack, Panel, Grid, Tabs (prop); all children (effect)',
     },
     {
       prop: <code>open</code>,
@@ -138,6 +144,12 @@ export default function UsagePage() {
           Many props repeat across components. Use this table as a quick reference for the most
           common patterns.
         </Typography>
+        <Button
+          variant='outlined'
+          onClick={() => navigate('/spacing')}
+        >
+          Spacing — Density &amp; Compact →
+        </Button>
         <Table
           data={data}
           columns={columns}

--- a/docs/src/pages/getting-started/Spacing.tsx
+++ b/docs/src/pages/getting-started/Spacing.tsx
@@ -1,0 +1,301 @@
+// ─────────────────────────────────────────────────────────────
+// src/pages/getting-started/Spacing.tsx  | valet-docs
+// The two spacing axes: density (scale) and compact (zero + cascade)
+// ─────────────────────────────────────────────────────────────
+import { useState } from 'react';
+import {
+  Surface,
+  Panel,
+  Stack,
+  Box,
+  Grid,
+  Typography,
+  Divider,
+  Button,
+  useTheme,
+  CodeBlock,
+} from '@archway/valet';
+import { useNavigate } from 'react-router-dom';
+import NavDrawer from '../../components/NavDrawer';
+import PageHero from '../../components/PageHero';
+import type { DocMeta } from '../../types';
+
+export const meta: DocMeta = {
+  id: 'spacing',
+  title: 'Spacing — Density & Compact',
+  description:
+    'valet has two orthogonal spacing axes: density scales spacing, and compact zeros it and cascades. Learn how each works and when to reach for which.',
+  pageType: 'concept',
+  prerequisites: ['theme-engine'],
+  components: ['Surface', 'Panel', 'Stack', 'Box', 'Grid'],
+  tldr: 'density = scale the spacing unit (tight 0.9× / standard 1× / comfortable 1.15×) on a Surface or any layout container; compact = hard-zero layout pad/gap that cascades to descendants, with compact={false} to opt a subtree back out. They are independent and combine.',
+};
+
+type Density = 'tight' | 'standard' | 'comfortable';
+
+const DENSITY_SNIPPET = `// Global — scale the whole screen
+<Surface density="comfortable"> … </Surface>
+
+// Subtree — scale just one region
+<Panel density="tight">
+  <Stack> … </Stack>   {/* gap + pads re-rhythm to 0.9× */}
+</Panel>
+
+// tight = 0.9×   standard = 1×   comfortable = 1.15×
+// Every theme.spacing(n) resolves to calc(var(--valet-space) * n),
+// so one prop re-rhythms the whole subtree.`;
+
+const COMPACT_SNIPPET = `// Zero the layout spacing of a region AND everything inside it
+<Panel compact>
+  <Stack>                    {/* gap → 0 */}
+    <Box pad={2}>A</Box>     {/* pad → 0 (inherited) */}
+    <Panel pad={1}>B</Panel> {/* pad → 0 (inherited) */}
+
+    <Panel compact={false} pad={1}>
+      {/* opted out — keeps its padding */}
+    </Panel>
+  </Stack>
+</Panel>`;
+
+export default function SpacingPage() {
+  const { theme } = useTheme();
+  const navigate = useNavigate();
+
+  const [density, setDensity] = useState<Density>('standard');
+  const [compact, setCompact] = useState(false);
+
+  /* A small, repeated content block used by both demos. */
+  const demoItems = ['Alpha', 'Bravo', 'Charlie'];
+
+  return (
+    <Surface>
+      <NavDrawer />
+      <Stack sx={{ gap: theme.spacing(1) }}>
+        <PageHero
+          title='Spacing — Density &amp; Compact'
+          subtitle='Two independent axes: density scales spacing, compact zeros it and cascades.'
+        />
+
+        {/* ── Mental model ─────────────────────────────────────── */}
+        <Panel
+          fullWidth
+          pad={1}
+        >
+          <Typography>
+            Every valet spacing value flows through <code>theme.spacing(n)</code>, which resolves to{' '}
+            <code>calc(var(--valet-space) * n)</code>. That single variable is the knob behind both
+            controls on this page — <b>density</b> changes its multiplier; <b>compact</b>{' '}
+            short-circuits spacing to <code>0</code>. They are orthogonal: you can run a tight,
+            comfortable, or standard subtree, and independently collapse any region to zero.
+          </Typography>
+          <Divider thickness={2} />
+          <Grid
+            columns={2}
+            gap={1}
+            adaptive
+          >
+            <Panel pad={1}>
+              <Typography
+                variant='h4'
+                bold
+              >
+                density — <i>scale</i>
+              </Typography>
+              <Typography>
+                A tier: <code>tight</code> · <code>standard</code> · <code>comfortable</code>. Keeps
+                rhythm, just tighter or looser. Cascades via CSS (<code>--valet-space</code>).
+              </Typography>
+            </Panel>
+            <Panel pad={1}>
+              <Typography
+                variant='h4'
+                bold
+              >
+                compact — <i>zero</i>
+              </Typography>
+              <Typography>
+                A boolean: hard-zeros container pad/gap. Cascades to descendants via React context;{' '}
+                <code>compact={'{false}'}</code> opts a subtree back out.
+              </Typography>
+            </Panel>
+          </Grid>
+        </Panel>
+
+        {/* ── Density ──────────────────────────────────────────── */}
+        <Panel
+          fullWidth
+          pad={1}
+        >
+          <Typography
+            variant='h3'
+            bold
+          >
+            Density — scale the spacing unit
+          </Typography>
+          <Typography>
+            <code>density</code> multiplies the spacing unit for a subtree: <code>tight</code> ={' '}
+            0.9×, <code>standard</code> = 1×, <code>comfortable</code> = 1.15×. Set it on a{' '}
+            <code>&lt;Surface&gt;</code> to re-rhythm a whole screen, or on any layout container (
+            <code>Stack</code>, <code>Panel</code>, <code>Grid</code>, <code>Tabs</code>) to scale
+            just that region. Because it rides <code>--valet-space</code>, every nested{' '}
+            <code>gap</code>/<code>pad</code> follows automatically.
+          </Typography>
+
+          <Stack
+            direction='row'
+            gap={1}
+            sx={{ flexWrap: 'wrap' }}
+          >
+            {(['tight', 'standard', 'comfortable'] as const).map((d) => (
+              <Button
+                key={d}
+                variant={density === d ? 'filled' : 'outlined'}
+                onClick={() => setDensity(d)}
+              >
+                {d}
+              </Button>
+            ))}
+          </Stack>
+
+          <Panel
+            density={density}
+            fullWidth
+            pad={1}
+            variant='outlined'
+          >
+            <Typography variant='subtitle'>
+              This Panel is <code>density=&quot;{density}&quot;</code> — its pad, the Stack gap, and
+              the nested Panels all scale together.
+            </Typography>
+            <Stack>
+              {demoItems.map((t) => (
+                <Panel
+                  key={t}
+                  pad={1}
+                >
+                  <Typography>{t}</Typography>
+                </Panel>
+              ))}
+            </Stack>
+          </Panel>
+
+          <CodeBlock
+            code={DENSITY_SNIPPET}
+            ariaLabel='Density usage example'
+          />
+        </Panel>
+
+        {/* ── Compact ──────────────────────────────────────────── */}
+        <Panel
+          fullWidth
+          pad={1}
+        >
+          <Typography
+            variant='h3'
+            bold
+          >
+            Compact — zero the spacing, and cascade
+          </Typography>
+          <Typography>
+            <code>compact</code> is a hard zero of <i>layout</i> spacing — container{' '}
+            <code>pad</code>, <code>gap</code>, and spacing-margins all become <code>0</code> — and
+            it <b>cascades</b> to every spacing-aware descendant. Reach for it when a region must
+            sit flush (dense toolbars, embedded chrome, tight cards). A nested{' '}
+            <code>compact={'{false}'}</code> opts that subtree back out.
+          </Typography>
+
+          <Stack
+            direction='row'
+            gap={1}
+            sx={{ alignItems: 'center', flexWrap: 'wrap' }}
+          >
+            <Button
+              variant={compact ? 'filled' : 'outlined'}
+              onClick={() => setCompact((c) => !c)}
+            >
+              compact: {compact ? 'on' : 'off'}
+            </Button>
+            <Typography variant='subtitle'>Toggle and watch the whole subtree collapse.</Typography>
+          </Stack>
+
+          <Panel
+            compact={compact}
+            fullWidth
+            pad={1}
+            variant='outlined'
+          >
+            <Typography variant='subtitle'>
+              Outer Panel (<code>compact={`{${String(compact)}}`}</code>)
+            </Typography>
+            <Stack>
+              {demoItems.map((t) => (
+                <Panel
+                  key={t}
+                  pad={1}
+                >
+                  <Typography>{t} — inherits compact</Typography>
+                </Panel>
+              ))}
+              <Panel
+                compact={false}
+                pad={1}
+              >
+                <Typography>
+                  I set <code>compact={'{false}'}</code> — I keep my padding even when the ancestor
+                  is compact.
+                </Typography>
+              </Panel>
+            </Stack>
+          </Panel>
+
+          <CodeBlock
+            code={COMPACT_SNIPPET}
+            ariaLabel='Compact usage example'
+          />
+
+          <Typography variant='subtitle'>
+            Compact zeros <i>spacing</i>, never structure. It preserves:
+          </Typography>
+          <Box
+            as='ul'
+            sx={{ marginBlock: 0, paddingInlineStart: theme.spacing(2) }}
+          >
+            <li>control-internal padding (Select trigger, Chip pill, field insets)</li>
+            <li>alignment &amp; centering (alignX, centerContent, auto-margins)</li>
+            <li>structural geometry (Tree indentation &amp; connector lines)</li>
+            <li>border-radius, glyph/icon sizes, control heights</li>
+            <li>safe-area insets, viewport gutters, and any spacing you set via sx</li>
+          </Box>
+        </Panel>
+
+        {/* ── Combine + migration ──────────────────────────────── */}
+        <Panel
+          fullWidth
+          pad={1}
+        >
+          <Typography
+            variant='h3'
+            bold
+          >
+            They combine
+          </Typography>
+          <Typography>
+            The axes are independent, so they compose: a <code>comfortable</code> screen can still
+            hold a <code>compact</code> toolbar, and a <code>tight</code> dashboard can give one
+            card room with <code>compact={'{false}'}</code>. Density sets the rhythm; compact
+            removes it where you need flush edges.
+          </Typography>
+          <Divider thickness={2} />
+          <Typography variant='subtitle'>
+            Migrating from an older valet? The density tier <code>&quot;compact&quot;</code> was
+            renamed to <code>&quot;tight&quot;</code> (hard rename, no alias). Replace{' '}
+            <code>density=&quot;compact&quot;</code> with <code>density=&quot;tight&quot;</code>;
+            the boolean <code>compact</code> prop is unrelated and now means zero-and-cascade.
+          </Typography>
+        </Panel>
+
+        <Button onClick={() => navigate(-1)}>← Back</Button>
+      </Stack>
+    </Surface>
+  );
+}

--- a/docs/src/pages/getting-started/ThemeEngine.tsx
+++ b/docs/src/pages/getting-started/ThemeEngine.tsx
@@ -473,7 +473,7 @@ useInitialTheme(
               <Stack sx={{ gap: theme.spacing(0.75) }}>
                 <Typography bold>Date Selector</Typography>
                 <DateSelector
-                  density='compact'
+                  density='tight'
                   minDate='2020-01-01'
                   maxDate='2030-12-31'
                 />

--- a/mcp-data/_meta.json
+++ b/mcp-data/_meta.json
@@ -1,6 +1,6 @@
 {
   "version": "0.35.1",
-  "builtAt": "2026-06-13T05:36:48.476Z",
+  "builtAt": "2026-06-14T02:18:31.461Z",
   "schemaVersion": "1.7",
-  "buildHash": "d9a1b69b6c6b28dc4aae3def2f9291b4cbd9571c"
+  "buildHash": "2713be130df0534c3785275e08380a8c3c2574f1"
 }

--- a/mcp-data/_routes.json
+++ b/mcp-data/_routes.json
@@ -50,6 +50,7 @@
     "/select-demo": "docs/src/pages/components/field/SelectDemo.tsx",
     "/slider-demo": "docs/src/pages/components/field/SliderDemo.tsx",
     "/snackbar-demo": "docs/src/pages/components/widgets/SnackbarDemo.tsx",
+    "/spacing": "docs/src/pages/getting-started/Spacing.tsx",
     "/speeddial-demo": "docs/src/pages/components/widgets/SpeedDialDemo.tsx",
     "/stack-demo": "docs/src/pages/components/layout/StackDemo.tsx",
     "/surface": "docs/src/pages/components/layout/Surface.tsx",

--- a/mcp-data/components/components_fields_dateselector.json
+++ b/mcp-data/components/components_fields_dateselector.json
@@ -66,11 +66,11 @@
     },
     {
       "name": "density",
-      "type": "'compact' | 'standard' | 'comfortable'",
+      "type": "'tight' | 'standard' | 'comfortable'",
       "required": false,
-      "description": "Density override; alias: `compact` maps to `density='compact'`",
+      "description": "Density scale for the calendar's own spacing and visual sizing. The small\n(formerly `compact`) visual mode is now `density='tight'`; density never\nzeroes layout.",
       "enumValues": [
-        "compact",
+        "tight",
         "standard",
         "comfortable"
       ]
@@ -79,7 +79,7 @@
       "name": "compact",
       "type": "boolean",
       "required": false,
-      "description": "Legacy alias for density='compact'."
+      "description": "Layout-compact relay: zeroes inherited layout spacing and cascades to\ndescendants via context. No longer a density alias."
     },
     {
       "name": "locale",
@@ -141,7 +141,7 @@
     "Constrain input with minDate/maxDate to prevent out-of-range selection.",
     "For ranges, keep [start, end] ordered and handle partial selection gracefully.",
     "Avoid timezone pitfalls: treat values as local dates to prevent off-by-one errors.",
-    "Prefer compactMode on small viewports; use default/adaptive on larger layouts.",
+    "Prefer density='tight' on small viewports for a denser calendar; use default/comfortable on larger layouts. (The standalone `compact` boolean only zeros layout spacing and no longer drives the calendar's visual size — that moved to the density tier.)",
     "Binding precedence (prop > form > internal). An explicit `value` prop always wins; otherwise, in single-date mode, a `name` inside a `FormControl` binds the ISO string to the store (seed the key in `createFormStore(initial)` so the initial selection is honoured); otherwise the picker is uncontrolled. The binding is latched at mount. Range mode binds the `[start, end]` tuple under the same `name`.",
     "Change source. `onValueChange`/`onValueCommit` report a truthful `info.source`: a day cell is selected by clicking, so the source is `'pointer'` rather than a blanket `'programmatic'`.",
     "Internationalize the built-in labels with the `labels` prop (instance-level) or a `ValetLocaleProvider` (app-wide). Resolution is instance `labels` > provider strings > built-in English.",

--- a/mcp-data/components/components_fields_metroselect.json
+++ b/mcp-data/components/components_fields_metroselect.json
@@ -112,6 +112,12 @@
       "type": "string | string[] | undefined",
       "required": false,
       "description": "One or many style-preset names registered via `definePreset()`"
+    },
+    {
+      "name": "compact",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Zeros all layout spacing (pad, gap, and spacing-margins) where supported and\ncascades to spacing-aware descendants. Does not touch control insets,\nstructural geometry, border-radius, glyph sizes, or alignment. `compact={false}`\nopts a subtree back out of an inherited compact."
     }
   ],
   "domPassthrough": {

--- a/mcp-data/components/components_layout_accordion.json
+++ b/mcp-data/components/components_layout_accordion.json
@@ -88,17 +88,16 @@
       "description": "One or many style-preset names registered via `definePreset()`"
     },
     {
+      "name": "compact",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Zeros all layout spacing (pad, gap, and spacing-margins) where supported and\ncascades to spacing-aware descendants. Does not touch control insets,\nstructural geometry, border-radius, glyph sizes, or alignment. `compact={false}`\nopts a subtree back out of an inherited compact."
+    },
+    {
       "name": "pad",
       "type": "Space | undefined",
       "required": false,
       "description": "Container padding as units or CSS length."
-    },
-    {
-      "name": "compact",
-      "type": "boolean | undefined",
-      "required": false,
-      "description": "Compact mode zeros gap and pad where supported.",
-      "default": "false"
     }
   ],
   "domPassthrough": {

--- a/mcp-data/components/components_layout_box.json
+++ b/mcp-data/components/components_layout_box.json
@@ -55,16 +55,16 @@
       "description": "One or many style-preset names registered via `definePreset()`"
     },
     {
+      "name": "compact",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Zeros all layout spacing (pad, gap, and spacing-margins) where supported and\ncascades to spacing-aware descendants. Does not touch control insets,\nstructural geometry, border-radius, glyph sizes, or alignment. `compact={false}`\nopts a subtree back out of an inherited compact."
+    },
+    {
       "name": "pad",
       "type": "Space | undefined",
       "required": false,
       "description": "Container padding as units or CSS length."
-    },
-    {
-      "name": "compact",
-      "type": "boolean | undefined",
-      "required": false,
-      "description": "Compact mode zeros gap and pad where supported."
     },
     {
       "name": "as",

--- a/mcp-data/components/components_layout_grid.json
+++ b/mcp-data/components/components_layout_grid.json
@@ -23,11 +23,11 @@
     },
     {
       "name": "density",
-      "type": "'compact' | 'standard' | 'comfortable'",
+      "type": "'tight' | 'standard' | 'comfortable'",
       "required": false,
-      "description": "Density override; alias: `compact` maps to `density='compact'`",
+      "description": "Density override; an independent spacing scale (never zeros)",
       "enumValues": [
-        "compact",
+        "tight",
         "standard",
         "comfortable"
       ]
@@ -36,8 +36,7 @@
       "name": "compact",
       "type": "boolean",
       "required": false,
-      "description": "Compact zeros both pad and gap (alias for density='compact')",
-      "default": "false"
+      "description": "Hard-zeros layout pad + gap and cascades to descendants (independent of density)"
     },
     {
       "name": "normalizeRowHeights",
@@ -83,7 +82,8 @@
     "--valet-panel-max-h",
     "--valet-stack-ov-y",
     "--valet-stack-max-h",
-    "--valet-box-max-h"
+    "--valet-box-max-h",
+    "--valet-space"
   ],
   "cssPresets": [],
   "events": [],

--- a/mcp-data/components/components_layout_modal.json
+++ b/mcp-data/components/components_layout_modal.json
@@ -67,8 +67,7 @@
       "name": "compact",
       "type": "boolean",
       "required": false,
-      "description": "Compact removes container + internal paddings",
-      "default": "false"
+      "description": "Compact removes container + internal paddings"
     },
     {
       "name": "disableBackdropClick",

--- a/mcp-data/components/components_layout_panel.json
+++ b/mcp-data/components/components_layout_panel.json
@@ -79,22 +79,22 @@
       "description": "One or many style-preset names registered via `definePreset()`"
     },
     {
+      "name": "compact",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Zeros all layout spacing (pad, gap, and spacing-margins) where supported and\ncascades to spacing-aware descendants. Does not touch control insets,\nstructural geometry, border-radius, glyph sizes, or alignment. `compact={false}`\nopts a subtree back out of an inherited compact."
+    },
+    {
       "name": "pad",
       "type": "Space | undefined",
       "required": false,
       "description": "Container padding as units or CSS length."
     },
     {
-      "name": "compact",
-      "type": "boolean | undefined",
-      "required": false,
-      "description": "Compact mode zeros gap and pad where supported."
-    },
-    {
       "name": "density",
-      "type": "\"compact\" | \"standard\" | \"comfortable\" | undefined",
+      "type": "\"tight\" | \"standard\" | \"comfortable\" | undefined",
       "required": false,
-      "description": "Density override for spacing scale; defaults from nearest Surface."
+      "description": "Density override for the spacing scale; defaults from nearest Surface."
     }
   ],
   "domPassthrough": {
@@ -110,6 +110,7 @@
     "--valet-bg",
     "--valet-text-color",
     "--valet-centered",
+    "--valet-space",
     "--valet-intent-bg",
     "--valet-intent-fg",
     "--valet-intent-border",

--- a/mcp-data/components/components_layout_stack.json
+++ b/mcp-data/components/components_layout_stack.json
@@ -66,13 +66,13 @@
       "name": "compact",
       "type": "boolean | undefined",
       "required": false,
-      "description": "Compact mode zeros gap and pad where supported."
+      "description": "Zeros all layout spacing (pad, gap, and spacing-margins) where supported and\ncascades to spacing-aware descendants. Does not touch control insets,\nstructural geometry, border-radius, glyph sizes, or alignment. `compact={false}`\nopts a subtree back out of an inherited compact."
     },
     {
       "name": "density",
-      "type": "\"compact\" | \"standard\" | \"comfortable\" | undefined",
+      "type": "\"tight\" | \"standard\" | \"comfortable\" | undefined",
       "required": false,
-      "description": "Density override for spacing scale; defaults from nearest Surface."
+      "description": "Density override for the spacing scale; defaults from nearest Surface."
     }
   ],
   "domPassthrough": {
@@ -83,7 +83,8 @@
   },
   "cssVars": [
     "--valet-stack-max-h",
-    "--valet-stack-ov-y"
+    "--valet-stack-ov-y",
+    "--valet-space"
   ],
   "cssPresets": [],
   "events": [],

--- a/mcp-data/components/components_layout_surface.json
+++ b/mcp-data/components/components_layout_surface.json
@@ -26,7 +26,7 @@
       "name": "compact",
       "type": "boolean",
       "required": false,
-      "description": "Alias: when true, maps to density='compact' (no override when false)."
+      "description": "Zeros all layout spacing and cascades to descendants; opt out with\ncompact={false}. Independent of the density scale."
     },
     {
       "name": "blockUntilFonts",
@@ -81,7 +81,7 @@
     "Opt into per-element metrics with $trackSize. styled() elements register with the surface store and expose --valet-el-width and --valet-el-height (updated via ResizeObserver) only when passed the $trackSize transient prop. Tracking is off by default — most elements never need their own metrics, so the default path stays allocation-free.",
     "Keep portalled overlays out of the registry. Drawers and Modals rendered outside the surface root are intentionally not tracked to avoid unnecessary observers. Size them via tokens and breakpoints, not child metrics.",
     "Respect height constraints. Tables are height‑aware by default; let their content scroll inside the component. Only pass constrainHeight={false} when page context requires full‑document scroll.",
-    "Drive spacing and density with variables. Adjust --valet-space, --valet-radius, and --valet-stroke on the surface to shift an entire view without changing component code.",
+    "Drive spacing and density with variables. Set `density` ('tight' 0.9× | 'standard' 1× | 'comfortable' 1.15×) on the Surface to scale spacing for the whole screen (it sets --valet-space); set it on any layout container to scale just that subtree. Use the `compact` boolean to hard-zero a region's layout spacing — it cascades to descendants and `compact={false}` opts a subtree back out. Adjust --valet-space/--valet-radius/--valet-stroke directly for finer control.",
     "blockUntilFonts is fail-safe. It hides content until web fonts settle, but a 500ms never-block grace reveals the screen anyway if no font load ever starts, so a missing or skipped font pipeline can never wedge the UI hidden forever."
   ],
   "examples": [],

--- a/mcp-data/components/components_layout_tabs.json
+++ b/mcp-data/components/components_layout_tabs.json
@@ -84,16 +84,16 @@
       "description": "One or many style-preset names registered via `definePreset()`"
     },
     {
+      "name": "compact",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Zeros all layout spacing (pad, gap, and spacing-margins) where supported and\ncascades to spacing-aware descendants. Does not touch control insets,\nstructural geometry, border-radius, glyph sizes, or alignment. `compact={false}`\nopts a subtree back out of an inherited compact."
+    },
+    {
       "name": "pad",
       "type": "Space | undefined",
       "required": false,
       "description": "Container padding as units or CSS length."
-    },
-    {
-      "name": "compact",
-      "type": "boolean | undefined",
-      "required": false,
-      "description": "Compact mode zeros gap and pad where supported."
     },
     {
       "name": "gap",
@@ -103,9 +103,9 @@
     },
     {
       "name": "density",
-      "type": "\"compact\" | \"standard\" | \"comfortable\" | undefined",
+      "type": "\"tight\" | \"standard\" | \"comfortable\" | undefined",
       "required": false,
-      "description": "Density override for spacing scale; defaults from nearest Surface."
+      "description": "Density override for the spacing scale; defaults from nearest Surface."
     }
   ],
   "domPassthrough": {
@@ -119,7 +119,8 @@
     "--valet-focus-width",
     "--valet-focus-ring-color",
     "--valet-focus-offset",
-    "--valet-underline-width"
+    "--valet-underline-width",
+    "--valet-space"
   ],
   "cssPresets": [],
   "events": [

--- a/mcp-data/components/components_layout_tabs.panel.json
+++ b/mcp-data/components/components_layout_tabs.panel.json
@@ -35,7 +35,8 @@
     "--valet-focus-width",
     "--valet-focus-ring-color",
     "--valet-focus-offset",
-    "--valet-underline-width"
+    "--valet-underline-width",
+    "--valet-space"
   ],
   "cssPresets": [],
   "events": [],

--- a/mcp-data/components/components_layout_tabs.tab.json
+++ b/mcp-data/components/components_layout_tabs.tab.json
@@ -40,7 +40,8 @@
     "--valet-focus-width",
     "--valet-focus-ring-color",
     "--valet-focus-offset",
-    "--valet-underline-width"
+    "--valet-underline-width",
+    "--valet-space"
   ],
   "cssPresets": [],
   "events": [],

--- a/mcp-data/components/components_primitives_divider.json
+++ b/mcp-data/components/components_primitives_divider.json
@@ -49,16 +49,16 @@
       "description": "One or many style-preset names registered via `definePreset()`"
     },
     {
+      "name": "compact",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Zeros all layout spacing (pad, gap, and spacing-margins) where supported and\ncascades to spacing-aware descendants. Does not touch control insets,\nstructural geometry, border-radius, glyph sizes, or alignment. `compact={false}`\nopts a subtree back out of an inherited compact."
+    },
+    {
       "name": "pad",
       "type": "Space | undefined",
       "required": false,
       "description": "Container padding as units or CSS length."
-    },
-    {
-      "name": "compact",
-      "type": "boolean | undefined",
-      "required": false,
-      "description": "Compact mode zeros gap and pad where supported."
     }
   ],
   "domPassthrough": {

--- a/mcp-data/components/components_widgets_llmchat.json
+++ b/mcp-data/components/components_widgets_llmchat.json
@@ -88,6 +88,12 @@
       "description": "Inline styles (with CSS var support)"
     },
     {
+      "name": "compact",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Zeros all layout spacing (pad, gap, and spacing-margins) where supported and\ncascades to spacing-aware descendants. Does not touch control insets,\nstructural geometry, border-radius, glyph sizes, or alignment. `compact={false}`\nopts a subtree back out of an inherited compact."
+    },
+    {
       "name": "preset",
       "type": "string | string[] | undefined",
       "required": false,

--- a/mcp-data/components/components_widgets_richchat.json
+++ b/mcp-data/components/components_widgets_richchat.json
@@ -74,6 +74,12 @@
       "description": "Inline styles (with CSS var support)"
     },
     {
+      "name": "compact",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Zeros all layout spacing (pad, gap, and spacing-margins) where supported and\ncascades to spacing-aware descendants. Does not touch control insets,\nstructural geometry, border-radius, glyph sizes, or alignment. `compact={false}`\nopts a subtree back out of an inherited compact."
+    },
+    {
       "name": "preset",
       "type": "string | string[] | undefined",
       "required": false,

--- a/mcp-data/glossary.json
+++ b/mcp-data/glossary.json
@@ -1,6 +1,21 @@
 {
   "entries": [
     {
+      "term": "--valet-space",
+      "definition": "The CSS custom property behind every valet spacing value: theme.spacing(n) resolves to calc(var(--valet-space) * n). density scales this variable (per-Surface or per-subtree); compact bypasses it, forcing spacing to 0. Setting it on a container re-rhythms that subtree without touching component code.",
+      "category": "css",
+      "aliases": [
+        "valet space",
+        "spacing unit",
+        "spacing token"
+      ],
+      "seeAlso": [
+        "density",
+        "compact",
+        "theme"
+      ]
+    },
+    {
       "term": "accessibility",
       "definition": "Mandatory accessibility in every component: proper roles, labels, keyboard support, and predictable focus behavior across the library.",
       "category": "a11y",
@@ -26,6 +41,21 @@
       ]
     },
     {
+      "term": "compact",
+      "definition": "The spacing-ZERO axis. A boolean that hard-zeros a container's LAYOUT spacing (pad, gap, spacing-margins) and CASCADES to every spacing-aware descendant via React context — so one <Panel compact> flattens its whole subtree. Reach for it where regions must sit flush: dense toolbars, embedded chrome, tight cards. compact={false} on a descendant opts that subtree back out. It deliberately PRESERVES what isn't whitespace: control-internal padding (field/Select/Chip insets), alignment and centering, structural geometry (e.g. Tree indentation and connector lines), border-radius, glyph/icon sizes, and any spacing set via sx. It removes spacing, never structure — and is independent of density (zero, not scale).",
+      "category": "css",
+      "aliases": [
+        "compact prop",
+        "zero spacing",
+        "cascade"
+      ],
+      "seeAlso": [
+        "density",
+        "--valet-space",
+        "Surface"
+      ]
+    },
+    {
       "term": "Context Bridge",
       "definition": "A typed, schema-driven bridge for state shared between app and agents, implemented with Zustand and JSON schemas.",
       "category": "ai",
@@ -35,6 +65,24 @@
       "seeAlso": [
         "theme",
         "MCP"
+      ]
+    },
+    {
+      "term": "density",
+      "definition": "The spacing SCALE axis. A tier — 'tight' (0.9×), 'standard' (1×), or 'comfortable' (1.15×) — that multiplies the spacing unit by setting the --valet-space CSS var. Set it on a <Surface> to re-rhythm a whole screen, or on any layout container (Stack/Panel/Grid/Tabs) to scale just that subtree; every theme.spacing(n) inside follows automatically. The former density tier 'compact' was renamed to 'tight' (hard rename, no alias) so the word 'compact' is free for the boolean. Orthogonal to compact: density scales spacing, it never zeros it.",
+      "category": "css",
+      "aliases": [
+        "density prop",
+        "tight",
+        "standard",
+        "comfortable",
+        "spacing scale"
+      ],
+      "seeAlso": [
+        "compact",
+        "--valet-space",
+        "Surface",
+        "theme"
       ]
     },
     {
@@ -167,5 +215,5 @@
     }
   ],
   "version": "0.35.1",
-  "builtAt": "2026-06-13T05:36:48.476Z"
+  "builtAt": "2026-06-14T02:18:31.461Z"
 }

--- a/packages/valet-mcp/mcp-data/_meta.json
+++ b/packages/valet-mcp/mcp-data/_meta.json
@@ -1,6 +1,6 @@
 {
   "version": "0.35.1",
-  "builtAt": "2026-06-13T05:36:48.476Z",
+  "builtAt": "2026-06-14T02:18:31.461Z",
   "schemaVersion": "1.7",
-  "buildHash": "d9a1b69b6c6b28dc4aae3def2f9291b4cbd9571c"
+  "buildHash": "2713be130df0534c3785275e08380a8c3c2574f1"
 }

--- a/packages/valet-mcp/mcp-data/components/components_fields_dateselector.json
+++ b/packages/valet-mcp/mcp-data/components/components_fields_dateselector.json
@@ -66,11 +66,11 @@
     },
     {
       "name": "density",
-      "type": "'compact' | 'standard' | 'comfortable'",
+      "type": "'tight' | 'standard' | 'comfortable'",
       "required": false,
-      "description": "Density override; alias: `compact` maps to `density='compact'`",
+      "description": "Density scale for the calendar's own spacing and visual sizing. The small\n(formerly `compact`) visual mode is now `density='tight'`; density never\nzeroes layout.",
       "enumValues": [
-        "compact",
+        "tight",
         "standard",
         "comfortable"
       ]
@@ -79,7 +79,7 @@
       "name": "compact",
       "type": "boolean",
       "required": false,
-      "description": "Legacy alias for density='compact'."
+      "description": "Layout-compact relay: zeroes inherited layout spacing and cascades to\ndescendants via context. No longer a density alias."
     },
     {
       "name": "locale",
@@ -141,7 +141,7 @@
     "Constrain input with minDate/maxDate to prevent out-of-range selection.",
     "For ranges, keep [start, end] ordered and handle partial selection gracefully.",
     "Avoid timezone pitfalls: treat values as local dates to prevent off-by-one errors.",
-    "Prefer compactMode on small viewports; use default/adaptive on larger layouts.",
+    "Prefer density='tight' on small viewports for a denser calendar; use default/comfortable on larger layouts. (The standalone `compact` boolean only zeros layout spacing and no longer drives the calendar's visual size — that moved to the density tier.)",
     "Binding precedence (prop > form > internal). An explicit `value` prop always wins; otherwise, in single-date mode, a `name` inside a `FormControl` binds the ISO string to the store (seed the key in `createFormStore(initial)` so the initial selection is honoured); otherwise the picker is uncontrolled. The binding is latched at mount. Range mode binds the `[start, end]` tuple under the same `name`.",
     "Change source. `onValueChange`/`onValueCommit` report a truthful `info.source`: a day cell is selected by clicking, so the source is `'pointer'` rather than a blanket `'programmatic'`.",
     "Internationalize the built-in labels with the `labels` prop (instance-level) or a `ValetLocaleProvider` (app-wide). Resolution is instance `labels` > provider strings > built-in English.",

--- a/packages/valet-mcp/mcp-data/components/components_fields_metroselect.json
+++ b/packages/valet-mcp/mcp-data/components/components_fields_metroselect.json
@@ -112,6 +112,12 @@
       "type": "string | string[] | undefined",
       "required": false,
       "description": "One or many style-preset names registered via `definePreset()`"
+    },
+    {
+      "name": "compact",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Zeros all layout spacing (pad, gap, and spacing-margins) where supported and\ncascades to spacing-aware descendants. Does not touch control insets,\nstructural geometry, border-radius, glyph sizes, or alignment. `compact={false}`\nopts a subtree back out of an inherited compact."
     }
   ],
   "domPassthrough": {

--- a/packages/valet-mcp/mcp-data/components/components_layout_accordion.json
+++ b/packages/valet-mcp/mcp-data/components/components_layout_accordion.json
@@ -88,17 +88,16 @@
       "description": "One or many style-preset names registered via `definePreset()`"
     },
     {
+      "name": "compact",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Zeros all layout spacing (pad, gap, and spacing-margins) where supported and\ncascades to spacing-aware descendants. Does not touch control insets,\nstructural geometry, border-radius, glyph sizes, or alignment. `compact={false}`\nopts a subtree back out of an inherited compact."
+    },
+    {
       "name": "pad",
       "type": "Space | undefined",
       "required": false,
       "description": "Container padding as units or CSS length."
-    },
-    {
-      "name": "compact",
-      "type": "boolean | undefined",
-      "required": false,
-      "description": "Compact mode zeros gap and pad where supported.",
-      "default": "false"
     }
   ],
   "domPassthrough": {

--- a/packages/valet-mcp/mcp-data/components/components_layout_box.json
+++ b/packages/valet-mcp/mcp-data/components/components_layout_box.json
@@ -55,16 +55,16 @@
       "description": "One or many style-preset names registered via `definePreset()`"
     },
     {
+      "name": "compact",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Zeros all layout spacing (pad, gap, and spacing-margins) where supported and\ncascades to spacing-aware descendants. Does not touch control insets,\nstructural geometry, border-radius, glyph sizes, or alignment. `compact={false}`\nopts a subtree back out of an inherited compact."
+    },
+    {
       "name": "pad",
       "type": "Space | undefined",
       "required": false,
       "description": "Container padding as units or CSS length."
-    },
-    {
-      "name": "compact",
-      "type": "boolean | undefined",
-      "required": false,
-      "description": "Compact mode zeros gap and pad where supported."
     },
     {
       "name": "as",

--- a/packages/valet-mcp/mcp-data/components/components_layout_grid.json
+++ b/packages/valet-mcp/mcp-data/components/components_layout_grid.json
@@ -23,11 +23,11 @@
     },
     {
       "name": "density",
-      "type": "'compact' | 'standard' | 'comfortable'",
+      "type": "'tight' | 'standard' | 'comfortable'",
       "required": false,
-      "description": "Density override; alias: `compact` maps to `density='compact'`",
+      "description": "Density override; an independent spacing scale (never zeros)",
       "enumValues": [
-        "compact",
+        "tight",
         "standard",
         "comfortable"
       ]
@@ -36,8 +36,7 @@
       "name": "compact",
       "type": "boolean",
       "required": false,
-      "description": "Compact zeros both pad and gap (alias for density='compact')",
-      "default": "false"
+      "description": "Hard-zeros layout pad + gap and cascades to descendants (independent of density)"
     },
     {
       "name": "normalizeRowHeights",
@@ -83,7 +82,8 @@
     "--valet-panel-max-h",
     "--valet-stack-ov-y",
     "--valet-stack-max-h",
-    "--valet-box-max-h"
+    "--valet-box-max-h",
+    "--valet-space"
   ],
   "cssPresets": [],
   "events": [],

--- a/packages/valet-mcp/mcp-data/components/components_layout_modal.json
+++ b/packages/valet-mcp/mcp-data/components/components_layout_modal.json
@@ -67,8 +67,7 @@
       "name": "compact",
       "type": "boolean",
       "required": false,
-      "description": "Compact removes container + internal paddings",
-      "default": "false"
+      "description": "Compact removes container + internal paddings"
     },
     {
       "name": "disableBackdropClick",

--- a/packages/valet-mcp/mcp-data/components/components_layout_panel.json
+++ b/packages/valet-mcp/mcp-data/components/components_layout_panel.json
@@ -79,22 +79,22 @@
       "description": "One or many style-preset names registered via `definePreset()`"
     },
     {
+      "name": "compact",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Zeros all layout spacing (pad, gap, and spacing-margins) where supported and\ncascades to spacing-aware descendants. Does not touch control insets,\nstructural geometry, border-radius, glyph sizes, or alignment. `compact={false}`\nopts a subtree back out of an inherited compact."
+    },
+    {
       "name": "pad",
       "type": "Space | undefined",
       "required": false,
       "description": "Container padding as units or CSS length."
     },
     {
-      "name": "compact",
-      "type": "boolean | undefined",
-      "required": false,
-      "description": "Compact mode zeros gap and pad where supported."
-    },
-    {
       "name": "density",
-      "type": "\"compact\" | \"standard\" | \"comfortable\" | undefined",
+      "type": "\"tight\" | \"standard\" | \"comfortable\" | undefined",
       "required": false,
-      "description": "Density override for spacing scale; defaults from nearest Surface."
+      "description": "Density override for the spacing scale; defaults from nearest Surface."
     }
   ],
   "domPassthrough": {
@@ -110,6 +110,7 @@
     "--valet-bg",
     "--valet-text-color",
     "--valet-centered",
+    "--valet-space",
     "--valet-intent-bg",
     "--valet-intent-fg",
     "--valet-intent-border",

--- a/packages/valet-mcp/mcp-data/components/components_layout_stack.json
+++ b/packages/valet-mcp/mcp-data/components/components_layout_stack.json
@@ -66,13 +66,13 @@
       "name": "compact",
       "type": "boolean | undefined",
       "required": false,
-      "description": "Compact mode zeros gap and pad where supported."
+      "description": "Zeros all layout spacing (pad, gap, and spacing-margins) where supported and\ncascades to spacing-aware descendants. Does not touch control insets,\nstructural geometry, border-radius, glyph sizes, or alignment. `compact={false}`\nopts a subtree back out of an inherited compact."
     },
     {
       "name": "density",
-      "type": "\"compact\" | \"standard\" | \"comfortable\" | undefined",
+      "type": "\"tight\" | \"standard\" | \"comfortable\" | undefined",
       "required": false,
-      "description": "Density override for spacing scale; defaults from nearest Surface."
+      "description": "Density override for the spacing scale; defaults from nearest Surface."
     }
   ],
   "domPassthrough": {
@@ -83,7 +83,8 @@
   },
   "cssVars": [
     "--valet-stack-max-h",
-    "--valet-stack-ov-y"
+    "--valet-stack-ov-y",
+    "--valet-space"
   ],
   "cssPresets": [],
   "events": [],

--- a/packages/valet-mcp/mcp-data/components/components_layout_surface.json
+++ b/packages/valet-mcp/mcp-data/components/components_layout_surface.json
@@ -26,7 +26,7 @@
       "name": "compact",
       "type": "boolean",
       "required": false,
-      "description": "Alias: when true, maps to density='compact' (no override when false)."
+      "description": "Zeros all layout spacing and cascades to descendants; opt out with\ncompact={false}. Independent of the density scale."
     },
     {
       "name": "blockUntilFonts",
@@ -81,7 +81,7 @@
     "Opt into per-element metrics with $trackSize. styled() elements register with the surface store and expose --valet-el-width and --valet-el-height (updated via ResizeObserver) only when passed the $trackSize transient prop. Tracking is off by default — most elements never need their own metrics, so the default path stays allocation-free.",
     "Keep portalled overlays out of the registry. Drawers and Modals rendered outside the surface root are intentionally not tracked to avoid unnecessary observers. Size them via tokens and breakpoints, not child metrics.",
     "Respect height constraints. Tables are height‑aware by default; let their content scroll inside the component. Only pass constrainHeight={false} when page context requires full‑document scroll.",
-    "Drive spacing and density with variables. Adjust --valet-space, --valet-radius, and --valet-stroke on the surface to shift an entire view without changing component code.",
+    "Drive spacing and density with variables. Set `density` ('tight' 0.9× | 'standard' 1× | 'comfortable' 1.15×) on the Surface to scale spacing for the whole screen (it sets --valet-space); set it on any layout container to scale just that subtree. Use the `compact` boolean to hard-zero a region's layout spacing — it cascades to descendants and `compact={false}` opts a subtree back out. Adjust --valet-space/--valet-radius/--valet-stroke directly for finer control.",
     "blockUntilFonts is fail-safe. It hides content until web fonts settle, but a 500ms never-block grace reveals the screen anyway if no font load ever starts, so a missing or skipped font pipeline can never wedge the UI hidden forever."
   ],
   "examples": [],

--- a/packages/valet-mcp/mcp-data/components/components_layout_tabs.json
+++ b/packages/valet-mcp/mcp-data/components/components_layout_tabs.json
@@ -84,16 +84,16 @@
       "description": "One or many style-preset names registered via `definePreset()`"
     },
     {
+      "name": "compact",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Zeros all layout spacing (pad, gap, and spacing-margins) where supported and\ncascades to spacing-aware descendants. Does not touch control insets,\nstructural geometry, border-radius, glyph sizes, or alignment. `compact={false}`\nopts a subtree back out of an inherited compact."
+    },
+    {
       "name": "pad",
       "type": "Space | undefined",
       "required": false,
       "description": "Container padding as units or CSS length."
-    },
-    {
-      "name": "compact",
-      "type": "boolean | undefined",
-      "required": false,
-      "description": "Compact mode zeros gap and pad where supported."
     },
     {
       "name": "gap",
@@ -103,9 +103,9 @@
     },
     {
       "name": "density",
-      "type": "\"compact\" | \"standard\" | \"comfortable\" | undefined",
+      "type": "\"tight\" | \"standard\" | \"comfortable\" | undefined",
       "required": false,
-      "description": "Density override for spacing scale; defaults from nearest Surface."
+      "description": "Density override for the spacing scale; defaults from nearest Surface."
     }
   ],
   "domPassthrough": {
@@ -119,7 +119,8 @@
     "--valet-focus-width",
     "--valet-focus-ring-color",
     "--valet-focus-offset",
-    "--valet-underline-width"
+    "--valet-underline-width",
+    "--valet-space"
   ],
   "cssPresets": [],
   "events": [

--- a/packages/valet-mcp/mcp-data/components/components_layout_tabs.panel.json
+++ b/packages/valet-mcp/mcp-data/components/components_layout_tabs.panel.json
@@ -35,7 +35,8 @@
     "--valet-focus-width",
     "--valet-focus-ring-color",
     "--valet-focus-offset",
-    "--valet-underline-width"
+    "--valet-underline-width",
+    "--valet-space"
   ],
   "cssPresets": [],
   "events": [],

--- a/packages/valet-mcp/mcp-data/components/components_layout_tabs.tab.json
+++ b/packages/valet-mcp/mcp-data/components/components_layout_tabs.tab.json
@@ -40,7 +40,8 @@
     "--valet-focus-width",
     "--valet-focus-ring-color",
     "--valet-focus-offset",
-    "--valet-underline-width"
+    "--valet-underline-width",
+    "--valet-space"
   ],
   "cssPresets": [],
   "events": [],

--- a/packages/valet-mcp/mcp-data/components/components_primitives_divider.json
+++ b/packages/valet-mcp/mcp-data/components/components_primitives_divider.json
@@ -49,16 +49,16 @@
       "description": "One or many style-preset names registered via `definePreset()`"
     },
     {
+      "name": "compact",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Zeros all layout spacing (pad, gap, and spacing-margins) where supported and\ncascades to spacing-aware descendants. Does not touch control insets,\nstructural geometry, border-radius, glyph sizes, or alignment. `compact={false}`\nopts a subtree back out of an inherited compact."
+    },
+    {
       "name": "pad",
       "type": "Space | undefined",
       "required": false,
       "description": "Container padding as units or CSS length."
-    },
-    {
-      "name": "compact",
-      "type": "boolean | undefined",
-      "required": false,
-      "description": "Compact mode zeros gap and pad where supported."
     }
   ],
   "domPassthrough": {

--- a/packages/valet-mcp/mcp-data/components/components_widgets_llmchat.json
+++ b/packages/valet-mcp/mcp-data/components/components_widgets_llmchat.json
@@ -88,6 +88,12 @@
       "description": "Inline styles (with CSS var support)"
     },
     {
+      "name": "compact",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Zeros all layout spacing (pad, gap, and spacing-margins) where supported and\ncascades to spacing-aware descendants. Does not touch control insets,\nstructural geometry, border-radius, glyph sizes, or alignment. `compact={false}`\nopts a subtree back out of an inherited compact."
+    },
+    {
       "name": "preset",
       "type": "string | string[] | undefined",
       "required": false,

--- a/packages/valet-mcp/mcp-data/components/components_widgets_richchat.json
+++ b/packages/valet-mcp/mcp-data/components/components_widgets_richchat.json
@@ -74,6 +74,12 @@
       "description": "Inline styles (with CSS var support)"
     },
     {
+      "name": "compact",
+      "type": "boolean | undefined",
+      "required": false,
+      "description": "Zeros all layout spacing (pad, gap, and spacing-margins) where supported and\ncascades to spacing-aware descendants. Does not touch control insets,\nstructural geometry, border-radius, glyph sizes, or alignment. `compact={false}`\nopts a subtree back out of an inherited compact."
+    },
+    {
       "name": "preset",
       "type": "string | string[] | undefined",
       "required": false,

--- a/packages/valet-mcp/mcp-data/glossary.json
+++ b/packages/valet-mcp/mcp-data/glossary.json
@@ -1,6 +1,21 @@
 {
   "entries": [
     {
+      "term": "--valet-space",
+      "definition": "The CSS custom property behind every valet spacing value: theme.spacing(n) resolves to calc(var(--valet-space) * n). density scales this variable (per-Surface or per-subtree); compact bypasses it, forcing spacing to 0. Setting it on a container re-rhythms that subtree without touching component code.",
+      "category": "css",
+      "aliases": [
+        "valet space",
+        "spacing unit",
+        "spacing token"
+      ],
+      "seeAlso": [
+        "density",
+        "compact",
+        "theme"
+      ]
+    },
+    {
       "term": "accessibility",
       "definition": "Mandatory accessibility in every component: proper roles, labels, keyboard support, and predictable focus behavior across the library.",
       "category": "a11y",
@@ -26,6 +41,21 @@
       ]
     },
     {
+      "term": "compact",
+      "definition": "The spacing-ZERO axis. A boolean that hard-zeros a container's LAYOUT spacing (pad, gap, spacing-margins) and CASCADES to every spacing-aware descendant via React context — so one <Panel compact> flattens its whole subtree. Reach for it where regions must sit flush: dense toolbars, embedded chrome, tight cards. compact={false} on a descendant opts that subtree back out. It deliberately PRESERVES what isn't whitespace: control-internal padding (field/Select/Chip insets), alignment and centering, structural geometry (e.g. Tree indentation and connector lines), border-radius, glyph/icon sizes, and any spacing set via sx. It removes spacing, never structure — and is independent of density (zero, not scale).",
+      "category": "css",
+      "aliases": [
+        "compact prop",
+        "zero spacing",
+        "cascade"
+      ],
+      "seeAlso": [
+        "density",
+        "--valet-space",
+        "Surface"
+      ]
+    },
+    {
       "term": "Context Bridge",
       "definition": "A typed, schema-driven bridge for state shared between app and agents, implemented with Zustand and JSON schemas.",
       "category": "ai",
@@ -35,6 +65,24 @@
       "seeAlso": [
         "theme",
         "MCP"
+      ]
+    },
+    {
+      "term": "density",
+      "definition": "The spacing SCALE axis. A tier — 'tight' (0.9×), 'standard' (1×), or 'comfortable' (1.15×) — that multiplies the spacing unit by setting the --valet-space CSS var. Set it on a <Surface> to re-rhythm a whole screen, or on any layout container (Stack/Panel/Grid/Tabs) to scale just that subtree; every theme.spacing(n) inside follows automatically. The former density tier 'compact' was renamed to 'tight' (hard rename, no alias) so the word 'compact' is free for the boolean. Orthogonal to compact: density scales spacing, it never zeros it.",
+      "category": "css",
+      "aliases": [
+        "density prop",
+        "tight",
+        "standard",
+        "comfortable",
+        "spacing scale"
+      ],
+      "seeAlso": [
+        "compact",
+        "--valet-space",
+        "Surface",
+        "theme"
       ]
     },
     {
@@ -167,5 +215,5 @@
     }
   ],
   "version": "0.35.1",
-  "builtAt": "2026-06-13T05:36:48.476Z"
+  "builtAt": "2026-06-14T02:18:31.461Z"
 }

--- a/src/components/fields/DateSelector.meta.json
+++ b/src/components/fields/DateSelector.meta.json
@@ -10,7 +10,7 @@
       "Constrain input with minDate/maxDate to prevent out-of-range selection.",
       "For ranges, keep [start, end] ordered and handle partial selection gracefully.",
       "Avoid timezone pitfalls: treat values as local dates to prevent off-by-one errors.",
-      "Prefer compactMode on small viewports; use default/adaptive on larger layouts.",
+      "Prefer density='tight' on small viewports for a denser calendar; use default/comfortable on larger layouts. (The standalone `compact` boolean only zeros layout spacing and no longer drives the calendar's visual size — that moved to the density tier.)",
       "Binding precedence (prop > form > internal). An explicit `value` prop always wins; otherwise, in single-date mode, a `name` inside a `FormControl` binds the ISO string to the store (seed the key in `createFormStore(initial)` so the initial selection is honoured); otherwise the picker is uncontrolled. The binding is latched at mount. Range mode binds the `[start, end]` tuple under the same `name`.",
       "Change source. `onValueChange`/`onValueCommit` report a truthful `info.source`: a day cell is selected by clicking, so the source is `'pointer'` rather than a blanket `'programmatic'`.",
       "Internationalize the built-in labels with the `labels` prop (instance-level) or a `ValetLocaleProvider` (app-wide). Resolution is instance `labels` > provider strings > built-in English.",

--- a/src/components/fields/DateSelector.tsx
+++ b/src/components/fields/DateSelector.tsx
@@ -27,6 +27,7 @@
 import React, { useMemo, useRef, useState } from 'react';
 import { styled } from '../../css/createStyled';
 import { useTheme } from '../../system/themeStore';
+import { CompactCtx, useCompact } from '../../system/compactContext';
 import { preset } from '../../css/stylePresets';
 import { IconButton } from './IconButton';
 import { Select } from './Select';
@@ -69,9 +70,12 @@ export interface DateSelectorProps
   range?: boolean;
   /** Inline styles (with CSS var support) */
   sx?: Sx;
-  /** Density override; alias: `compact` maps to `density='compact'` */
-  density?: 'compact' | 'standard' | 'comfortable';
-  /** Legacy alias for density='compact'. */
+  /** Density scale for the calendar's own spacing and visual sizing. The small
+   * (formerly `compact`) visual mode is now `density='tight'`; density never
+   * zeroes layout. */
+  density?: 'tight' | 'standard' | 'comfortable';
+  /** Layout-compact relay: zeroes inherited layout spacing and cascades to
+   * descendants via context. No longer a density alias. */
   compact?: boolean;
   /**
    * BCP-47 locale for the DISPLAY of month names, weekday headers, and day
@@ -225,7 +229,8 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
   const { theme } = useTheme();
   const t = useComponentStrings('dateSelector', labels);
   const wrapRef = useRef<HTMLDivElement>(null);
-  const compactEffective = compact || density === 'compact';
+  const effectiveCompact = useCompact(compact); // relay only (layout compaction)
+  const tight = density === 'tight'; // drives the visual scale (D6)
 
   /* Intl-derived localization (A11Y S10) ------------------------------------
    * Display-only: month names, weekday headers, the first day of the week, and
@@ -233,9 +238,9 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
    * (formatLocalISO → ISO Latin digits). Defaults to en-US / Sunday-start so
    * the prior English output is byte-identical. */
   const monthNames = useMemo(() => getMonthNames(locale, 'long'), [locale]);
-  /* Non-compact weekday headers reproduce the previous 2-letter English form
+  /* Non-tight weekday headers reproduce the previous 2-letter English form
    * (`Su`, `Mo`, …) via the locale's long names truncated to two characters;
-   * compact takes the first character (the previous `d[0]` behavior). The base
+   * tight takes the first character (the previous `d[0]` behavior). The base
    * array is Monday-first (helper contract), rotated to the resolved first day. */
   const weekdays = useMemo(() => {
     const base = getWeekdayNames(locale, 'long').map((d) => d.slice(0, 2));
@@ -441,163 +446,165 @@ export const DateSelector: React.FC<DateSelectorProps> = ({
       data-valet-component='DateSelector'
       $bg={theme.colors.backgroundAlt}
       $text={`var(--valet-text-color, ${theme.colors.text})` as string}
-      $compact={!!compactEffective}
+      $compact={tight}
       className={cls}
       style={{ '--valet-date-radius': theme.radius(1), ...sx } as React.CSSProperties}
     >
-      <Header $gap={theme.spacing(1)}>
-        <div style={{ display: 'flex', gap: theme.spacing(0.5) }}>
-          {!compactEffective && (
+      <CompactCtx.Provider value={effectiveCompact}>
+        <Header $gap={theme.spacing(1)}>
+          <div style={{ display: 'flex', gap: theme.spacing(0.5) }}>
+            {!tight && (
+              <IconButton
+                size='sm'
+                variant='outlined'
+                color='primaryText'
+                icon='mdi:chevron-double-left'
+                aria-label={t.previousYear}
+                onClick={() => {
+                  const yr = viewYear - 1;
+                  let m = viewMonth;
+                  if (yr === minYear && m < minMonth) m = minMonth;
+                  setViewYear(yr);
+                  setViewMonth(m);
+                }}
+                disabled={new Date(viewYear - 1, 11, 31) < min}
+              />
+            )}
             <IconButton
-              size='sm'
+              size={tight ? 'xs' : 'sm'}
               variant='outlined'
               color='primaryText'
-              icon='mdi:chevron-double-left'
-              aria-label={t.previousYear}
-              onClick={() => {
-                const yr = viewYear - 1;
+              icon='mdi:chevron-left'
+              aria-label={t.previousMonth}
+              onClick={() => changeMonth(-1)}
+              disabled={new Date(viewYear, viewMonth, 0) < min}
+            />
+          </div>
+          <div style={{ display: 'flex', gap: theme.spacing(0.5), flex: 1, minWidth: 0 }}>
+            <Select
+              size='xs'
+              value={viewMonth}
+              onValueChange={(v) => setViewMonth(Number(v))}
+              sx={{ flex: 1, minWidth: 0 }}
+            >
+              {months.map((idx) => (
+                <Select.Option
+                  key={monthNames[idx]}
+                  value={idx}
+                >
+                  {tight ? monthNames[idx].slice(0, 3) : monthNames[idx]}
+                </Select.Option>
+              ))}
+              {/* monthNames is locale-derived (Intl); tight still shows the
+                first three characters, matching the previous 3-letter form. */}
+            </Select>
+            <Select
+              size='xs'
+              value={viewYear}
+              onValueChange={(v) => {
+                const yr = Number(v);
                 let m = viewMonth;
                 if (yr === minYear && m < minMonth) m = minMonth;
-                setViewYear(yr);
-                setViewMonth(m);
-              }}
-              disabled={new Date(viewYear - 1, 11, 31) < min}
-            />
-          )}
-          <IconButton
-            size={compactEffective ? 'xs' : 'sm'}
-            variant='outlined'
-            color='primaryText'
-            icon='mdi:chevron-left'
-            aria-label={t.previousMonth}
-            onClick={() => changeMonth(-1)}
-            disabled={new Date(viewYear, viewMonth, 0) < min}
-          />
-        </div>
-        <div style={{ display: 'flex', gap: theme.spacing(0.5), flex: 1, minWidth: 0 }}>
-          <Select
-            size='xs'
-            value={viewMonth}
-            onValueChange={(v) => setViewMonth(Number(v))}
-            sx={{ flex: 1, minWidth: 0 }}
-          >
-            {months.map((idx) => (
-              <Select.Option
-                key={monthNames[idx]}
-                value={idx}
-              >
-                {compactEffective ? monthNames[idx].slice(0, 3) : monthNames[idx]}
-              </Select.Option>
-            ))}
-            {/* monthNames is locale-derived (Intl); compact still shows the
-                first three characters, matching the previous 3-letter form. */}
-          </Select>
-          <Select
-            size='xs'
-            value={viewYear}
-            onValueChange={(v) => {
-              const yr = Number(v);
-              let m = viewMonth;
-              if (yr === minYear && m < minMonth) m = minMonth;
-              if (yr === maxYear && m > maxMonth) m = maxMonth;
-              setViewYear(yr);
-              setViewMonth(m);
-            }}
-            sx={{ flex: 1, minWidth: 0 }}
-          >
-            {years.map((y) => (
-              <Select.Option
-                key={y}
-                value={y}
-              >
-                {y}
-              </Select.Option>
-            ))}
-          </Select>
-        </div>
-        <div style={{ display: 'flex', gap: theme.spacing(0.5) }}>
-          <IconButton
-            size={compactEffective ? 'xs' : 'sm'}
-            variant='outlined'
-            color='primaryText'
-            icon='mdi:chevron-right'
-            aria-label={t.nextMonth}
-            onClick={() => changeMonth(1)}
-            disabled={new Date(viewYear, viewMonth + 1, 1) > max}
-          />
-          {!compactEffective && (
-            <IconButton
-              size='sm'
-              variant='outlined'
-              color='primaryText'
-              icon='mdi:chevron-double-right'
-              aria-label={t.nextYear}
-              onClick={() => {
-                const yr = viewYear + 1;
-                let m = viewMonth;
                 if (yr === maxYear && m > maxMonth) m = maxMonth;
                 setViewYear(yr);
                 setViewMonth(m);
               }}
-              disabled={new Date(viewYear + 1, 0, 1) > max}
-            />
-          )}
-        </div>
-      </Header>
-      <Grid $compact={compactEffective}>
-        {weekdays.map((d, i) => (
-          <DayLabel
-            key={`${d}-${i}`}
-            $compact={compactEffective}
-          >
-            {compactEffective ? d[0] : d}
-          </DayLabel>
-        ))}
-        {Array.from({ length: startDay }).map((_, i) => (
-          <span key={`blank-${i}`} />
-        ))}
-        {Array.from({ length: daysInMonth }).map((_, i) => {
-          const day = i + 1;
-          const date = new Date(viewYear, viewMonth, day);
-          const disabled = date < min || date > max;
-          const startSel =
-            startDate.getFullYear() === viewYear &&
-            startDate.getMonth() === viewMonth &&
-            startDate.getDate() === day;
-          const endSel =
-            range &&
-            endDate.getFullYear() === viewYear &&
-            endDate.getMonth() === viewMonth &&
-            endDate.getDate() === day;
-          const inRange = range && date > startDate && date < endDate;
-          return (
-            <Cell
-              key={day}
-              $start={startSel}
-              $end={!!endSel && !startSel}
-              $inRange={!!inRange}
-              $primary={theme.colors.primary}
-              $secondary={theme.colors.secondary}
-              $rangeBg={rangeBg}
-              $hoverStart={hoverStart}
-              $hoverEnd={hoverEnd}
-              $hoverRange={hoverRange}
-              $hoverDefault={hoverDefault}
-              $selText={theme.colors.primaryText}
-              $endText={theme.colors.secondaryText}
-              $rangeText={theme.colors.primaryText}
-              $compact={!!compactEffective}
-              style={{ '--valet-date-cell-radius': theme.radius(1) } as React.CSSProperties}
-              onClick={() => !disabled && (range ? commitRange(day) : commit(day))}
-              disabled={disabled}
+              sx={{ flex: 1, minWidth: 0 }}
             >
-              {/* DISPLAY-only locale digits; the committed VALUE stays ISO
+              {years.map((y) => (
+                <Select.Option
+                  key={y}
+                  value={y}
+                >
+                  {y}
+                </Select.Option>
+              ))}
+            </Select>
+          </div>
+          <div style={{ display: 'flex', gap: theme.spacing(0.5) }}>
+            <IconButton
+              size={tight ? 'xs' : 'sm'}
+              variant='outlined'
+              color='primaryText'
+              icon='mdi:chevron-right'
+              aria-label={t.nextMonth}
+              onClick={() => changeMonth(1)}
+              disabled={new Date(viewYear, viewMonth + 1, 1) > max}
+            />
+            {!tight && (
+              <IconButton
+                size='sm'
+                variant='outlined'
+                color='primaryText'
+                icon='mdi:chevron-double-right'
+                aria-label={t.nextYear}
+                onClick={() => {
+                  const yr = viewYear + 1;
+                  let m = viewMonth;
+                  if (yr === maxYear && m > maxMonth) m = maxMonth;
+                  setViewYear(yr);
+                  setViewMonth(m);
+                }}
+                disabled={new Date(viewYear + 1, 0, 1) > max}
+              />
+            )}
+          </div>
+        </Header>
+        <Grid $compact={tight}>
+          {weekdays.map((d, i) => (
+            <DayLabel
+              key={`${d}-${i}`}
+              $compact={tight}
+            >
+              {tight ? d[0] : d}
+            </DayLabel>
+          ))}
+          {Array.from({ length: startDay }).map((_, i) => (
+            <span key={`blank-${i}`} />
+          ))}
+          {Array.from({ length: daysInMonth }).map((_, i) => {
+            const day = i + 1;
+            const date = new Date(viewYear, viewMonth, day);
+            const disabled = date < min || date > max;
+            const startSel =
+              startDate.getFullYear() === viewYear &&
+              startDate.getMonth() === viewMonth &&
+              startDate.getDate() === day;
+            const endSel =
+              range &&
+              endDate.getFullYear() === viewYear &&
+              endDate.getMonth() === viewMonth &&
+              endDate.getDate() === day;
+            const inRange = range && date > startDate && date < endDate;
+            return (
+              <Cell
+                key={day}
+                $start={startSel}
+                $end={!!endSel && !startSel}
+                $inRange={!!inRange}
+                $primary={theme.colors.primary}
+                $secondary={theme.colors.secondary}
+                $rangeBg={rangeBg}
+                $hoverStart={hoverStart}
+                $hoverEnd={hoverEnd}
+                $hoverRange={hoverRange}
+                $hoverDefault={hoverDefault}
+                $selText={theme.colors.primaryText}
+                $endText={theme.colors.secondaryText}
+                $rangeText={theme.colors.primaryText}
+                $compact={tight}
+                style={{ '--valet-date-cell-radius': theme.radius(1) } as React.CSSProperties}
+                onClick={() => !disabled && (range ? commitRange(day) : commit(day))}
+                disabled={disabled}
+              >
+                {/* DISPLAY-only locale digits; the committed VALUE stays ISO
                   Latin via formatLocalISO (veto register / ruling R7/R8). */}
-              {formatDayNumber(day, locale)}
-            </Cell>
-          );
-        })}
-      </Grid>
+                {formatDayNumber(day, locale)}
+              </Cell>
+            );
+          })}
+        </Grid>
+      </CompactCtx.Provider>
     </Wrapper>
   );
 };

--- a/src/components/fields/MetroSelect.tsx
+++ b/src/components/fields/MetroSelect.tsx
@@ -33,9 +33,10 @@ import { Typography } from '../primitives/Typography';
 import { useTheme } from '../../system/themeStore';
 import { preset } from '../../css/stylePresets';
 import { toHex, toRgb, mix } from '../../helpers/color';
-import type { FieldBaseProps, Presettable, Space, Sx } from '../../types';
+import type { FieldBaseProps, Presettable, Space, SpacingProps, Sx } from '../../types';
 import type { ChangeInfo, InputSource, OnValueChange, OnValueCommit } from '../../system/events';
 import { styled } from '../../css/createStyled';
+import { CompactCtx, useCompact } from '../../system/compactContext';
 import { valetError } from '../../system/devErrors';
 import { useFieldState } from '../../hooks/useControlledState';
 
@@ -65,7 +66,8 @@ export interface MetroSelectProps
       React.HTMLAttributes<HTMLDivElement>,
       'onChange' | 'value' | 'defaultValue' | 'style'
     >,
-    FieldBaseProps {
+    FieldBaseProps,
+    Pick<SpacingProps, 'compact'> {
   value?: Primitive | Primitive[];
   defaultValue?: Primitive | Primitive[];
   /** Inter-tile spacing as units or CSS length. */
@@ -279,6 +281,7 @@ export const MetroSelect: MetroSelectComponent = ({
   // aria-invalid below; `fullWidth` rendering is Phase 2 / Q10.
   error,
   fullWidth: _fullWidth,
+  compact,
   preset: p,
   className,
   sx,
@@ -286,6 +289,7 @@ export const MetroSelect: MetroSelectComponent = ({
   ...rest
 }) => {
   void _fullWidth;
+  const effectiveCompact = useCompact(compact);
   /**
    * Single resolution of value/control/form binding (ruling R9). Precedence is
    * prop > form > internal, latched at mount; an unseeded form key renders
@@ -465,7 +469,7 @@ export const MetroSelect: MetroSelectComponent = ({
       <Stack
         direction='row'
         wrap
-        compact
+        compact={effectiveCompact}
         gap={gap}
         data-valet-component='MetroSelect'
         data-disabled={disabled ? 'true' : 'false'}
@@ -529,16 +533,18 @@ export const MetroSelect: MetroSelectComponent = ({
         }}
         className={[presetCls, className].filter(Boolean).join(' ')}
       >
-        {rawOpts.map((el, i) =>
-          React.cloneElement(el, {
-            id: optIds[i],
-            role: 'option',
-            'aria-selected': isSel(el.props.value),
-            'aria-disabled': el.props.disabled || disabled || undefined,
-            'data-active': (showActive && i === active) || undefined,
-            onMouseEnter: () => setActive(i),
-          } as Partial<MetroOptionProps> & { id: string }),
-        )}
+        <CompactCtx.Provider value={effectiveCompact}>
+          {rawOpts.map((el, i) =>
+            React.cloneElement(el, {
+              id: optIds[i],
+              role: 'option',
+              'aria-selected': isSel(el.props.value),
+              'aria-disabled': el.props.disabled || disabled || undefined,
+              'data-active': (showActive && i === active) || undefined,
+              onMouseEnter: () => setActive(i),
+            } as Partial<MetroOptionProps> & { id: string }),
+          )}
+        </CompactCtx.Provider>
       </Stack>
       {helperText && (
         <div

--- a/src/components/layout/Accordion.tsx
+++ b/src/components/layout/Accordion.tsx
@@ -31,6 +31,7 @@ import { resolveDeprecatedProp } from '../../system/deprecate';
 import { shallow } from 'zustand/shallow';
 import type { Presettable, SpacingProps, Sx } from '../../types';
 import { resolveSpace } from '../../utils/resolveSpace';
+import { CompactCtx, useCompact } from '../../system/compactContext';
 import { Typography } from '../primitives/Typography';
 import { useControlledState } from '../../hooks/useControlledState';
 
@@ -269,7 +270,7 @@ export const Accordion: React.FC<AccordionProps> & {
   constrainHeight = true,
   unmountOnExit = false,
   pad: padProp,
-  compact = false,
+  compact,
   preset: p,
   className,
   sx,
@@ -277,6 +278,7 @@ export const Accordion: React.FC<AccordionProps> & {
   ...divProps
 }) => {
   const { theme } = useTheme();
+  const effCompact = useCompact(compact);
   const surface = useSurface(
     (s) => ({
       element: s.element,
@@ -508,21 +510,23 @@ export const Accordion: React.FC<AccordionProps> & {
             const mergedStyle = { ...(sx || {}), ...(styleProp as React.CSSProperties) };
             return { ...rest, style: mergedStyle } as typeof divProps;
           })()}
-          $pad={resolveSpace(padProp, theme, compact, 1)}
+          $pad={resolveSpace(padProp, theme, effCompact, 1)}
           className={[presetClasses, className].filter(Boolean).join(' ')}
           data-valet-component='Accordion'
         >
-          {React.Children.map(children, (child, idx) =>
-            React.isValidElement(child)
-              ? React.cloneElement(
-                  child as React.ReactElement<{ index?: number; unmountOnExit?: boolean }>,
-                  {
-                    index: idx,
-                    unmountOnExit,
-                  },
-                )
-              : child,
-          )}
+          <CompactCtx.Provider value={effCompact}>
+            {React.Children.map(children, (child, idx) =>
+              React.isValidElement(child)
+                ? React.cloneElement(
+                    child as React.ReactElement<{ index?: number; unmountOnExit?: boolean }>,
+                    {
+                      index: idx,
+                      unmountOnExit,
+                    },
+                  )
+                : child,
+            )}
+          </CompactCtx.Provider>
         </Root>
       </Wrapper>
     </AccordionCtx.Provider>

--- a/src/components/layout/Box.tsx
+++ b/src/components/layout/Box.tsx
@@ -9,6 +9,7 @@ import { useTheme } from '../../system/themeStore';
 import { preset } from '../../css/stylePresets';
 import type { Presettable, SpacingProps, Sx } from '../../types';
 import { resolveSpace } from '../../utils/resolveSpace';
+import { CompactCtx, useCompact } from '../../system/compactContext';
 import {
   createPolymorphicComponent,
   type PolymorphicProps,
@@ -87,11 +88,14 @@ const BoxImpl = <E extends React.ElementType = 'div'>(
     compact,
     pad: padProp,
     sx,
+    children,
     ...rest
   } = props as unknown as BoxOwnProps & { as?: E } & {
     style?: React.CSSProperties;
+    children?: React.ReactNode;
   } & Record<string, unknown>;
   const { theme } = useTheme();
+  const effectiveCompact = useCompact(compact);
   const presetClass = p ? preset(p) : '';
 
   let resolvedText = textColor;
@@ -106,7 +110,7 @@ const BoxImpl = <E extends React.ElementType = 'div'>(
             : undefined;
   }
 
-  const pad = resolveSpace(padProp, theme, compact, 1);
+  const pad = resolveSpace(padProp, theme, effectiveCompact, 1);
 
   const internalCenter = !!centerContent;
   const normalizedAlign: 'left' | 'right' | 'center' = (alignX ?? 'left') as
@@ -146,7 +150,9 @@ const BoxImpl = <E extends React.ElementType = 'div'>(
       $pad={pad}
       style={inlineStyle}
       className={[presetClass, className].filter(Boolean).join(' ')}
-    />
+    >
+      <CompactCtx.Provider value={effectiveCompact}>{children}</CompactCtx.Provider>
+    </Base>
   );
 };
 

--- a/src/components/layout/Grid.tsx
+++ b/src/components/layout/Grid.tsx
@@ -10,6 +10,7 @@ import { useSurface } from '../../system/surfaceStore';
 import { shallow } from 'zustand/shallow';
 import type { Presettable, SpacingProps, Space, Sx } from '../../types';
 import { resolveSpace } from '../../utils/resolveSpace';
+import { CompactCtx, useCompact } from '../../system/compactContext';
 
 /*───────────────────────────────────────────────────────────*/
 export interface GridProps
@@ -19,9 +20,9 @@ export interface GridProps
   columns?: number;
   /** Auto switch to 1 column in portrait */
   adaptive?: boolean;
-  /** Density override; alias: `compact` maps to `density='compact'` */
-  density?: 'compact' | 'standard' | 'comfortable';
-  /** Compact zeros both pad and gap (alias for density='compact') */
+  /** Density override; an independent spacing scale (never zeros) */
+  density?: 'tight' | 'standard' | 'comfortable';
+  /** Hard-zeros layout pad + gap and cascades to descendants (independent of density) */
   compact?: boolean;
   /**
    * Normalize child heights per row by stretching items to match
@@ -85,7 +86,8 @@ export const Grid: React.FC<GridProps> = ({
   columns = 2,
   gap: gapProp,
   pad: padProp,
-  compact = false,
+  compact,
+  density,
   adaptive = false,
   normalizeRowHeights = true,
   preset: p,
@@ -100,10 +102,20 @@ export const Grid: React.FC<GridProps> = ({
   const portrait = height > width;
   const effectiveCols = adaptive && portrait ? 1 : columns;
 
+  const effectiveCompact = useCompact(compact);
+
   // Standardize default gap to 1 for consistency with Stack/Tabs
-  const compactEffective = compact || rest.density === 'compact';
-  const g = resolveSpace(gapProp as Space, theme, compactEffective, 1);
-  const pad = resolveSpace(padProp, theme, compactEffective, 1);
+  const g = resolveSpace(gapProp as Space, theme, effectiveCompact, 1);
+  const pad = resolveSpace(padProp, theme, effectiveCompact, 1);
+
+  const densityScale =
+    density === 'comfortable'
+      ? 1.15
+      : density === 'tight'
+        ? 0.9
+        : density === 'standard'
+          ? 1.0
+          : undefined;
 
   const presetClass = p ? preset(p) : '';
 
@@ -115,10 +127,14 @@ export const Grid: React.FC<GridProps> = ({
       $gap={g}
       $pad={pad}
       $normalize={Boolean(normalizeRowHeights)}
-      style={sx}
+      style={
+        densityScale != null
+          ? { ...sx, '--valet-space': `calc(${theme.spacingUnit} * ${densityScale})` }
+          : sx
+      }
       className={[presetClass, className].filter(Boolean).join(' ')}
     >
-      {children}
+      <CompactCtx.Provider value={effectiveCompact}>{children}</CompactCtx.Provider>
     </Root>
   );
 };

--- a/src/components/layout/Modal.tsx
+++ b/src/components/layout/Modal.tsx
@@ -14,6 +14,7 @@ import { preset } from '../../css/stylePresets';
 import { getOverlayRoot, useOverlay } from '../../system/overlay';
 import { inheritSurfaceFontVars } from '../../system/inheritSurfaceFontVars';
 import { zVar } from '../../system/zIndex';
+import { CompactCtx, useCompact } from '../../system/compactContext';
 import type { Presettable, Space, Sx } from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
@@ -155,7 +156,7 @@ export const Modal: React.FC<ModalProps> = ({
   children,
   actions,
   pad: padProp,
-  compact = false,
+  compact,
   disableBackdropClick = false,
   disableEscapeKeyDown = false,
   maxWidth,
@@ -167,6 +168,8 @@ export const Modal: React.FC<ModalProps> = ({
 }) => {
   const { theme } = useTheme();
   const presetClasses = presetKey ? preset(presetKey) : '';
+  // Inherited compact also zeros the sections; own `compact` prop still wins.
+  const compactEff = useCompact(compact);
 
   /* ----- state ---------------------------------------------------------- */
   const uncontrolled = controlledOpen === undefined;
@@ -276,7 +279,7 @@ export const Modal: React.FC<ModalProps> = ({
         $maxW={maxWidth}
         $full={fullWidth}
         $pad={
-          compact
+          compactEff
             ? '0'
             : typeof padProp === 'number'
               ? theme.spacing(padProp)
@@ -293,32 +296,34 @@ export const Modal: React.FC<ModalProps> = ({
           } as Sx
         }
       >
-        {title && (
-          <Header
-            id={idTitle}
-            $pt={compact ? '0' : theme.spacing(2)}
-            $px={compact ? '0' : theme.spacing(3)}
-            $pb={compact ? '0' : theme.spacing(2)}
+        <CompactCtx.Provider value={compactEff}>
+          {title && (
+            <Header
+              id={idTitle}
+              $pt={compactEff ? '0' : theme.spacing(2)}
+              $px={compactEff ? '0' : theme.spacing(3)}
+              $pb={compactEff ? '0' : theme.spacing(2)}
+            >
+              {title}
+            </Header>
+          )}
+          <Content
+            $px={compactEff ? '0' : theme.spacing(3)}
+            $pb={compactEff ? '0' : theme.spacing(3)}
           >
-            {title}
-          </Header>
-        )}
-        <Content
-          $px={compact ? '0' : theme.spacing(3)}
-          $pb={compact ? '0' : theme.spacing(3)}
-        >
-          {children}
-        </Content>
-        {actions && (
-          <Actions
-            $pt={compact ? '0' : theme.spacing(2)}
-            $px={compact ? '0' : theme.spacing(3)}
-            $pb={compact ? '0' : theme.spacing(3)}
-            $gap={compact ? '0' : theme.spacing(1)}
-          >
-            {actions}
-          </Actions>
-        )}
+            {children}
+          </Content>
+          {actions && (
+            <Actions
+              $pt={compactEff ? '0' : theme.spacing(2)}
+              $px={compactEff ? '0' : theme.spacing(3)}
+              $pb={compactEff ? '0' : theme.spacing(3)}
+              $gap={compactEff ? '0' : theme.spacing(1)}
+            >
+              {actions}
+            </Actions>
+          )}
+        </CompactCtx.Provider>
       </Box>
     </>
   );

--- a/src/components/layout/Panel.tsx
+++ b/src/components/layout/Panel.tsx
@@ -15,6 +15,7 @@ import { toRgb, mix, toHex } from '../../helpers/color';
 import type { Intent, Presettable, SpacingProps, Sx } from '../../types';
 import { resolveSpace } from '../../utils/resolveSpace';
 import { resolveDeprecatedProp } from '../../system/deprecate';
+import { CompactCtx, useCompact } from '../../system/compactContext';
 
 export type PanelVariant = 'filled' | 'outlined';
 
@@ -148,6 +149,7 @@ export const Panel: React.FC<PanelProps> = ({
   color,
   intent,
   compact,
+  density,
   pad: padProp,
   children,
   ...rest
@@ -197,9 +199,19 @@ export const Panel: React.FC<PanelProps> = ({
     else textColour = theme.colors.text;
   }
 
-  const compactEffective =
-    compact || (rest as unknown as { density?: string }).density === 'compact';
+  const compactEffective = useCompact(compact);
   const pad = resolveSpace(padProp, theme, compactEffective, 1);
+
+  // V1: when density is explicitly provided, scale the subtree (and the
+  // panel's own pad/gap) via the local --valet-space var.
+  const densityScale =
+    density === 'comfortable'
+      ? 1.15
+      : density === 'tight'
+        ? 0.9
+        : density === 'standard'
+          ? 1.0
+          : undefined;
   const presetClasses = p ? preset(p) : '';
 
   // Normalize alignX with Box semantics
@@ -224,6 +236,9 @@ export const Panel: React.FC<PanelProps> = ({
       $noNormalize={!normalizeRowHeights}
       style={
         {
+          ...(densityScale != null
+            ? { '--valet-space': `calc(${theme.spacingUnit} * ${densityScale})` }
+            : {}),
           '--valet-intent-bg': bg ?? 'transparent',
           '--valet-intent-fg': textColour ?? theme.colors.text,
           '--valet-intent-border': borderColor ?? theme.colors.divider,
@@ -242,7 +257,7 @@ export const Panel: React.FC<PanelProps> = ({
       }
       className={[presetClasses, className].filter(Boolean).join(' ')}
     >
-      {children}
+      <CompactCtx.Provider value={compactEffective}>{children}</CompactCtx.Provider>
     </Base>
   );
 };

--- a/src/components/layout/Stack.tsx
+++ b/src/components/layout/Stack.tsx
@@ -11,6 +11,7 @@ import { useTheme } from '../../system/themeStore';
 import { preset } from '../../css/stylePresets';
 import type { Presettable, SpacingProps, Sx } from '../../types';
 import { resolveSpace } from '../../utils/resolveSpace';
+import { CompactCtx, useCompact } from '../../system/compactContext';
 
 /*───────────────────────────────────────────────────────────*/
 export interface StackProps
@@ -90,14 +91,26 @@ export const Stack: React.FC<StackProps> = ({
 }) => {
   const { theme } = useTheme();
 
-  const compactEffective = compact || density === 'compact';
-  const gap = resolveSpace(gapProp, theme, compactEffective, 1);
+  const effectiveCompact = useCompact(compact);
+  const gap = resolveSpace(gapProp, theme, effectiveCompact, 1);
 
   /* Enable wrapping by default for rows */
   const shouldWrap = typeof wrap === 'boolean' ? wrap : direction === 'row';
 
   const presetClasses = p ? preset(p) : '';
-  const pad = resolveSpace(padProp, theme, compactEffective, 1);
+  const pad = resolveSpace(padProp, theme, effectiveCompact, 1);
+
+  /* V1: density scales the subtree via --valet-space */
+  const densityScale =
+    density === 'comfortable'
+      ? 1.15
+      : density === 'tight'
+        ? 0.9
+        : density === 'standard'
+          ? 1.0
+          : undefined;
+  const spaceVar =
+    densityScale != null ? `calc(${theme.spacingUnit} * ${densityScale})` : undefined;
 
   return (
     <StackContainer
@@ -109,9 +122,9 @@ export const Stack: React.FC<StackProps> = ({
       $pad={pad}
       $alignX={alignX}
       className={[presetClasses, className].filter(Boolean).join(' ')}
-      style={sx}
+      style={spaceVar ? { ...sx, '--valet-space': spaceVar } : sx}
     >
-      {children}
+      <CompactCtx.Provider value={effectiveCompact}>{children}</CompactCtx.Provider>
     </StackContainer>
   );
 };

--- a/src/components/layout/Surface.meta.json
+++ b/src/components/layout/Surface.meta.json
@@ -10,7 +10,7 @@
       "Opt into per-element metrics with $trackSize. styled() elements register with the surface store and expose --valet-el-width and --valet-el-height (updated via ResizeObserver) only when passed the $trackSize transient prop. Tracking is off by default — most elements never need their own metrics, so the default path stays allocation-free.",
       "Keep portalled overlays out of the registry. Drawers and Modals rendered outside the surface root are intentionally not tracked to avoid unnecessary observers. Size them via tokens and breakpoints, not child metrics.",
       "Respect height constraints. Tables are height‑aware by default; let their content scroll inside the component. Only pass constrainHeight={false} when page context requires full‑document scroll.",
-      "Drive spacing and density with variables. Adjust --valet-space, --valet-radius, and --valet-stroke on the surface to shift an entire view without changing component code.",
+      "Drive spacing and density with variables. Set `density` ('tight' 0.9× | 'standard' 1× | 'comfortable' 1.15×) on the Surface to scale spacing for the whole screen (it sets --valet-space); set it on any layout container to scale just that subtree. Use the `compact` boolean to hard-zero a region's layout spacing — it cascades to descendants and `compact={false}` opts a subtree back out. Adjust --valet-space/--valet-radius/--valet-stroke directly for finer control.",
       "blockUntilFonts is fail-safe. It hides content until web fonts settle, but a 500ms never-block grace reveals the screen anyway if no font load ever starts, so a missing or skipped font pipeline can never wedge the UI hidden forever."
     ]
   }

--- a/src/components/layout/Surface.tsx
+++ b/src/components/layout/Surface.tsx
@@ -17,6 +17,7 @@ import { preset } from '../../css/stylePresets';
 import { valetError } from '../../system/devErrors';
 import { useValetLocale } from '../../system/locale';
 import type { Presettable, Sx } from '../../types';
+import { CompactCtx, useCompact } from '../../system/compactContext';
 
 /* Allow strongly-typed CSS custom properties (e.g. --valet-*) */
 type CSSVarName = `--${string}`;
@@ -30,7 +31,10 @@ export interface SurfaceProps
   fullscreen?: boolean;
   /** Optional density override for spacing scale */
   density?: Density;
-  /** Alias: when true, maps to density='compact' (no override when false). */
+  /**
+   * Zeros all layout spacing and cascades to descendants; opt out with
+   * compact={false}. Independent of the density scale.
+   */
   compact?: boolean;
   /**
    * When true, block content visibility until fonts load (FOIT).
@@ -240,11 +244,14 @@ export const Surface: React.FC<SurfaceProps> = ({
 
   const gap = theme.spacing(1);
 
+  /* compact cascade seed (independent of density) ---------------------- */
+  const effectiveCompact = useCompact(compactAlias);
+
   /* Density → --valet-space ------------------------------------------- */
-  // Public density tokens: 'compact' | 'standard' | 'comfortable'.
-  // Alias: compact?: true ⇒ density='compact'.
-  const effectiveDensity: Density =
-    (density as Density | undefined) ?? (compactAlias ? 'compact' : globalDensity);
+  // Public density tokens: 'tight' | 'standard' | 'comfortable'.
+  const effectiveDensity: Density = (density as Density | undefined) ?? globalDensity;
+  // 'tight' is the 0.9 branch; --valet-space is the density SCALE and is never
+  // zeroed by compact (compact zeros layout spacing via effectiveCompact only).
   const scale =
     effectiveDensity === 'comfortable' ? 1.15 : effectiveDensity === 'standard' ? 1.0 : 0.9;
   const spaceVar = `calc(${theme.spacingUnit} * ${scale})`;
@@ -286,17 +293,19 @@ export const Surface: React.FC<SurfaceProps> = ({
         {/* Inner wrapper gains padding but NO scrollbars. `blocking` (not raw
             blockUntilFonts) drives visibility so the never-started grace can
             reveal content even when fonts never load. */}
-        <div
-          style={{
-            visibility: blocking ? 'hidden' : 'visible',
-            padding: gap,
-            maxWidth: '100%',
-            maxHeight: '100%',
-            boxSizing: 'border-box',
-          }}
-        >
-          {children}
-        </div>
+        <CompactCtx.Provider value={effectiveCompact}>
+          <div
+            style={{
+              visibility: blocking ? 'hidden' : 'visible',
+              padding: effectiveCompact ? '0' : gap,
+              maxWidth: '100%',
+              maxHeight: '100%',
+              boxSizing: 'border-box',
+            }}
+          >
+            {children}
+          </div>
+        </CompactCtx.Provider>
       </div>
     </SurfaceCtx.Provider>
   );

--- a/src/components/layout/Tabs.tsx
+++ b/src/components/layout/Tabs.tsx
@@ -30,6 +30,7 @@ import { resolveSpace } from '../../utils/resolveSpace';
 import { withAlpha } from '../../helpers/color';
 import { valetError } from '../../system/devErrors';
 import { useControlledState } from '../../hooks/useControlledState';
+import { CompactCtx, useCompact } from '../../system/compactContext';
 
 /*───────────────────────────────────────────────────────────*/
 /* Context                                                   */
@@ -333,7 +334,8 @@ const TabsBase = forwardRef<HTMLDivElement, TabsProps>(
       tabAlign,
       gap: gapProp,
       pad: padProp,
-      compact = false,
+      compact,
+      density,
       preset: p,
       className,
       children,
@@ -463,10 +465,20 @@ const TabsBase = forwardRef<HTMLDivElement, TabsProps>(
     );
 
     const cls = [p ? preset(p) : '', className].filter(Boolean).join(' ');
-    const compactEffective =
-      compact || (divProps as unknown as { density?: string }).density === 'compact';
-    const gap = resolveSpace(gapProp, theme, compactEffective, 1);
-    const pad = resolveSpace(padProp, theme, compactEffective, 1);
+    const effectiveCompact = useCompact(compact);
+    const gap = resolveSpace(gapProp, theme, effectiveCompact, 1);
+    const pad = resolveSpace(padProp, theme, effectiveCompact, 1);
+    /* V1 density-scales-the-subtree: when density is explicitly provided,
+       set --valet-space locally so the strip/panel (and descendants)
+       scale. density never zeroes — that is compact's job. */
+    const densityScale =
+      density === 'comfortable'
+        ? 1.15
+        : density === 'tight'
+          ? 0.9
+          : density === 'standard'
+            ? 1.0
+            : undefined;
     const stripFirst =
       (orientation === 'horizontal' && placement === 'top') ||
       (orientation === 'vertical' && placement === 'left');
@@ -625,7 +637,11 @@ const TabsBase = forwardRef<HTMLDivElement, TabsProps>(
           $gap={gap}
           $pad={pad}
           className={cls}
-          style={sx}
+          style={
+            densityScale != null
+              ? { ...sx, '--valet-space': `calc(${theme.spacingUnit} * ${densityScale})` }
+              : sx
+          }
           onFocus={(e) => {
             // Only redirect focus when the root itself receives focus.
             // Do NOT hijack focus when a child within the tabs (e.g., inputs, buttons)
@@ -643,63 +659,65 @@ const TabsBase = forwardRef<HTMLDivElement, TabsProps>(
             }
           }}
         >
-          {stripFirst && (
-            <TabStripWrap
-              $fadeLeft={fadeL}
-              $fadeRight={fadeR}
-              $fadeCol={theme.colors.primary}
-              $dur={theme.motion.duration.xlong}
-              $ease={theme.motion.easing.emphasized}
-              $slide={theme.spacing(2)}
-            >
-              <TabList
-                ref={listRef}
-                role='tablist'
-                aria-orientation={orientation}
-                $orientation={orientation}
-                $place={placement}
-                $edgeGap={edgeGap}
-                $align={(tabAlign ?? alignX ?? 'left') as 'left' | 'right' | 'center'}
+          <CompactCtx.Provider value={effectiveCompact}>
+            {stripFirst && (
+              <TabStripWrap
                 $fadeLeft={fadeL}
                 $fadeRight={fadeR}
                 $fadeCol={theme.colors.primary}
-                $overflow={overflowing}
+                $dur={theme.motion.duration.xlong}
+                $ease={theme.motion.easing.emphasized}
+                $slide={theme.spacing(2)}
               >
-                {tabs}
-              </TabList>
-              {/* Custom scroll hint removed */}
-            </TabStripWrap>
-          )}
+                <TabList
+                  ref={listRef}
+                  role='tablist'
+                  aria-orientation={orientation}
+                  $orientation={orientation}
+                  $place={placement}
+                  $edgeGap={edgeGap}
+                  $align={(tabAlign ?? alignX ?? 'left') as 'left' | 'right' | 'center'}
+                  $fadeLeft={fadeL}
+                  $fadeRight={fadeR}
+                  $fadeCol={theme.colors.primary}
+                  $overflow={overflowing}
+                >
+                  {tabs}
+                </TabList>
+                {/* Custom scroll hint removed */}
+              </TabStripWrap>
+            )}
 
-          <Panel>{panels}</Panel>
+            <Panel>{panels}</Panel>
 
-          {!stripFirst && (
-            <TabStripWrap
-              $fadeLeft={fadeL}
-              $fadeRight={fadeR}
-              $fadeCol={theme.colors.primary}
-              $dur={theme.motion.duration.xlong}
-              $ease={theme.motion.easing.emphasized}
-              $slide={theme.spacing(2)}
-            >
-              <TabList
-                ref={listRef}
-                role='tablist'
-                aria-orientation={orientation}
-                $orientation={orientation}
-                $place={placement}
-                $edgeGap={edgeGap}
-                $align={(tabAlign ?? alignX ?? 'left') as 'left' | 'right' | 'center'}
+            {!stripFirst && (
+              <TabStripWrap
                 $fadeLeft={fadeL}
                 $fadeRight={fadeR}
                 $fadeCol={theme.colors.primary}
-                $overflow={overflowing}
+                $dur={theme.motion.duration.xlong}
+                $ease={theme.motion.easing.emphasized}
+                $slide={theme.spacing(2)}
               >
-                {tabs}
-              </TabList>
-              {/* Custom scroll hint removed */}
-            </TabStripWrap>
-          )}
+                <TabList
+                  ref={listRef}
+                  role='tablist'
+                  aria-orientation={orientation}
+                  $orientation={orientation}
+                  $place={placement}
+                  $edgeGap={edgeGap}
+                  $align={(tabAlign ?? alignX ?? 'left') as 'left' | 'right' | 'center'}
+                  $fadeLeft={fadeL}
+                  $fadeRight={fadeR}
+                  $fadeCol={theme.colors.primary}
+                  $overflow={overflowing}
+                >
+                  {tabs}
+                </TabList>
+                {/* Custom scroll hint removed */}
+              </TabStripWrap>
+            )}
+          </CompactCtx.Provider>
         </Root>
       </TabsCtx.Provider>
     );

--- a/src/components/primitives/Divider.tsx
+++ b/src/components/primitives/Divider.tsx
@@ -8,6 +8,7 @@ import { useTheme } from '../../system/themeStore';
 import { preset } from '../../css/stylePresets';
 import type { Presettable, SpacingProps, Space, Sx } from '../../types';
 import { resolveSpace } from '../../utils/resolveSpace';
+import { useCompact } from '../../system/compactContext';
 
 export type DividerOrientation = 'horizontal' | 'vertical';
 
@@ -67,6 +68,7 @@ export const Divider: React.FC<DividerProps> = ({
   ...rest
 }) => {
   const { theme } = useTheme();
+  const effectiveCompact = useCompact(compact);
 
   // Default color uses divider token via CSS var, with a theme fallback.
   const color =
@@ -83,7 +85,7 @@ export const Divider: React.FC<DividerProps> = ({
   const len =
     length === undefined ? undefined : typeof length === 'number' ? `${length}px` : String(length);
 
-  const pad = resolveSpace(padProp as Space | undefined, theme, compact, 0);
+  const pad = resolveSpace(padProp as Space | undefined, theme, effectiveCompact, 0);
   const presetClass = p ? preset(p) : '';
 
   return (

--- a/src/components/widgets/LLMChat.tsx
+++ b/src/components/widgets/LLMChat.tsx
@@ -38,7 +38,8 @@ import Select from '../fields/Select';
 import { useAIKey, AIProvider } from '../../system/aiKeyStore';
 import { useComponentStrings } from '../../system/locale';
 import type { DeepPartialStrings, ValetStrings } from '../../system/locale';
-import type { Presettable, Sx } from '../../types';
+import type { Presettable, Sx, SpacingProps } from '../../types';
+import { CompactCtx, useCompact } from '../../system/compactContext';
 
 /**
  * Built-in model catalog for the picker, keyed by provider. This is a
@@ -65,6 +66,7 @@ export interface ChatMessage {
 
 export interface ChatProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSubmit' | 'style'>,
+    Pick<SpacingProps, 'compact'>,
     Presettable {
   messages: ChatMessage[];
   onSend?: (message: ChatMessage) => void;
@@ -189,10 +191,12 @@ export const LLMChat: React.FC<ChatProps> = ({
   preset: p,
   className,
   labels,
+  compact: compactProp,
   sx,
   ...rest
 }) => {
   const { theme } = useTheme();
+  const compact = useCompact(compactProp);
   const t = useComponentStrings('llmChat', labels);
   const surface = useSurface(
     (s) => ({
@@ -336,161 +340,165 @@ export const LLMChat: React.FC<ChatProps> = ({
         sx={sx}
         className={cls}
       >
-        <Bar
-          $bg={theme.colors.secondary}
-          $text={theme.colors.secondaryText}
-          $gap={theme.spacing(0.5)}
-          $pad={`${theme.spacing(1)} ${theme.spacing(2)}`}
-        >
-          {provider && key ? (
-            <Select
-              size='sm'
-              value={model}
-              onValueChange={(v) => handleModelChange(v as string)}
-            >
-              {modelOptions.map((m) => (
-                <Select.Option
-                  key={m}
-                  value={m}
-                >
-                  {m}
-                </Select.Option>
-              ))}
-            </Select>
-          ) : (
-            <span />
-          )}
-          <span
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              cursor: 'pointer',
-              gap: theme.spacing(0.5),
-            }}
-            onClick={() => !propKey && setShowKeyModal(true)}
+        <CompactCtx.Provider value={compact}>
+          <Bar
+            $bg={theme.colors.secondary}
+            $text={theme.colors.secondaryText}
+            $gap={theme.spacing(0.5)}
+            $pad={`${theme.spacing(1)} ${theme.spacing(2)}`}
           >
-            <Typography variant='subtitle'>{key ? 'Connected' : 'Disconnected'}</Typography>
-            <IconButton
-              icon={key ? 'carbon:checkmark' : 'carbon:circle-dash'}
-              aria-label={t.setApiKey}
-            />
-          </span>
-        </Bar>
-        <Wrapper
-          ref={wrapRef}
-          $gap={theme.spacing(3)}
-          style={{ overflow: 'hidden' }}
-        >
-          <Messages
-            role='log'
-            aria-relevant='additions'
-            aria-busy={isTyping}
-            $gap={theme.spacing(1.5)}
-            style={shouldConstrain ? { overflowY: 'auto', maxHeight } : undefined}
-          >
-            {messages
-              .filter((m) => m.role !== 'system')
-              .map((m, i) => {
-                const sidePad = portrait ? theme.spacing(8) : theme.spacing(24);
-                const avatarPad = theme.spacing(1);
-                return (
-                  <Row
-                    key={i}
-                    $from={m.role}
-                    $left={m.role === 'user' ? sidePad : avatarPad}
-                    $right={m.role === 'user' ? avatarPad : sidePad}
-                  >
-                    {m.role !== 'user' && systemAvatar && (
-                      <Avatar
-                        src={systemAvatar}
-                        size='sm'
-                        variant='outline'
-                        sx={{ marginRight: theme.spacing(1) }}
-                      />
-                    )}
-                    <Panel
-                      compact
-                      variant='filled'
-                      color={m.role === 'user' ? theme.colors.primary : undefined}
-                      sx={{
-                        maxWidth: '100%',
-                        width: 'fit-content',
-                        borderRadius: theme.spacing(0.5),
-                        animation: m.animate ? `${fadeIn} 0.2s ease-out` : undefined,
-                      }}
-                    >
-                      {m.name && (
-                        <Typography
-                          variant='subtitle'
-                          bold
-                        >
-                          {m.name}
-                        </Typography>
-                      )}
-                      {m.typing ? (
-                        <Typing
-                          $color={m.role === 'user' ? theme.colors.primaryText : theme.colors.text}
-                        >
-                          <span />
-                          <span />
-                          <span />
-                        </Typing>
-                      ) : m.role === 'assistant' ? (
-                        <Markdown
-                          data={m.content}
-                          codeBackground={theme.colors.background}
-                        />
-                      ) : (
-                        <Typography>{m.content}</Typography>
-                      )}
-                    </Panel>
-                    {m.role === 'user' && userAvatar && (
-                      <Avatar
-                        src={userAvatar}
-                        size='sm'
-                        variant='outline'
-                        sx={{ marginLeft: theme.spacing(1) }}
-                      />
-                    )}
-                  </Row>
-                );
-              })}
-          </Messages>
-
-          {!disableInput && (
-            <form
-              onSubmit={handleSubmit}
-              style={{ width: '100%' }}
-            >
-              <Stack
-                direction='row'
-                compact
+            {provider && key ? (
+              <Select
+                size='sm'
+                value={model}
+                onValueChange={(v) => handleModelChange(v as string)}
               >
-                <TextField
-                  as='textarea'
-                  name='chat-message'
-                  value={text}
-                  onChange={(e) => setText(e.target.value)}
-                  onKeyDown={(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-                    if (e.key === 'Enter' && !e.shiftKey) {
-                      e.preventDefault();
-                      const form = e.currentTarget.form;
-                      form?.requestSubmit();
-                    }
-                  }}
-                  rows={1}
-                  placeholder={placeholder}
-                  fullWidth
-                />
-                <IconButton
-                  icon='carbon:send'
-                  type='submit'
-                  aria-label={t.send}
-                />
-              </Stack>
-            </form>
-          )}
-        </Wrapper>
+                {modelOptions.map((m) => (
+                  <Select.Option
+                    key={m}
+                    value={m}
+                  >
+                    {m}
+                  </Select.Option>
+                ))}
+              </Select>
+            ) : (
+              <span />
+            )}
+            <span
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                cursor: 'pointer',
+                gap: theme.spacing(0.5),
+              }}
+              onClick={() => !propKey && setShowKeyModal(true)}
+            >
+              <Typography variant='subtitle'>{key ? 'Connected' : 'Disconnected'}</Typography>
+              <IconButton
+                icon={key ? 'carbon:checkmark' : 'carbon:circle-dash'}
+                aria-label={t.setApiKey}
+              />
+            </span>
+          </Bar>
+          <Wrapper
+            ref={wrapRef}
+            $gap={theme.spacing(3)}
+            style={{ overflow: 'hidden' }}
+          >
+            <Messages
+              role='log'
+              aria-relevant='additions'
+              aria-busy={isTyping}
+              $gap={theme.spacing(1.5)}
+              style={shouldConstrain ? { overflowY: 'auto', maxHeight } : undefined}
+            >
+              {messages
+                .filter((m) => m.role !== 'system')
+                .map((m, i) => {
+                  const sidePad = portrait ? theme.spacing(8) : theme.spacing(24);
+                  const avatarPad = theme.spacing(1);
+                  return (
+                    <Row
+                      key={i}
+                      $from={m.role}
+                      $left={m.role === 'user' ? sidePad : avatarPad}
+                      $right={m.role === 'user' ? avatarPad : sidePad}
+                    >
+                      {m.role !== 'user' && systemAvatar && (
+                        <Avatar
+                          src={systemAvatar}
+                          size='sm'
+                          variant='outline'
+                          sx={{ marginRight: theme.spacing(1) }}
+                        />
+                      )}
+                      <Panel
+                        compact
+                        variant='filled'
+                        color={m.role === 'user' ? theme.colors.primary : undefined}
+                        sx={{
+                          maxWidth: '100%',
+                          width: 'fit-content',
+                          borderRadius: theme.spacing(0.5),
+                          animation: m.animate ? `${fadeIn} 0.2s ease-out` : undefined,
+                        }}
+                      >
+                        {m.name && (
+                          <Typography
+                            variant='subtitle'
+                            bold
+                          >
+                            {m.name}
+                          </Typography>
+                        )}
+                        {m.typing ? (
+                          <Typing
+                            $color={
+                              m.role === 'user' ? theme.colors.primaryText : theme.colors.text
+                            }
+                          >
+                            <span />
+                            <span />
+                            <span />
+                          </Typing>
+                        ) : m.role === 'assistant' ? (
+                          <Markdown
+                            data={m.content}
+                            codeBackground={theme.colors.background}
+                          />
+                        ) : (
+                          <Typography>{m.content}</Typography>
+                        )}
+                      </Panel>
+                      {m.role === 'user' && userAvatar && (
+                        <Avatar
+                          src={userAvatar}
+                          size='sm'
+                          variant='outline'
+                          sx={{ marginLeft: theme.spacing(1) }}
+                        />
+                      )}
+                    </Row>
+                  );
+                })}
+            </Messages>
+
+            {!disableInput && (
+              <form
+                onSubmit={handleSubmit}
+                style={{ width: '100%' }}
+              >
+                <Stack
+                  direction='row'
+                  compact
+                >
+                  <TextField
+                    as='textarea'
+                    name='chat-message'
+                    value={text}
+                    onChange={(e) => setText(e.target.value)}
+                    onKeyDown={(e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+                      if (e.key === 'Enter' && !e.shiftKey) {
+                        e.preventDefault();
+                        const form = e.currentTarget.form;
+                        form?.requestSubmit();
+                      }
+                    }}
+                    rows={1}
+                    placeholder={placeholder}
+                    fullWidth
+                  />
+                  <IconButton
+                    icon='carbon:send'
+                    type='submit'
+                    aria-label={t.send}
+                  />
+                </Stack>
+              </form>
+            )}
+          </Wrapper>
+        </CompactCtx.Provider>
       </Panel>
     </>
   );

--- a/src/components/widgets/RichChat.tsx
+++ b/src/components/widgets/RichChat.tsx
@@ -16,8 +16,9 @@ import Typography from '../primitives/Typography';
 import Markdown from './Markdown';
 import Avatar from '../primitives/Avatar';
 import { useComponentStrings } from '../../system/locale';
+import { CompactCtx, useCompact } from '../../system/compactContext';
 import type { DeepPartialStrings, ValetStrings } from '../../system/locale';
-import type { Presettable, Sx } from '../../types';
+import type { Presettable, Sx, SpacingProps } from '../../types';
 
 /*───────────────────────────────────────────────────────────*/
 /* Types                                                      */
@@ -33,6 +34,7 @@ export interface RichMessage {
 
 export interface RichChatProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'onSubmit' | 'style'>,
+    Pick<SpacingProps, 'compact'>,
     Presettable {
   messages: RichMessage[];
   /** Called when a form message collects a response; `index` is the
@@ -262,11 +264,13 @@ export const RichChat: React.FC<RichChatProps> = ({
   preset: p,
   className,
   labels,
+  compact: compactProp,
   sx,
   ...rest
 }) => {
   const { theme } = useTheme();
   const t = useComponentStrings('richChat', labels);
+  const effectiveCompact = useCompact(compactProp);
   const surface = useSurface(
     (s) => ({
       element: s.element,
@@ -432,161 +436,162 @@ export const RichChat: React.FC<RichChatProps> = ({
       fullWidth
       variant='outlined'
       /* Trim outer chrome to pull avatars/icons toward edges */
-      compact={portrait}
-      pad={'0 0 1rem 0'}
+      pad={portrait ? '0' : '0 0 1rem 0'}
       sx={{ overflowY: 'visible', overflowX: 'hidden', ...sx }}
       className={cls}
     >
-      <Wrapper
-        ref={wrapRef}
-        $gap={theme.spacing(3)}
-        style={{ overflow: 'hidden' }}
-      >
-        <Messages
-          ref={messagesRef}
-          role='log'
-          aria-relevant='additions'
-          aria-busy={isTyping}
-          $gap={theme.spacing(1.25)}
-          /* Tighter side padding to bring avatars closer to edge */
-          $pad={portrait ? theme.spacing(0.25) : theme.spacing(0.5)}
-          $dur={theme.motion.duration.short}
-          $ease={theme.motion.easing.standard}
-          style={{
-            overflowY: 'auto',
-            maxHeight,
-            scrollbarGutter: 'stable',
-            touchAction: 'auto',
-          }}
+      <CompactCtx.Provider value={effectiveCompact}>
+        <Wrapper
+          ref={wrapRef}
+          $gap={theme.spacing(3)}
+          style={{ overflow: 'hidden' }}
         >
-          {messages
-            /* Pair each message with its index in the caller's array BEFORE
-               filtering — onFormSubmit must report the original index. */
-            .map((m, i) => ({ m, i }))
-            .filter(({ m }) => m.role !== 'system')
-            .map(({ m, i }) => {
-              /* Near-edge gutter (towards container edge) kept tiny; far edge roomy */
-              const near = theme.spacing(0.25);
-              const far = portrait ? theme.spacing(0.5) : theme.spacing(0.75);
-              const laneGap = portrait ? theme.spacing(0.5) : theme.spacing(0.75);
-              const content =
-                typeof m.content === 'string' ? (
-                  m.role === 'assistant' ? (
-                    <Markdown
-                      data={m.content}
-                      codeBackground={theme.colors.background}
-                    />
-                  ) : (
-                    <Typography>{m.content}</Typography>
-                  )
-                ) : (
-                  m.content
-                );
-              const Form = m.form;
-              return (
-                <Row
-                  key={i}
-                  $from={m.role}
-                  $gap={laneGap}
-                  $padL={m.role !== 'user' ? near : far}
-                  $padR={m.role === 'user' ? near : far}
-                  $dur={theme.motion.duration.short}
-                  $ease={theme.motion.easing.standard}
-                >
-                  {/* Measure content height to decide vertical alignment */}
-                  {m.role !== 'user' && systemAvatar && (
-                    <MeasuredAvatar
-                      src={systemAvatar}
-                      size='sm'
-                      variant='outline'
-                    />
-                  )}
-                  <MeasuredBubble
-                    variant='filled'
-                    color={m.role === 'user' ? theme.colors.primary : undefined}
-                    alignX={m.role === 'user' ? 'right' : 'left'}
-                    sx={{
-                      /* Readable max width and clean right/left alignment */
-                      maxWidth: portrait ? '100%' : 'min(75%, 48rem)',
-                      width: 'fit-content',
-                      borderRadius: theme.spacing(1),
-                      /* Slightly reduce top/bottom padding while keeping sides the same */
-                      padding: `${portrait ? theme.spacing(1) : theme.spacing(1.75)} ${
-                        portrait ? theme.spacing(1.25) : theme.spacing(2)
-                      }`,
-                      animation: m.animate ? `${fadeIn} 0.2s ease-out` : undefined,
-                      position: 'relative',
-                      justifySelf: m.role === 'user' ? 'end' : 'start',
-                    }}
-                  >
-                    {m.name && (
-                      <Typography
-                        variant='subtitle'
-                        bold
-                      >
-                        {m.name}
-                      </Typography>
-                    )}
-                    {m.typing ? (
-                      <Typing
-                        $color={m.role === 'user' ? theme.colors.primaryText : theme.colors.text}
-                      >
-                        <span />
-                        <span />
-                        <span />
-                      </Typing>
-                    ) : (
-                      content
-                    )}
-                    {Form && <Form onSubmit={(v: string) => onFormSubmit?.(v, i)} />}
-                  </MeasuredBubble>
-                  {m.role === 'user' && userAvatar && (
-                    <MeasuredAvatar
-                      src={userAvatar}
-                      size='sm'
-                      variant='outline'
-                    />
-                  )}
-                </Row>
-              );
-            })}
-        </Messages>
-
-        {!inputDisabled && (
-          <form
-            ref={inputRef}
-            onSubmit={handleSubmit}
-            style={{ width: '100%' }}
+          <Messages
+            ref={messagesRef}
+            role='log'
+            aria-relevant='additions'
+            aria-busy={isTyping}
+            $gap={theme.spacing(1.25)}
+            /* Tighter side padding to bring avatars closer to edge */
+            $pad={portrait ? theme.spacing(0.25) : theme.spacing(0.5)}
+            $dur={theme.motion.duration.short}
+            $ease={theme.motion.easing.standard}
+            style={{
+              overflowY: 'auto',
+              maxHeight,
+              scrollbarGutter: 'stable',
+              touchAction: 'auto',
+            }}
           >
-            <InputRow
-              $gap={theme.spacing(1)}
-              $pad={theme.spacing(0.5)}
+            {messages
+              /* Pair each message with its index in the caller's array BEFORE
+               filtering — onFormSubmit must report the original index. */
+              .map((m, i) => ({ m, i }))
+              .filter(({ m }) => m.role !== 'system')
+              .map(({ m, i }) => {
+                /* Near-edge gutter (towards container edge) kept tiny; far edge roomy */
+                const near = theme.spacing(0.25);
+                const far = portrait ? theme.spacing(0.5) : theme.spacing(0.75);
+                const laneGap = portrait ? theme.spacing(0.5) : theme.spacing(0.75);
+                const content =
+                  typeof m.content === 'string' ? (
+                    m.role === 'assistant' ? (
+                      <Markdown
+                        data={m.content}
+                        codeBackground={theme.colors.background}
+                      />
+                    ) : (
+                      <Typography>{m.content}</Typography>
+                    )
+                  ) : (
+                    m.content
+                  );
+                const Form = m.form;
+                return (
+                  <Row
+                    key={i}
+                    $from={m.role}
+                    $gap={laneGap}
+                    $padL={m.role !== 'user' ? near : far}
+                    $padR={m.role === 'user' ? near : far}
+                    $dur={theme.motion.duration.short}
+                    $ease={theme.motion.easing.standard}
+                  >
+                    {/* Measure content height to decide vertical alignment */}
+                    {m.role !== 'user' && systemAvatar && (
+                      <MeasuredAvatar
+                        src={systemAvatar}
+                        size='sm'
+                        variant='outline'
+                      />
+                    )}
+                    <MeasuredBubble
+                      variant='filled'
+                      color={m.role === 'user' ? theme.colors.primary : undefined}
+                      alignX={m.role === 'user' ? 'right' : 'left'}
+                      sx={{
+                        /* Readable max width and clean right/left alignment */
+                        maxWidth: portrait ? '100%' : 'min(75%, 48rem)',
+                        width: 'fit-content',
+                        borderRadius: theme.spacing(1),
+                        /* Slightly reduce top/bottom padding while keeping sides the same */
+                        padding: `${portrait ? theme.spacing(1) : theme.spacing(1.75)} ${
+                          portrait ? theme.spacing(1.25) : theme.spacing(2)
+                        }`,
+                        animation: m.animate ? `${fadeIn} 0.2s ease-out` : undefined,
+                        position: 'relative',
+                        justifySelf: m.role === 'user' ? 'end' : 'start',
+                      }}
+                    >
+                      {m.name && (
+                        <Typography
+                          variant='subtitle'
+                          bold
+                        >
+                          {m.name}
+                        </Typography>
+                      )}
+                      {m.typing ? (
+                        <Typing
+                          $color={m.role === 'user' ? theme.colors.primaryText : theme.colors.text}
+                        >
+                          <span />
+                          <span />
+                          <span />
+                        </Typing>
+                      ) : (
+                        content
+                      )}
+                      {Form && <Form onSubmit={(v: string) => onFormSubmit?.(v, i)} />}
+                    </MeasuredBubble>
+                    {m.role === 'user' && userAvatar && (
+                      <MeasuredAvatar
+                        src={userAvatar}
+                        size='sm'
+                        variant='outline'
+                      />
+                    )}
+                  </Row>
+                );
+              })}
+          </Messages>
+
+          {!inputDisabled && (
+            <form
+              ref={inputRef}
+              onSubmit={handleSubmit}
+              style={{ width: '100%' }}
             >
-              <TextField
-                as='textarea'
-                name='chat-message'
-                value={text}
-                onChange={(e) => setText(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' && !e.shiftKey) {
-                    e.preventDefault();
-                    doSubmit();
-                  }
-                }}
-                rows={1}
-                placeholder={placeholder}
-                sx={{ width: '100%', minWidth: 0, maxWidth: 'calc(100% - 1rem)' }}
-                fontFamily={fontFamily}
-              />
-              <IconButton
-                icon='carbon:send'
-                type='submit'
-                aria-label={t.send}
-              />
-            </InputRow>
-          </form>
-        )}
-      </Wrapper>
+              <InputRow
+                $gap={theme.spacing(1)}
+                $pad={theme.spacing(0.5)}
+              >
+                <TextField
+                  as='textarea'
+                  name='chat-message'
+                  value={text}
+                  onChange={(e) => setText(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && !e.shiftKey) {
+                      e.preventDefault();
+                      doSubmit();
+                    }
+                  }}
+                  rows={1}
+                  placeholder={placeholder}
+                  sx={{ width: '100%', minWidth: 0, maxWidth: 'calc(100% - 1rem)' }}
+                  fontFamily={fontFamily}
+                />
+                <IconButton
+                  icon='carbon:send'
+                  type='submit'
+                  aria-label={t.send}
+                />
+              </InputRow>
+            </form>
+          )}
+        </Wrapper>
+      </CompactCtx.Provider>
     </Panel>
   );
 };

--- a/src/system/compactContext.dom.test.tsx
+++ b/src/system/compactContext.dom.test.tsx
@@ -1,0 +1,155 @@
+// ─────────────────────────────────────────────────────────────
+// src/system/compactContext.dom.test.tsx | valet
+// useCompact(own ?? inherited) resolution + the compact cascade
+// through real layout containers (Panel/Stack/Box) and the
+// compact={false} subtree opt-out.
+// ─────────────────────────────────────────────────────────────
+import { afterEach, describe, expect, it } from 'vitest';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { CompactCtx, useCompact } from './compactContext';
+import { Panel } from '../components/layout/Panel';
+import { Stack } from '../components/layout/Stack';
+import { Box } from '../components/layout/Box';
+
+/* react-dom warns unless act usage is announced ----------------------- */
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+/* Helpers -------------------------------------------------------------- */
+const roots: Array<{ root: Root; container: HTMLDivElement }> = [];
+
+function render(node: React.ReactNode) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  roots.push({ root, container });
+  act(() => {
+    root.render(node);
+  });
+  return { container };
+}
+
+afterEach(() => {
+  for (const { root, container } of roots.splice(0)) {
+    act(() => root.unmount());
+    container.remove();
+  }
+});
+
+/** Reads the effective compact via useCompact and stamps it on the DOM. */
+const Probe: React.FC<{ own?: boolean; id?: string }> = ({ own, id = 'probe' }) => {
+  const v = useCompact(own);
+  return (
+    <span
+      data-testid={id}
+      data-compact={v ? '1' : '0'}
+    />
+  );
+};
+
+const read = (c: HTMLElement, id = 'probe') =>
+  c.querySelector(`[data-testid="${id}"]`)?.getAttribute('data-compact');
+
+/* Suite ---------------------------------------------------------------- */
+describe('useCompact — own ?? inherited', () => {
+  it('defaults to false with no provider in scope', () => {
+    const { container } = render(<Probe />);
+    expect(read(container)).toBe('0');
+  });
+
+  it('own=true forces compact', () => {
+    const { container } = render(<Probe own />);
+    expect(read(container)).toBe('1');
+  });
+
+  it('inherits the provider value when own is undefined', () => {
+    const { container } = render(
+      <CompactCtx.Provider value={true}>
+        <Probe />
+      </CompactCtx.Provider>,
+    );
+    expect(read(container)).toBe('1');
+  });
+
+  it('own=false opts out of an inherited compact', () => {
+    const { container } = render(
+      <CompactCtx.Provider value={true}>
+        <Probe own={false} />
+      </CompactCtx.Provider>,
+    );
+    expect(read(container)).toBe('0');
+  });
+
+  it('own=true forces compact even under a non-compact ancestor', () => {
+    const { container } = render(
+      <CompactCtx.Provider value={false}>
+        <Probe own />
+      </CompactCtx.Provider>,
+    );
+    expect(read(container)).toBe('1');
+  });
+});
+
+describe('compact cascades through layout containers', () => {
+  it('<Panel compact> provides compact to descendants', () => {
+    const { container } = render(
+      <Panel compact>
+        <Probe />
+      </Panel>,
+    );
+    expect(read(container)).toBe('1');
+  });
+
+  it('<Stack compact> provides compact to descendants', () => {
+    const { container } = render(
+      <Stack compact>
+        <Probe />
+      </Stack>,
+    );
+    expect(read(container)).toBe('1');
+  });
+
+  it('<Box compact> provides compact to descendants', () => {
+    const { container } = render(
+      <Box compact>
+        <Probe />
+      </Box>,
+    );
+    expect(read(container)).toBe('1');
+  });
+
+  it('cascades down nested containers that do not set compact', () => {
+    const { container } = render(
+      <Panel compact>
+        <Stack>
+          <Box>
+            <Probe />
+          </Box>
+        </Stack>
+      </Panel>,
+    );
+    expect(read(container)).toBe('1');
+  });
+
+  it('a nested compact={false} opts only its subtree back out', () => {
+    const { container } = render(
+      <Panel compact>
+        <Probe id='outer' />
+        <Panel compact={false}>
+          <Probe id='inner' />
+        </Panel>
+      </Panel>,
+    );
+    expect(read(container, 'outer')).toBe('1');
+    expect(read(container, 'inner')).toBe('0');
+  });
+
+  it('a non-compact container leaves descendants non-compact', () => {
+    const { container } = render(
+      <Panel>
+        <Probe />
+      </Panel>,
+    );
+    expect(read(container)).toBe('0');
+  });
+});

--- a/src/system/compactContext.ts
+++ b/src/system/compactContext.ts
@@ -1,0 +1,32 @@
+// ─────────────────────────────────────────────────────────────
+// src/system/compactContext.ts | valet
+// compact cascade: a container with `compact` zeros its own layout
+// spacing AND forces every spacing-aware descendant to do the same,
+// propagated by React context. Orthogonal to the density scale — see
+// `Density` in themeStore.ts (compact zeros spacing; density scales it).
+// ─────────────────────────────────────────────────────────────
+import { createContext, useContext } from 'react';
+
+/**
+ * Inherited `compact` flag for a subtree. Default `false` (no provider in scope
+ * ⇒ normal spacing). A spacing-aware container reads it with {@link useCompact}
+ * and, when it owns a `compact` prop, re-provides the resolved value to its
+ * descendants via `CompactCtx.Provider`. Context crosses React portals by tree
+ * position, so portalled content (Modal, Select menu) inherits correctly.
+ */
+export const CompactCtx = createContext<boolean>(false);
+
+/**
+ * Resolve the effective `compact` for a component, blending its own prop with
+ * the inherited value:
+ *
+ * - `own === true`      → forced compact (and propagated where the component provides).
+ * - `own === false`     → explicit opt-out, even inside a compact ancestor.
+ * - `own === undefined` → inherit the nearest ancestor's value.
+ */
+export const useCompact = (own?: boolean): boolean => {
+  const inherited = useContext(CompactCtx);
+  return own ?? inherited;
+};
+
+export default useCompact;

--- a/src/system/themeStore.ts
+++ b/src/system/themeStore.ts
@@ -10,7 +10,7 @@ import { baseTheme, composeTheme, mergeThemePatch } from './themeUtils';
 
 export type Breakpoint = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 export type ThemeMode = 'light' | 'dark';
-export type Density = 'compact' | 'standard' | 'comfortable';
+export type Density = 'tight' | 'standard' | 'comfortable';
 
 export interface Theme {
   colors: Record<string, string>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,10 +18,15 @@ export interface SpacingProps {
   gap?: Space;
   /** Container padding as units or CSS length. */
   pad?: Space;
-  /** Compact mode zeros gap and pad where supported. */
+  /**
+   * Zeros all layout spacing (pad, gap, and spacing-margins) where supported and
+   * cascades to spacing-aware descendants. Does not touch control insets,
+   * structural geometry, border-radius, glyph sizes, or alignment. `compact={false}`
+   * opts a subtree back out of an inherited compact.
+   */
   compact?: boolean;
-  /** Density override for spacing scale; defaults from nearest Surface. */
-  density?: 'compact' | 'standard' | 'comfortable';
+  /** Density override for the spacing scale; defaults from nearest Surface. */
+  density?: 'tight' | 'standard' | 'comfortable';
 }
 
 /** Sx prop: inline CSS with support for CSS custom properties (e.g. --valet-*) */


### PR DESCRIPTION
…→tight

compact is now a hard-zero of layout spacing (pad/gap/spacing-margins) that cascades to every spacing-aware descendant via a new CompactCtx/useCompact, fully decoupled from the density scale. compact={false} opts a subtree back out. density now also scales a subtree locally via --valet-space on Stack/Panel/Grid/Tabs. compact preserves control insets, alignment, structural geometry, radius, glyph sizes, and sx.

BREAKING CHANGE: the density tier 'compact' is renamed to 'tight' (hard rename, no alias per the pre-1.0 policy). Replace density="compact" with density="tight". The boolean compact no longer shrinks the density scale to 0.9; it zeros layout spacing and cascades.

- new src/system/compactContext.ts (CompactCtx + useCompact: own ?? inherited)
- 8 layout containers decoupled + cascade-wired; fixes density leaking onto the DOM (Panel/Grid/Tabs) and the compact=false default that blocked inheritance (Tabs/Modal/Accordion)
- fix MetroSelect's hardcoded <Stack compact> that dead-zeroed its gap prop, and RichChat's compact={portrait} misuse that ate an explicit pad
- DateSelector visual scale (icon/cell/label) moved to density="tight" (D6)
- docs: new /spacing page with live density+compact demos; PropPatterns rows updated and linked; ThemeEngine/DateSelectorDemo density rename
- MCP: glossary terms compact/density/--valet-space, Surface/DateSelector meta fixes; mcp-data (both copies) regenerated and fresh
- tests: compactContext.dom.test.tsx (resolution + cascade + opt-out)